### PR TITLE
Add gitman adopt: forge-merged trunk adoption

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,10 @@
       "Bash(grep -rn \"jj git init\\\\|jj CLI\\\\|jjPkgs\\\\|jujutsu.*packages\\\\|needs the jj\\\\|jj` CLI\" docs/*.md 2>/dev/null)",
       "Bash(git fetch *)",
       "Bash(python -c \"import pyjutsu; print\\(pyjutsu.__file__\\)\")",
-      "Bash(find / -name \"*.pyi\" -path \"*pyjutsu*\")"
+      "Bash(find / -name \"*.pyi\" -path \"*pyjutsu*\")",
+      "Bash(command -v gh)",
+      "Bash(echo \"gh: $\\(command -v gh || echo MISSING\\)\")",
+      "Bash(gh auth *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(sed -n '/def snapshot/,/def /p' python/pyjutsu/workspace.py)",
       "Bash(CLI\" docs/*.md 2>/dev/null)",
       "Bash(grep -rn \"jj git init\\\\|jj CLI\\\\|jjPkgs\\\\|jujutsu.*packages\\\\|needs the jj\\\\|jj` CLI\" docs/*.md 2>/dev/null)",
-      "Bash(git fetch *)"
+      "Bash(git fetch *)",
+      "Bash(python -c \"import pyjutsu; print\\(pyjutsu.__file__\\)\")",
+      "Bash(find / -name \"*.pyi\" -path \"*pyjutsu*\")"
     ]
   }
 }

--- a/.claude/skills/gitman/SKILL.md
+++ b/.claude/skills/gitman/SKILL.md
@@ -19,9 +19,35 @@ gitman save -m "<message>"  # describe the current change
 gitman status               # see trunk + all lanes (canonical or off-canonical)
 gitman sync                 # fetch trunk + rebase this lane onto it
 gitman publish              # push the lane (branch = lane name); verify hook runs first
-gitman land [<lane>...]     # fold lane(s) into trunk, advance trunk, retire the lane(s)
+gitman land [<lane>...]     # fold lane(s) into trunk LOCALLY, advance trunk, retire the lane(s)
 gitman abandon [<lane>]     # discard a lane
 ```
+
+`sync` fetches **lanes-only** and rebases onto the *local* trunk — it never advances trunk and
+signposts `gitman adopt` when origin's trunk has moved.
+
+## Forge PRs: `publish → PR → merge → adopt`
+
+When you review/merge on the **forge** instead of landing locally — `gitman publish`, open a PR,
+click **Merge** (squash / merge-commit / rebase all re-hash to a new SHA on `origin/<trunk>`) —
+the local trunk falls behind. Pull it forward with **one command**:
+
+```
+gh pr merge --squash --delete-branch    # (or via the web UI)
+gitman adopt                # advance local trunk to origin/<trunk>, retire merged lanes,
+                            #   rebase un-merged survivors; stays canonical, undoable
+gitman adopt --dry-run      # preview the plan without mutating
+gitman adopt --force        # only if trunk diverged (un-pushed local lands + origin moved):
+                            #   hard-set trunk to origin, dropping the un-pushed lands (undoable)
+```
+
+`adopt` retires forge-merged lanes by **content** (works across squash/merge/rebase), so you
+never run the old raw-git reconcile dance (`rm -rf .jj` / `git reset --hard` — **deprecated**;
+`adopt` replaces it). **Never** `gitman land` after a forge merge — it would mint a divergent
+local SHA from the forge's merge commit.
+
+**Keep `gitman.toml` and other VC wiring committed on trunk, never only inside a lane** — so
+retiring/abandoning a lane can never delete it from disk.
 
 ## Safety net
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ uv.lock
 .ruff_cache/
 
 # local working notes (untracked)
-.scratch/
+# .scratch/
 
 # retired old-gitman code, kept for reference only
 archive/

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ uv.lock
 .mypy_cache/
 .ruff_cache/
 
-# local working notes (untracked)
-# .scratch/
+# local working notes: loose scratch is untracked; tracked design docs live in .scratch/projects/
+.scratch/*
+!.scratch/projects/
 
 # retired old-gitman code, kept for reference only
 archive/

--- a/.scratch/dogfood_mp1.py
+++ b/.scratch/dogfood_mp1.py
@@ -1,0 +1,105 @@
+"""MP1 dogfood: drive the full lane lifecycle through the migrated do_* over a Session."""
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import do_abandon, do_land, do_save, do_start, do_sync, do_undo
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def build(d: Path) -> None:
+    ws = Workspace.init(d, colocate=True)
+    (d / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+
+
+def sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def check(label, cond):
+    print(f"  {'OK ' if cond else 'XX '} {label}")
+    assert cond, label
+
+
+tmp = Path(tempfile.mkdtemp(prefix="dogfood-")); repo = tmp / "repo"; repo.mkdir()
+build(repo)
+
+print("== start feat ==")
+r = do_start(sess(repo), "feat", workspace=False)
+check("STARTED", r.outcome == "STARTED")
+check("undo line", r.undo_command == "gitman undo")
+st = capture_state(sess(repo))
+check("lane feat present", [l.name for l in st.lanes] == ["feat"])
+check("current_lane feat", st.current_lane == "feat")
+check("canonical", st.canonical)
+
+print("== save -m ==")
+(repo / "f.txt").write_text("base\nfeat\n")
+r = do_save(sess(repo), "add feat line")
+check("SAVED", r.outcome == "SAVED")
+check("described msg", r.messages == ['described: "add feat line"'])
+st = capture_state(sess(repo))
+check("lane has 1 change non-empty", st.lanes[0].change_count == 1 and not st.lanes[0].head.empty)
+
+print("== save (no -m) NOOP echo ==")
+r = do_save(sess(repo), None)
+check("NOOP", r.outcome == "NOOP")
+print("    echo:", r.messages[0])
+
+print("== undo the save ==")
+r = do_undo(sess(repo), op=None, list_=False)
+check("UNDONE", r.outcome == "UNDONE")
+st = capture_state(sess(repo))
+check("after undo: change empty again (save reverted)", st.lanes[0].head.description == "")
+
+print("== re-save (distinct content) then land ==")
+(repo / "f.txt").write_text("base\nfeat2\n")
+do_save(sess(repo), "add feat line v2")
+trunk_before = capture_state(sess(repo)).trunk.commit_id
+r = do_land(sess(repo), ["feat"])
+check("LANDED", r.outcome == "LANDED")
+st = capture_state(sess(repo))
+check("lane retired", st.lanes == [])
+check("trunk advanced", st.trunk.commit_id != trunk_before)
+check("canonical after land", st.canonical)
+
+print("== undo the land (trunk back) ==")
+r = do_undo(sess(repo), op=None, list_=False)
+check("UNDONE", r.outcome == "UNDONE")
+st = capture_state(sess(repo))
+check("trunk restored", st.trunk.commit_id == trunk_before)
+check("lane feat back", [l.name for l in st.lanes] == ["feat"])
+
+print("== abandon feat ==")
+r = do_abandon(sess(repo), "feat")
+check("ABANDONED", r.outcome == "ABANDONED")
+st = capture_state(sess(repo))
+check("no lanes", st.lanes == [])
+check("canonical after abandon", st.canonical)
+
+print("== sync (no remote) ==")
+do_start(sess(repo), "lane2", workspace=False)
+(repo / "g.txt").write_text("g\n")
+do_save(sess(repo), "g work")
+r = do_sync(sess(repo), all_=False)
+check("SYNCED", r.outcome == "SYNCED")
+check("sync exit 0", r.exit_code == 0)
+check("canonical after sync", capture_state(sess(repo)).canonical)
+
+print("== undo --list shows gitman:* ==")
+r = do_undo(sess(repo), op=None, list_=True)
+check("LIST", r.outcome == "LIST")
+print("    rows:")
+for row in r.messages:
+    print("     ", row)
+check("all rows gitman:", all("gitman:" in m for m in r.messages))
+
+print("\nALL DOGFOOD CHECKS PASSED", tmp)

--- a/.scratch/dogfood_mp2.sh
+++ b/.scratch/dogfood_mp2.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# MP2 extended dogfood: init → start → save → version bump → publish → release → reconcile,
+# each with an undo where applicable. Drives the real `gitman` console script. The repo + the
+# stray are bootstrapped via pyjutsu (the `jj` CLI is not on PATH; the embedded lib is).
+set -euo pipefail
+
+GM="$DEVENV_STATE/venv/bin/gitman"
+PY="$DEVENV_STATE/venv/bin/python"
+ROOT="$(mktemp -d /tmp/gitman-dogfood-XXXX)"
+REPO="$ROOT/repo"
+REMOTE="$ROOT/remote.git"
+mkdir -p "$REPO"
+git init --bare -q "$REMOTE"
+
+"$PY" - "$REPO" <<'PY'
+import sys
+from pathlib import Path
+from pyjutsu import Workspace
+repo = Path(sys.argv[1])
+ws = Workspace.init(repo, colocate=True)
+(repo / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "1.2.3"\n')
+(repo / "app.py").write_text("print(1)\n")
+with ws.transaction("initial") as tx:
+    tx.describe("@", "initial")  # no bookmark — init freezes trunk
+PY
+
+cd "$REPO"
+git remote add origin "$REMOTE"
+
+run() { echo; echo ">>> gitman $*"; "$GM" "$@"; }
+
+run init
+run status
+run start feat
+printf 'print(2)\n' >> app.py
+run save -m "feat work"
+run version
+run version bump minor
+echo "  version file now: $(grep '^version\|version =' pyproject.toml)"
+run undo
+echo "  version file after undo: $(grep '^version\|version =' pyproject.toml)"
+run version bump minor
+run publish
+echo "  remote branches: $(git ls-remote "$REMOTE" 'refs/heads/*' | awk '{print $2}' | tr '\n' ' ')"
+run land feat
+run status
+run release
+echo "  tags: $(git tag -l | tr '\n' ' ')"
+
+# reconcile: bootstrap a stray off trunk via pyjutsu, then recover through gitman.
+"$PY" - "$REPO" <<'PY'
+import sys
+from pathlib import Path
+from pyjutsu import Workspace
+repo = Path(sys.argv[1])
+ws = Workspace.load(repo)
+with ws.transaction("stray") as tx:
+    tx.new("main"); tx.describe("@", "stray work")
+(repo / "stray.txt").write_text("stray\n")
+ws.snapshot()
+with ws.transaction("move @") as tx:
+    tx.new("main")
+PY
+
+set +e
+run status
+set -e
+run reconcile
+run status
+run undo
+set +e
+run status
+set -e
+
+echo; echo "=== DOGFOOD OK ($ROOT) ==="

--- a/.scratch/probe2.py
+++ b/.scratch/probe2.py
@@ -1,0 +1,87 @@
+"""Probe part 2: immutability config, empty tx, noop rebase, frozen reads, push-delete."""
+import tempfile, subprocess
+from pathlib import Path
+from pyjutsu import Workspace
+from pyjutsu import errors as E
+
+def banner(s): print(f"\n===== {s} =====")
+
+tmp = Path(tempfile.mkdtemp(prefix="probe2-"))
+repo = tmp / "repo"; repo.mkdir()
+ws = Workspace.init(repo, colocate=True)
+(repo / "f.txt").write_text("base\n")
+with ws.transaction("base") as tx:
+    tx.describe("@", "base"); tx.create_bookmark("main", "@")
+with ws.transaction("new") as tx:
+    tx.new("main")
+
+banner("3a. immutability: is main/trunk immutable by default in pyjutsu?")
+# jj's default config: immutable_heads() = trunk() | tags(). Does pyjutsu load that?
+try:
+    with ws.transaction("describe main") as tx:
+        tx.describe("main", "rewrite trunk tip")
+    print("  describe(main) -> OK: main is NOT immutable in pyjutsu (no jj default config loaded?)")
+except BaseException as ex:
+    print("  describe(main) ->", type(ex).__name__, str(ex)[:80])
+
+banner("3b. abandon root -> clean ImmutableCommitError or panic?")
+try:
+    with ws.transaction("abandon root") as tx:
+        tx.abandon("root()")
+except BaseException as ex:
+    print("  abandon(root()) ->", type(ex).__name__, str(ex)[:80])
+
+banner("4. empty transaction: does committing a no-op publish an op?")
+a = ws.head_operation()
+try:
+    with ws.transaction("empty") as tx:
+        pass
+    b = ws.head_operation()
+    print("  head moved on empty tx:", a != b)
+except BaseException as ex:
+    print("  empty tx ->", type(ex).__name__, str(ex)[:80])
+
+banner("5. describe to SAME message: op published? (noop detection)")
+cur = ws.resolve("main").description
+a = ws.head_operation()
+with ws.transaction("redescribe same") as tx:
+    tx.describe("main", cur.rstrip("\n"))
+b = ws.head_operation()
+print("  head moved on same-desc describe:", a != b)
+
+banner("6. reads frozen: ws.log sees on-disk edit only after snapshot?")
+with ws.transaction("edit @") as tx:
+    tx.edit("main")
+(repo / "f.txt").write_text("UNSNAP\n")
+print("  diff_stat before snapshot:", ws.diff_stat("@").total_insertions, "ins")
+ws.snapshot()
+print("  diff_stat after snapshot: ", ws.diff_stat("@").total_insertions, "ins")
+
+banner("7. git_push delete semantics (no remote -> error type)")
+try:
+    ws.git_push("origin", "main", delete=True)
+except BaseException as ex:
+    print("  push delete no-remote ->", type(ex).__name__, str(ex)[:80])
+
+banner("8. restore_operation returns? & undo() of a snapshot+mutation")
+a = ws.head_operation()
+(repo / "f.txt").write_text("change-for-undo\n")
+with ws.transaction("desc2") as tx:
+    tx.describe("@", "second")
+print("  ops between:", [ (o.id[:8], o.is_snapshot) for o in ws.operations(limit=3)])
+r = ws.undo()  # undo head op only
+print("  after ws.undo(): @ desc =", repr(ws.working_copy().description), "f.txt=", (repo/'f.txt').read_text().strip())
+print("  (note whether undo of just-head leaves the snapshot's file change)")
+
+banner("9. workspace add: new @ base + stale detection across workspaces")
+wpath = tmp / "ws-lane"
+info = ws.add_workspace(wpath, name="lane")
+print("  added workspace:", info.name, "wc_commit", info.wc_commit_id[:8])
+ws_lane = Workspace.load(wpath)
+print("  lane is_stale right after add:", ws_lane.is_stale())
+# mutate from default ws in a way that moves the lane's @? operations move repo head
+with ws.transaction("unrelated") as tx:
+    tx.new("main")
+print("  lane is_stale after default-ws op:", ws_lane.is_stale())
+
+print("\nDONE", tmp)

--- a/.scratch/probe3.py
+++ b/.scratch/probe3.py
@@ -1,0 +1,61 @@
+import tempfile, subprocess
+from pathlib import Path
+from pyjutsu import Workspace
+from pyjutsu import errors as E
+def banner(s): print(f"\n===== {s} =====")
+
+tmp = Path(tempfile.mkdtemp(prefix="probe3-")); repo = tmp/"repo"; repo.mkdir()
+ws = Workspace.init(repo, colocate=True)
+(repo/"f.txt").write_text("base\n")
+with ws.transaction("base") as tx:
+    tx.describe("@","base"); tx.create_bookmark("main","@")
+with ws.transaction("new") as tx: tx.new("main")
+
+banner("A. snapshot-first + auto_snapshot=False -> single mutation op, ws.undo() correct?")
+(repo/"f.txt").write_text("edited work\n")           # dirty @ (unsaved user work)
+ws.snapshot()                                         # fold dirty @ into its own op
+op_before = ws.head_operation()
+with ws.transaction("save", auto_snapshot=False) as tx:
+    tx.describe("@", "my save message")
+print("  ops:", [(o.id[:8], o.is_snapshot, o.description) for o in ws.operations(limit=3)])
+print("  -> head op is the single mutation:", ws.operations(limit=1)[0].description)
+ws.undo()                                             # plain head undo
+print("  after ws.undo(): @ desc =", repr(ws.working_copy().description))
+print("  f.txt still has user work:", (repo/'f.txt').read_text().strip(), "(snapshot preserved)")
+
+banner("B. clean frozen-read: add a NEW file, read before/after snapshot")
+with ws.transaction("fresh") as tx: tx.new("main")
+(repo/"brand_new.txt").write_text("x\ny\n")
+print("  diff files before snapshot:", [f.path for f in ws.diff_stat('@').files])
+ws.snapshot()
+print("  diff files after snapshot: ", [f.path for f in ws.diff_stat('@').files])
+
+banner("C. rebase already-based (nothing to do): raise / noop / return?")
+with ws.transaction("lane") as tx:
+    tx.new("main"); tx.create_bookmark("lane","@")
+(repo/"l.txt").write_text("lane\n")
+with ws.transaction("save lane") as tx:
+    tx.describe("lane","lane work"); tx.set_bookmark("lane","@")
+# lane already on main; rebase onto main again
+try:
+    with ws.transaction("rebase noop") as tx:
+        r = tx.rebase("lane", onto="main", mode="branch")
+        print("  rebase already-based returned:", r.commit_id[:8])
+    print("  -> no raise")
+except BaseException as ex:
+    print("  rebase already-based ->", type(ex).__name__, str(ex)[:80])
+
+banner("D. does an intent that does nothing but commits empty tx hurt undo target?")
+# (already know empty tx publishes op) -> just confirm restore_operation rolls it back cleanly
+a = ws.head_operation()
+with ws.transaction("noop intent") as tx: pass
+ws.restore_operation(a)
+print("  restored, head==a:", ws.head_operation()==a)
+
+banner("E. operation descriptions: can we identify gitman ops from op-log to avoid state file?")
+with ws.transaction("gitman:save") as tx:
+    tx.describe("main", "tagged op")
+for o in ws.operations(limit=2):
+    print(f"   op {o.id[:8]} desc={o.description!r} tags={o.tags}")
+
+print("\nDONE", tmp)

--- a/.scratch/probe4.py
+++ b/.scratch/probe4.py
@@ -1,0 +1,88 @@
+"""Probe 4: confirm LAND, ABANDON, and start --workspace recipes for MP1."""
+import tempfile, shutil
+from pathlib import Path
+from pyjutsu import Workspace
+from pyjutsu import errors as E
+
+def banner(s): print(f"\n===== {s} =====")
+
+tmp = Path(tempfile.mkdtemp(prefix="probe4-")); repo = tmp / "repo"; repo.mkdir()
+ws = Workspace.init(repo, colocate=True)
+(repo / "f.txt").write_text("base\n")
+with ws.transaction("base") as tx:
+    tx.describe("@", "base"); tx.create_bookmark("main", "@")
+
+def stray_revset(trunk): return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+
+banner("LAND: rebase(branch)->set_bookmark(trunk,lane)->delete_bookmark(lane) in 1 tx")
+# build a lane with one non-empty change
+with ws.transaction("start feat") as tx:
+    tx.new("main"); tx.create_bookmark("feat", "@")
+(repo / "feat.txt").write_text("feat\n")
+ws.snapshot()
+with ws.transaction("save feat") as tx:
+    tx.describe("feat", "feat work")
+trunk_before = ws.resolve("main").commit_id
+op_before = ws.head_operation()
+# move @ off the lane so it's like landing another lane (also test @ on lane below)
+with ws.transaction("gitman:land", auto_snapshot=False) as tx:
+    rebased = tx.rebase("feat", onto="main", mode="branch")
+    print("  rebased has_conflict:", rebased.has_conflict)
+    tx.set_bookmark("main", "feat")
+    tx.delete_bookmark("feat")
+print("  trunk advanced:", ws.resolve("main").commit_id != trunk_before)
+print("  feat gone:", "feat" not in [b.name for b in ws.bookmarks() if b.remote is None])
+print("  strays after land:", [c.change_id[:8] for c in ws.log(stray_revset("main"))])
+print("  @ desc after land:", repr(ws.working_copy().description), "empty:", ws.working_copy().is_empty)
+ws.restore_operation(op_before)
+print("  restored: feat back:", "feat" in [b.name for b in ws.bookmarks() if b.remote is None])
+
+banner("ABANDON: abandon each trunk..lane change_id then delete_bookmark, 1 tx")
+# rebuild lane state already there after restore
+change_ids = [c.change_id for c in ws.log("main..feat")]
+print("  trunk..feat change_ids:", [c[:8] for c in change_ids])
+op_before2 = ws.head_operation()
+with ws.transaction("gitman:abandon", auto_snapshot=False) as tx:
+    for cid in change_ids:
+        tx.abandon(cid)
+    tx.delete_bookmark("feat")
+print("  feat gone:", "feat" not in [b.name for b in ws.bookmarks() if b.remote is None])
+print("  strays after abandon:", [c.change_id[:8] for c in ws.log(stray_revset("main"))])
+print("  canonical-ish (no strays):", len(ws.log(stray_revset("main"))) == 0)
+
+banner("ABANDON with @ ON the lane")
+ws.restore_operation(op_before2)
+with ws.transaction("edit onto feat") as tx:
+    tx.edit("feat")
+print("  @ on feat now, @ bookmarks:", ws.working_copy().bookmarks)
+cids = [c.change_id for c in ws.log("main..feat")]
+with ws.transaction("gitman:abandon2", auto_snapshot=False) as tx:
+    for cid in cids:
+        tx.abandon(cid)
+    tx.delete_bookmark("feat")
+print("  after abandon @-on-lane: @ empty:", ws.working_copy().is_empty,
+      "strays:", len(ws.log(stray_revset("main"))))
+
+banner("START --workspace: add_workspace + sub tx on shared op-log")
+op_before3 = ws.head_operation()
+wpath = tmp / "ws-lane"
+info = ws.add_workspace(wpath, name="lane")
+print("  added ws:", info.name, "@ commit", info.wc_commit_id[:8])
+print("  head moved by add_workspace:", ws.head_operation() != op_before3)
+sub = Workspace.load(wpath)
+print("  sub @ before tx, parents=root?:", sub.working_copy().parent_ids)
+with sub.transaction("gitman:start", auto_snapshot=False) as tx:
+    tx.new("main")
+    tx.create_bookmark("lane", "@")
+print("  default ws sees 'lane' bookmark:", "lane" in [b.name for b in ws.bookmarks() if b.remote is None])
+print("  lane head desc/empty:", ws.resolve("lane").is_empty)
+print("  strays from default ws:", [c.change_id[:8] for c in ws.log(stray_revset("main"))])
+print("  default ws @ is_stale:", ws.is_stale())
+# now test guard rollback: restore op_before3 should unwind both the add_workspace AND sub tx
+ws.restore_operation(op_before3)
+print("  after restore: lane bookmark present:", "lane" in [b.name for b in ws.bookmarks() if b.remote is None])
+print("  after restore: workspaces:", [w.name for w in ws.workspaces()])
+# cleanup half-made workspace dir
+if wpath.exists(): shutil.rmtree(wpath, ignore_errors=True)
+
+print("\nDONE", tmp)

--- a/.scratch/probe5_mp2.py
+++ b/.scratch/probe5_mp2.py
@@ -1,0 +1,79 @@
+"""Probe 5 (MP2): version-bump snapshot flow + git annotated tag on a jj commit + reconcile."""
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+def banner(s): print(f"\n===== {s} =====")
+
+tmp = Path(tempfile.mkdtemp(prefix="probe5-")); repo = tmp / "repo"; repo.mkdir()
+ws = Workspace.init(repo, colocate=True)
+(repo / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "1.2.3"\n')
+with ws.transaction("initial") as tx:
+    tx.describe("@", "initial"); tx.create_bookmark("main", "@")
+# a lane
+with ws.transaction("start rel") as tx:
+    tx.new("main"); tx.create_bookmark("rel", "@")
+
+banner("A. version-bump flow: new -> write file -> snapshot -> describe + set_bookmark (3 ops)")
+op_before = ws.head_operation()
+lane = "rel"
+# 1) dedicated empty change on @
+with ws.transaction("gitman:version", auto_snapshot=False) as tx:
+    tx.new("@")
+# 2) write the bumped version on disk (now @ is the new empty change)
+txt = (repo / "pyproject.toml").read_text().replace('version = "1.2.3"', 'version = "1.3.0"')
+(repo / "pyproject.toml").write_text(txt)
+# 3) fold the file into @ via snapshot (own op)
+ws.snapshot()
+# 4) describe + advance the lane bookmark to the bump change
+with ws.transaction("gitman:version", auto_snapshot=False) as tx:
+    tx.describe("@", "Bump version to 1.3.0")
+    tx.set_bookmark(lane, "@")
+
+head = ws.resolve("rel")
+print("  rel head desc:", repr(head.description), "empty:", head.is_empty)
+print("  rel ahead of main:", len(ws.log("main..rel")), "changes")
+print("  file on disk:", "1.3.0" in (repo / "pyproject.toml").read_text())
+print("  diff_stat of bump change files:", [f.path for f in ws.diff_stat("rel").files])
+# undo: restore op_before should revert the whole bump (file too)
+ws.restore_operation(op_before)
+print("  after undo: file back to 1.2.3:", "1.2.3" in (repo / "pyproject.toml").read_text())
+print("  after undo: rel ahead:", len(ws.log("main..rel")), "changes")
+
+banner("B. git annotated tag on a jj-authored commit_id (colocated)")
+# land rel-ish: just tag main's commit. First advance main to a real change.
+with ws.transaction("work") as tx:
+    tx.new("main"); tx.describe("@", "real work")
+(repo / "f.txt").write_text("hi\n")
+ws.snapshot()
+with ws.transaction("bm") as tx:
+    tx.set_bookmark("main", "@")
+commit = ws.resolve("main").commit_id
+print("  main commit_id:", commit[:12])
+r = subprocess.run(["git", "tag", "-a", "v9.9.9", "-m", "Release 9.9.9", commit],
+                   cwd=repo, capture_output=True, text=True)
+print("  git tag rc:", r.returncode, "stderr:", r.stderr.strip()[:120])
+r2 = subprocess.run(["git", "rev-parse", "-q", "--verify", "refs/tags/v9.9.9"],
+                    cwd=repo, capture_output=True, text=True)
+print("  tag exists:", r2.returncode == 0, r2.stdout.strip()[:12])
+
+banner("C. reconcile-style: adopt a stray via tx.create_bookmark (no precheck)")
+# make a stray: non-empty unbookmarked change off main, @ elsewhere
+with ws.transaction("stray") as tx:
+    tx.new("main"); tx.describe("@", "stray work")
+(repo / "s.txt").write_text("stray\n")
+ws.snapshot()
+with ws.transaction("move @") as tx:
+    tx.edit("main")
+stray_revset = "(main..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+strays = [c for c in ws.log(stray_revset) if not c.is_empty]
+print("  strays found:", [(c.change_id[:8], c.description) for c in strays])
+with ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
+    for c in strays:
+        tx.create_bookmark(f"adopted-{c.change_id[:8]}", c.change_id)
+remaining = [c for c in ws.log(stray_revset) if not c.is_empty]
+print("  strays after adopt:", len(remaining), "-> canonical:", len(remaining) == 0)
+
+print("\nDONE", tmp)

--- a/.scratch/probe_pyjutsu.py
+++ b/.scratch/probe_pyjutsu.py
@@ -1,0 +1,116 @@
+"""Probe the pyjutsu behaviors the migration plan depends on. Ground truth > prose."""
+import tempfile, os, subprocess
+from pathlib import Path
+from pyjutsu import Workspace
+from pyjutsu import errors as E
+
+def sh(cwd, *args):
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+
+def banner(s): print(f"\n===== {s} =====")
+
+tmp = Path(tempfile.mkdtemp(prefix="probe-"))
+repo = tmp / "repo"
+repo.mkdir()
+ws = Workspace.init(repo, colocate=True)
+
+# make an initial trunk commit
+(repo / "f.txt").write_text("base\n")
+with ws.transaction("init trunk") as tx:
+    tx.describe("@", "base")
+    tx.create_bookmark("main", "@")
+with ws.transaction("new on top") as tx:
+    tx.new("main")
+
+banner("1. auto_snapshot: is the snapshot a SEPARATE preceding op?")
+# dirty @ then open a transaction with auto_snapshot
+(repo / "dirty.txt").write_text("dirty\n")
+before = ws.head_operation()
+print("head before:", before[:12])
+with ws.transaction("describe with dirty @") as tx:
+    tx.describe("@", "msg1")
+ops = ws.operations(limit=5)
+print("ops after (newest first):")
+for o in ops:
+    print(f"  {o.id[:12]} snap={o.is_snapshot} desc={o.description!r}")
+print("=> restore to `before` and see if dirty.txt edit + describe both revert")
+ws.restore_operation(before)
+print("   dirty.txt exists after restore:", (repo / "dirty.txt").exists())
+print("   @ description after restore:", repr(ws.working_copy().description))
+
+banner("2. rebase that CONFLICTS: raise, or first-class conflict commit?")
+# build two divergent lanes editing same file
+ws2 = ws  # reuse
+# reset: create lane editing f.txt, trunk also edits f.txt
+with ws.transaction("trunk edit") as tx:
+    tx.edit("main")
+(repo / "f.txt").write_text("trunk-change\n")
+with ws.transaction("snapshot+describe trunk") as tx:
+    tx.describe("main", "trunk edits f")
+    tx.set_bookmark("main", "@")
+# new lane off the *old* main parent
+main_commit = ws.resolve("main")
+with ws.transaction("start lane") as tx:
+    tx.new([main_commit.parent_ids[0]])
+    tx.create_bookmark("lane", "@")
+(repo / "f.txt").write_text("lane-change\n")
+with ws.transaction("snapshot lane") as tx:
+    tx.describe("lane", "lane edits f")
+    tx.set_bookmark("lane", "@")
+print("attempting rebase of lane (branch mode) onto main...")
+try:
+    with ws.transaction("rebase lane onto main") as tx:
+        r = tx.rebase("lane", onto="main", mode="branch")
+        print("  rebase returned commit:", r.commit_id[:12], "has_conflict=", r.has_conflict)
+    print("  -> NO exception raised; checking lane conflict state")
+    lane_head = ws.resolve("lane")
+    print("  lane has_conflict:", lane_head.has_conflict)
+    print("  conflicts():", ws.conflicts("lane"))
+except E.PyjutsuError as ex:
+    print("  RAISED:", type(ex).__name__, ex)
+
+banner("3. immutability: does rebasing/abandoning trunk-immutable raise?")
+# jj default immutable_heads is trunk()|tags; here no remote/trunk() config. Test root + main.
+try:
+    with ws.transaction("try rewrite root") as tx:
+        tx.describe("root()", "x")
+except E.PyjutsuError as ex:
+    print("  rewrite root ->", type(ex).__name__)
+# does describing main (a bookmark, not configured immutable) raise? probably not
+try:
+    with ws.transaction("describe main") as tx:
+        tx.describe("main", "still trunk edits f")
+    print("  describe main -> OK (no immutability by default for bookmarks)")
+except E.PyjutsuError as ex:
+    print("  describe main ->", type(ex).__name__, ex)
+
+banner("4. empty transaction: does committing a no-op publish an op?")
+op_a = ws.head_operation()
+with ws.transaction("empty tx") as tx:
+    pass
+op_b = ws.head_operation()
+print("  head moved on empty tx:", op_a != op_b, "(a", op_a[:8], "b", op_b[:8], ")")
+
+banner("5. rebase that is already-based (nothing to do): raise or noop?")
+try:
+    with ws.transaction("rebase noop") as tx:
+        tx.rebase("lane", onto="main", mode="branch")
+    print("  second rebase -> OK no raise")
+except E.PyjutsuError as ex:
+    print("  second rebase ->", type(ex).__name__, ex)
+
+banner("6. reads frozen: does ws.log see on-disk edit without snapshot?")
+(repo / "f.txt").write_text("UNSNAPSHOTTED EDIT\n")
+wc = ws.working_copy()
+print("  working_copy desc (no snapshot):", repr(wc.description))
+ds = ws.diff_stat("@")
+print("  diff_stat totals before snapshot: +", ds.total_insertions, "-", ds.total_deletions)
+ws.snapshot()
+ds2 = ws.diff_stat("@")
+print("  diff_stat totals after snapshot:  +", ds2.total_insertions, "-", ds2.total_deletions)
+
+banner("7. bookmarks(): remote field shape for local vs git-backing")
+for b in ws.bookmarks():
+    print(f"  name={b.name} remote={b.remote!r} tracked={b.tracked}")
+
+print("\nDONE. tmp:", tmp)

--- a/.scratch/projects/01-vcs-concept-brainstorming/GITMAN_CONCEPT.md
+++ b/.scratch/projects/01-vcs-concept-brainstorming/GITMAN_CONCEPT.md
@@ -1,0 +1,517 @@
+# Gitman — Concept (Consolidated)
+
+**Status:** Concept / pre-implementation (consolidated from
+`05-vcs-brainstorming/CONCEPT_BRAINSTORM.md`; lane model added 2026-06-15).
+**Name:** Gitman (Git Manager) · **CLI:** `gitman`
+**Language:** Python · **CLI:** Typer · **Models:** Pydantic v2
+**Substrate:** jujutsu (`jj`) for local operations, git as the interop layer (colocated)
+**Runtime:** runs only inside a `devenv.sh` shell · **Primary consumer:** coding agents
+**Sibling project:** Testee (verification policy layer) — same shape, different domain.
+
+---
+
+## 1. What Gitman is
+
+Gitman is the **single version-control interface** for a repository. Instead of an agent
+running `git add` / `commit` / `rebase` / `push` / `tag` (or `jj` plumbing) ad hoc, it
+asks Gitman:
+
+```bash
+devenv shell gitman status
+devenv shell gitman sync
+devenv shell gitman publish
+```
+
+and gets back a compact, structured, actionable report. Gitman decides *what* to run
+(`jj` or `git`), runs it safely, captures the repo state into one Pydantic model, and
+reports back the next action.
+
+Gitman is **not** a new VCS and **not** a git wrapper for power users. It exposes a tiny
+set of **intents** (not git/jj verbs) over a **canonical workflow** (the lane model, §5),
+engineered so an agent cannot get wedged, lose work, or leave the repo in a shape no one
+can reason about.
+
+## 2. Why
+
+Agents do version control badly: destructive commands (`git reset --hard`, blind
+`push --force`), the staging dance (`git add` the wrong subset), getting wedged
+mid-merge/rebase in a modal repo state they can't reason about, losing uncommitted work,
+producing messy history, pasting enormous `git status`/`log`/diff output into context,
+and being unable to recover from mistakes (reflog spelunking).
+
+The gap isn't tooling — it's the lack of a **version-control policy layer** for agents.
+Gitman is that layer, and **jujutsu is what makes the layer safe** rather than a thin set
+of guard rails over a sharp tool.
+
+## 3. Why jujutsu (the thesis)
+
+jj fixes the agent failure modes at the *data-model* level:
+
+- **No staging area; the working copy is an auto-snapshotted commit.** Work is *always*
+  saved — no `git add` mistakes, no clobbered changes.
+- **First-class conflicts.** Conflicts are recorded *in commits*, not a blocking modal
+  state. An agent is **never stuck** in a half-merged repo; it resolves later and keeps
+  working meanwhile.
+- **Operation log + total undo.** `jj op log` records *every* operation; `jj undo` /
+  `jj op restore` revert *any* of them. Cheap, total, reliable undo is the headline — the
+  thing raw git cannot safely offer. Gitman also uses it as a **transactional rollback**
+  (§11).
+- **Stable change IDs.** A change keeps its identity across rewrites, so "the thing I'm
+  working on" is a stable referent even as its git hash churns.
+- **Workspaces.** Multiple working copies share one repo (`jj workspace add`), each with
+  its own `@` — the native substrate for **parallel agents** (§8).
+- **`jj git --colocate`.** A real `.git` stays in sync, so git tooling, CI, `gh`, tags,
+  bookmarks→branches, and external collaborators all keep working. **jj is local
+  ergonomics; git is the wire format.**
+
+The division of labor: the **agent lives in jj locally** (safe, undoable,
+conflict-tolerant); **git/GitHub is the boundary** to the outside world, which never
+needs to know jj is in use.
+
+## 4. Locked decisions
+
+- **Agent-first** positioning (humans/CI secondary).
+- **jj required + colocated** (`jj git init --colocate`). No plain-git fallback.
+- **GitHub is an optional extra** (`gitman.advanced.github`); the base never imports it.
+- **Verification is an optional pre-publish hook, off by default** — a generic command
+  (any verifier, incl. Testee). Zero Testee dependency.
+- **Bare-minimum scope.** Ship the smallest useful daily loop, dogfood hard, let real
+  friction decide additions.
+- **Versioning + release tagging in v1** (semver major/minor/patch).
+- **The lane model is *the* workflow** (§5): structured multiplicity — parallel work is
+  supported, but only as well-formed, named lanes. Stacked PRs and `shape`/`switch` are
+  still deferred.
+
+## 5. The lane model (the canonical workflow)
+
+The core design stance. The mess we want to eliminate is not *multiple changes* — it's
+*unstructured* changes (anonymous, non-linear, divergent, stray). So:
+
+> **Every change belongs to exactly one named lane.** A **lane** is a unit of work —
+> a readable name, anchored on trunk, kept linear, with a stable identity Gitman tracks.
+> The repo is always a *set of canonical lanes*. Multiplicity is fine; anarchy is not.
+
+This keeps jj's cheap parallel changes (spin up N agents on N problems, merge back) while
+collapsing the runtime variability, because variability came from structurelessness, not
+count. A lane is just a **named jj bookmark on a trunk descendant** (+ optionally its own
+workspace) — so the bookmark name *is* the lane name *is* the git branch name: readable,
+repo-global, and auto-following the change across rewrites.
+
+### Invariants
+
+| # | Invariant | What it dissolves |
+|---|---|---|
+| I1 | **Trunk is resolved once at `init`, written to config, frozen.** Runtime never re-detects. | All runtime trunk-ambiguity states. |
+| I2 | **Every change belongs to exactly one named lane; no anonymous/stray changes.** | Stranded work — every change is *listable*; `status` is a uniform enumeration, not a triage. |
+| I3 | **Branch name = the lane's readable name**, unique-checked at creation, stable via the bookmark. | Branch-name generation / collision / freeze logic. |
+| I4 | **Gitman is the sole writer; mutating ops are serialized by a brief repo lock.** | Concurrent-rewrite divergence (parallel work lives in separate workspaces). |
+| I5 | **Each lane is linear on trunk (rebase-always); trunk advances only via `land`.** | Merge-commit states; "which base?" ambiguity. |
+
+The principle: **resolve variability once, at a well-defined moment (init, lane
+creation), not repeatedly at runtime.**
+
+### Lane lifecycle
+
+```
+start ──▶ draft ──(edit · save · sync · resolve)──▶ published ──▶ landed
+              │                                                      ▲
+              └──────────────── abandon ◀─────────────────────── (or)┘
+```
+
+A lane is always in exactly one of three states — **draft** (being edited), **published**
+(pushed / PR open), **landed/abandoned** (terminal). That bounds everything `status` must
+render.
+
+## 6. Architecture
+
+```
+Agent → devenv shell → gitman CLI → Intent planner → Executor (jj / git)  [under repo lock]
+      → RepoState (Pydantic) → Renderer (compact report)
+                            → op-log (undo + transactional rollback)   → --json
+```
+
+- **Intent planner** — deterministic; turns intent + flags + config + current RepoState
+  into a sequence of jj/git operations.
+- **Executor** — runs jj/git, records facts (op id before/after, exit, change IDs).
+  Never interprets results. Wraps each mutating intent transactionally (§11).
+- **Lane registry** — the set of Gitman-managed bookmarks; near-zero extra state since jj
+  already tracks bookmarks. Workspace ↔ lane mapping via `jj workspace list`.
+- **State adapters** (`jj.py`, `git.py`) — own all tool-specific knowledge: query jj with
+  templates / colocated git for numbers, parse into typed `RepoState`. Pure `parse_*`
+  separated from effectful `run_*` (Testee convention).
+- **Renderer** — compact agent report; `--json` emits the `RepoState`/result model.
+- **Forge bridge** (optional extra) — `publish`→PR and the forge backend of `land`.
+
+### Package layout (mirrors Testee)
+
+```
+src/gitman/
+  cli.py        Typer intents
+  core.py       orchestration per intent, devenv guard, repo lock, state IO
+  lanes.py      lane registry + workspace lifecycle (create/forget/cleanup)
+  jj.py         jj adapter: run_* + pure parse_* (templates → models)
+  git.py        colocated git: numstat, tags, remotes, push
+  state.py      RepoState capture (composes jj.py + git.py + lanes.py)
+  models.py     Pydantic: RepoState, Lane, Change, Conflict, Op, TrunkRef, ...
+  config.py     [tool.gitman] policy (Pydantic-validated)
+  invariants.py canonical checks + transactional rollback wrapper
+  version.py    semver math + version-source read/write
+  release.py    tag + push flow
+  render.py     compact agent reports (plain Python)
+  init.py doctor.py reconcile.py
+  advanced/     optional forge extra (github) — base never imports it
+```
+
+Base deps kept lean: `pydantic`, `typer`. `jj` and `git` binaries come from devenv.
+
+## 7. Intent vocabulary — v1
+
+Eleven intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
+model requires; everything else is deferred until friction proves it.
+
+| Intent | Signature | What it does | Underneath |
+|---|---|---|---|
+| `status` | `gitman status [--json]` | Canonical/off-canonical report: trunk + all lanes. | `jj log`/`op log`/`workspace list` (+git numstat) |
+| `start` | `gitman start <name> [--workspace]` | Create a lane (new change on trunk + bookmark `<name>`); `--workspace` isolates it. | `jj new <trunk>` + `jj bookmark create` (+ `jj workspace add`) |
+| `save` | `gitman save [-m <desc>]` | Describe the current lane's change. | `jj describe` |
+| `sync` | `gitman sync [--all]` | Fetch trunk + rebase the current lane (or `--all` lanes) onto it. | `jj git fetch` + `jj rebase` |
+| `publish` | `gitman publish` | Push the current lane; branch = lane name. Verify hook first. | `jj git push` (forge extra: + open/update PR) |
+| `land` | `gitman land [<lane>…]` | Fold lane(s) into trunk, advance trunk, retire the lane(s). | rebase + ff trunk + bookmark/workspace cleanup (forge extra: merge PR) |
+| `abandon` | `gitman abandon [<lane>]` | Discard a lane (terminal). | `jj abandon` + bookmark delete + workspace cleanup |
+| `undo` | `gitman undo [--op <id>] [--list]` | Revert the last intent, or to a chosen op. | `jj undo` / `jj op restore` |
+| `resolve` | `gitman resolve [--list]` | Surface remaining conflicts / confirm cleared. | `jj resolve --list` |
+| `version` | `gitman version [bump <major\|minor\|patch>]` | Show or bump the repo's semver. | version-source read/write |
+| `release` | `gitman release [<level> \| --version X.Y.Z]` | (bump →) tag `vX.Y.Z` → push tag. Verify hook first. | version write + `git tag` + push |
+
+**Global flags:** `--json`, `--repo <path>`.
+**Exit codes:** `0` ok · `1` VC decision needed (conflict / push rejected / verify
+blocked / off-canonical) · `2` infra/config (no remote, auth, jj/git missing, outside
+devenv, no version source) · `3` invalid usage.
+
+**Deferred:** the forge extra's PR `land`/`pr-status`, stacked PRs, `shape`
+(squash/split/reorder), `switch` (parallel lanes use workspaces instead), pre-release
+version metadata, pluggable forges.
+
+## 8. Lane & workspace flow (parallel agents)
+
+The motivating case: several agents chase several fixes simultaneously, then merge back.
+
+```bash
+# three agents, three lanes, three isolated working copies
+agent1$ gitman start fix-auth-test    --workspace   # → ../repo-fix-auth-test/,    lane+branch "fix-auth-test"
+agent2$ gitman start fix-billing-test --workspace   # → ../repo-fix-billing-test/, lane+branch "fix-billing-test"
+agent3$ gitman start fix-cart-test    --workspace   # → ../repo-fix-cart-test/,    lane+branch "fix-cart-test"
+
+# each agent works in its own workspace dir — no contention over @
+agent1$ gitman save -m "fix: tolerate missing auth header"
+agent1$ gitman publish                                # pushes branch fix-auth-test (forge extra also opens PR)
+
+# merge back — local trunk-based, or via PRs (forge extra)
+$ gitman land fix-auth-test fix-billing-test          # rebase each onto trunk, ff trunk, retire lanes+workspaces
+$ gitman abandon fix-cart-test                        # gave up on that one
+```
+
+- **`--workspace`** runs the lane in its own `jj workspace` (separate directory, shared
+  repo). That's how true parallelism avoids stepping on a single `@`; it also matches how
+  parallel agents are spawned anyway (separate working dirs). Without `--workspace`,
+  `start` creates the lane in the current working copy (serial, single-agent flow).
+- **The brief repo lock** (I4) only bites on operations that touch shared state (trunk
+  advance, op-log head, bookmark namespace). Per-lane editing is contention-free, so
+  parallelism is real. Concurrent lane *creation* with the same name is resolved once,
+  under the lock, at creation (refuse or suffix) — never an ambiguity downstream.
+- **`land`** is the sanctioned trunk-advance (I5): it rebases the lane onto current trunk,
+  fast-forwards trunk to include it, then deletes the bookmark and forgets the workspace.
+  The forge extra swaps the local fast-forward for a GitHub PR merge.
+
+## 9. The `RepoState` model (the Pydantic heart)
+
+Analogous to Testee's `VerificationReport`. A reloadable snapshot; the **durable history
+is the jj op-log**, the model is a point-in-time view rendered to the agent.
+
+```
+RepoState
+  repo_root: Path
+  colocated_git: bool
+  canonical: bool                   # all invariants hold
+  off_canonical: str | None         # reason, if not canonical
+  trunk: TrunkRef                   # frozen, from config (name, change_id, commit_id)
+  current_lane: str | None          # the lane of this workspace's @
+  lanes: list[Lane]
+  recent_ops: list[Op]              # tail of op-log → powers undo affordances
+  notes: list[str]                  # honesty notes ("not done" / staleness)
+
+Lane
+  name: str                         # = bookmark = git branch (readable)
+  state: draft | published | landed
+  head: Change                      # tip change (lane = head + linear ancestors to trunk)
+  workspace: str | None             # isolated workspace dir, if any
+  conflict: bool
+  ahead: int · behind: int          # vs trunk
+  pr: PRRef | None                  # populated only by the github extra
+
+Change
+  change_id: str        # STABLE across rewrites — the agent's referent
+  commit_id: str        # current git hash (churns on amend)
+  description: str
+  empty: bool
+  files_changed: int · insertions: int · deletions: int
+
+Conflict   { lane, files: list[{path, sides}] }     # jj-style markers (see §10.7)
+TrunkRef   { name, change_id, commit_id }
+Op         { op_id, description, timestamp, undoable }   # description from op-log tags.args
+```
+
+## 10. Feeding `RepoState` — jj structured output
+
+Capturing state is the central engineering question. Five strategies; Gitman layers
+several. **All validated against jj 0.38 by a 2026-06-15 spike** (the version nixpkgs
+provides); templates are pinned in `jj.py`, and `doctor` asserts the jj version so an
+upgrade that moves a keyword fails loudly.
+
+### 10.1 Strategy B — a custom `json()` template (PRIMARY)
+
+jj has a `json()` template **function**. The clean win is not `json(self)` (omits
+`empty`/`conflict`, nests full parent objects) but a **custom JSON object built by
+concatenating `json()` of exactly the fields we want** — escaped, no delimiter parsing.
+Per lane (revset selects the lane's changes, `<head>` = the lane bookmark):
+
+```bash
+jj log --no-graph -r 'trunk()..<lane> | <lane>' -T '
+  "{"
+    ++ "\"change_id\":"   ++ json(change_id.short())
+    ++ ",\"commit_id\":"  ++ json(commit_id.short())
+    ++ ",\"desc\":"       ++ json(description.first_line())
+    ++ ",\"empty\":"      ++ json(empty)
+    ++ ",\"conflict\":"   ++ json(conflict)
+    ++ ",\"bookmarks\":[" ++ bookmarks.map(|b| json(b.name())).join(",") ++ "]"
+    ++ "}\n"'
+```
+
+**Spike-confirmed limitation (important):** jj has **no list/object literal** and `json()`
+rejects a `.map()` result (`Serialize` vs `ListTemplate`). So `json()` is used only on
+**scalar leaves**; **list** fields are built by concatenation — `"[" ++ xs.map(|x|
+json(x)).join(",") ++ "]"`. The template above is the verified, `json.loads`-clean form →
+parse with stdlib `json` into `Change`. Also: `self.json()` does **not** exist (json is a
+function); `\u{..}` escapes are rejected (`\x..`, `\t`, `\n` work).
+
+The op log is likewise structured: `jj op log --no-graph -T 'json(self) ++ "\n"'` emits
+`{id, parents, time:{start,end}, description, is_snapshot, tags:{args}}` — and `tags.args`
+carries the literal command behind each op, surfaced in undo reports.
+
+### 10.2 Lane enumeration
+
+Lanes = Gitman-managed bookmarks. List them with `jj bookmark list -T '...'` (name +
+target change), pair with `jj workspace list` for the workspace mapping, and run 10.1 per
+lane head. The set of lane heads also gives the revset for "all lanes" capture.
+
+### 10.3 Strategy C — colocated git for numbers jj won't template
+
+Keyed by the `commit_id` from 10.1:
+
+```bash
+git show --numstat --format= <commit_id>     # → files_changed, insertions, deletions
+git rev-list --count <trunk>..<commit_id>    # → ahead
+git rev-list --count <commit_id>..<trunk>    # → behind
+```
+
+The thesis in miniature: **git as the data layer for what git is good at**, keyed by IDs
+jj hands us.
+
+### 10.4 Strategy D — dedicated jj subcommands
+
+- **Conflicts (per-file):** `jj resolve --list` → `path\tN-sided conflict`.
+- **Recent ops (undo):** `jj op log --no-graph -T 'json(self)'`.
+- **Last fetch time:** most recent `fetch` entry in the op log → staleness notes.
+
+### 10.5 Strategy A — delimited template (defensive fallback only)
+
+A control-char-delimited (`\x1f`/`\x1e`) `jj log` template, equivalent to 10.1 without
+`json()`. Built only if a future pinned jj drops/changes `json()`. Not built now.
+
+### 10.6 Strategy E — porcelain fallback
+
+`jj status` parsing as a last resort for any facet A–D can't reach; flagged fragile.
+
+### 10.7 Field → source map & a gotcha
+
+| `RepoState` field | Source |
+|---|---|
+| `trunk` | B at revset `trunk()` (trunk name from config, I1) |
+| `lanes[]` + `current_lane` | 10.2 (`jj bookmark list` + `jj workspace list`) |
+| `Lane.head` / `Change.{change_id,commit_id,desc,empty}` | B (10.1) |
+| `Change.{files_changed,insertions,deletions}` | C (git numstat) |
+| `Lane.{ahead,behind}` | C (`git rev-list --count`) |
+| `Conflict.files` / `Lane.conflict` | D (`jj resolve --list`) + `json(conflict)` |
+| `recent_ops` | D (`jj op log` json) |
+| `canonical` / `off_canonical` | invariant checks (§11) over the captured state |
+
+**Gotcha:** jj conflict markers differ from git's (`<<<<<<< conflict 1 of 1` / `%%%%%%%` /
+`+++++++` / `>>>>>>>` — not git's `=======`); marker-aware logic must expect the jj form.
+
+Keep every jj/git invocation in `jj.py`/`git.py` behind a pure `parse_*` (golden-fixture
+testable, Testee convention), with all template strings in one module to re-pin on jj
+upgrades.
+
+## 11. Enforcement — invariants & transactional rollback
+
+Constraints that are only *documented* drift. The lane model holds by construction:
+
+- **Per-intent invariant precheck.** Each mutating intent first asserts the repo is
+  canonical (one lane per change, trunk where config says, no divergence). Cheap; reuses
+  the §10 capture. A violated precondition refuses with the single recovery instruction.
+- **Transactional rollback.** Each mutating intent captures the op-id before acting, then
+  asserts the **postcondition "still canonical"**; if violated, it auto-`jj op restore`s
+  to the captured op. **Every Gitman command either lands in a canonical state or didn't
+  happen.** (Same op-log lever as `undo`, §12, used as rollback.)
+- **One deviation handler, not N.** External mutation (raw `jj`/`git`, a human) is the one
+  thing Gitman can't prevent. So `status` classifies the repo as **canonical** or
+  **off-canonical** and there is exactly one recovery path — `gitman reconcile` — which
+  adopts stray changes into lanes or abandons them. No per-deviant-state handling.
+
+## 12. The undo model (the headline feature)
+
+- **Intent-level checkpoints.** A single intent (e.g. `sync` = fetch + rebase) may be
+  several jj ops. Capture the op-id before; "undo this intent" = `jj op restore
+  <captured>` — reverts the *whole* intent atomically.
+- **`gitman undo`** = undo the last intent. **`--op <id>`** = restore to any op.
+  **`--list`** = show recent undoable intents (descriptions from op-log `tags.args`).
+- **Every mutating report ends with its own undo command** — the escape hatch is always
+  inline. The single strongest reason to route VC through Gitman.
+
+## 13. Versioning & release
+
+Gitman owns the **semver math and the tag/release flow** but delegates *reading/writing
+the number* to the repo. Two mechanisms:
+
+```toml
+[version]
+# Mechanism A — declarative (default, common case):
+file    = "pyproject.toml"
+pattern = 'version = "{version}"'        # {version} marks the slot to rewrite
+
+# Mechanism B — script hook (repo owns the logic; the agent may edit the script):
+# read  = ["./scripts/version.sh", "get"]
+# write = ["./scripts/version.sh", "set", "{version}"]
+
+[release]
+tag_format = "v{version}"     # default
+verify     = []               # inherits [publish].verify if set; [] = no gate
+push_tag   = true
+```
+
+- **Semver:** `major`→`(X+1).0.0` · `minor`→`X.(Y+1).0` · `patch`→`X.Y.(Z+1)`. v1 is
+  `MAJOR.MINOR.PATCH` only (pre-release/build metadata deferred).
+- `version bump` writes the new number into the current lane and `save`s a "Bump version
+  to X.Y.Z" change — local, undoable.
+- `release` is atomic: optionally bump, create an **annotated git tag** on the lane's
+  commit (tags live on the git side — colocated; jj tag support is read-only) and push it.
+  The **verify hook runs before any write**, so a blocked release leaves no tag and no
+  bump. Release normally happens from a landed change on trunk.
+- **Agent angle:** `gitman init` scaffolds `.claude/skills/gitman/SKILL.md` documenting
+  the lane loop *and* where this repo's version lives + how to bump it. If versioning is
+  unusual, the agent edits `scripts/version.sh`, not Gitman.
+
+## 14. Safety & policy
+
+- **Protected trunk.** Trunk is never rewritten or force-pushed; it only advances via
+  `land` (I5).
+- **No raw destructive primitive** in the intent surface (no `reset --hard`, no blind
+  force-push). Force-push is allowed only to a lane's own branch, via `publish`.
+- **Everything undoable**, always surfaced inline; every command transactional (§11).
+- **Policy is Pydantic-validated config** — trunk, protected refs, verify hook
+  (same discipline as `[tool.testee]`).
+
+## 15. Configuration
+
+Loaded from `gitman.toml` (preferred) or `[tool.gitman]` in `pyproject.toml`,
+Pydantic-validated.
+
+| Key | Meaning |
+|---|---|
+| `trunk` | Trunk bookmark/branch. **Written once by `init`, then frozen** (I1). |
+| `[lanes] workspace_dir` | Where `--workspace` lanes live (default `../<repo>-<lane>`). |
+| `[lanes] always_workspace` | If true, `start` always isolates (default false). |
+| `[publish] verify` | Command run before publish/release (`[]` → no gate). |
+| `[publish] on_fail` | `block` (default) or `warn`. |
+| `[publish] branch_prefix` | Optional prefix on the lane→branch name (default none). |
+| `[version] …` | Version source (see §13). |
+| `[release] …` | Tag format, verify, push behavior (see §13). |
+| `[policy] protected` | Refs that must never be rewritten/force-pushed. |
+
+## 16. Report design
+
+Compact, actionable, Testee-style. Header `Gitman <intent> — <OUTCOME>`; every mutating
+report ends with an inline **Undo** line. `status` is a uniform lane enumeration:
+
+```text
+Gitman status — CANONICAL · 3 lanes
+trunk: main @ def456  (up to date with origin/main)
+* fix-auth-test     draft      1 change,  +18 −4   · ws ../repo-fix-auth-test  (you are here)
+  fix-billing-test  published  1 change,  +30 −2   · PR #41
+  fix-cart-test     draft      2 changes, +60 −9   · ws ../repo-fix-cart-test
+Next: edit · `gitman publish` · `gitman land fix-billing-test`
+```
+
+```text
+Gitman status — OFF-CANONICAL
+Reason: change `pqrs` belongs to no lane (edited outside Gitman?).
+Recover: `gitman reconcile`  — adopt it into a lane, or abandon it.
+Exit: 1
+```
+
+Throughlines: **"not blocked" wherever conflicts appear** (reinforce jj's first-class
+conflicts); **honesty about one-way actions** (pushed branches/tags can't be cheaply
+undone, and the report says so). Per-intent layouts (clean / behind / conflicted /
+blocked / infra-error) follow `05-vcs-brainstorming/CONCEPT_BRAINSTORM.md` §17, adapted to
+name the lane.
+
+## 17. Agent integration
+
+`gitman init` scaffolds `.claude/skills/gitman/SKILL.md` (mirrors Testee's skill): route
+*all* version control through Gitman, never raw `jj`/`git` (it breaks canonicity);
+documents the lane loop and the eleven intents; explains exit codes; points at
+`gitman undo` as the safety net and `gitman reconcile` for off-canonical; and records the
+repo's version-bump procedure.
+
+## 18. Execution boundary
+
+Runs only inside a `devenv.sh` shell (consistent with Testee). `jj`, `git`, and `gh` (for
+the extra) resolve to pinned versions — no host drift. `gitman doctor` validates the
+toolchain (jj present + **version assert**, colocated `.git`, remote, frozen trunk exists,
+version source) and reports canonicity.
+
+## 19. Scope — v1 vs deferred
+
+**v1 (this concept):** the lane model + invariants + transactional enforcement (§5, §11);
+the eleven intents (§7) incl. lane lifecycle + workspaces (§8); `RepoState` + capture
+(§9–10); undo (§12); versioning + release (§13); config + policy (§14–15); compact reports
+(§16); the agent skill (§17); `init`/`doctor`/`reconcile`; devenv boundary.
+
+**Deferred until dogfooding demands it:** the forge extra (PR `publish`/`land`/`pr-status`),
+stacked PRs, `shape` (squash/split/reorder), `switch`, pre-release/build version metadata,
+pluggable forges (GitLab/Gitea).
+
+## 20. Resolved questions
+
+The four prior open questions are now resolved by the lane model + the spike:
+
+1. **Trunk detection** → I1: resolved once at `init`, written to config, frozen; `doctor`
+   validates; ambiguity is a hard stop at `init`, never a silent runtime guess.
+2. **Branch naming** → I3: the branch *is* the readable lane name, unique-checked at
+   creation, stable via the bookmark following the change. No generation/collision/freeze
+   logic.
+3. **`RepoState` capture** → §10: custom `json()` template (Strategy B), spike-validated on
+   jj 0.38; git numstat for numbers; `jj resolve --list` for conflicts.
+4. **Multiple local changes** → I2 + lanes: not hidden and not a soup — every change is a
+   named, listable lane; `status` is a uniform enumeration; parallelism via workspaces.
+
+**Genuinely still open (decide during implementation):**
+
+- **Lock mechanism** — jj op-log concurrency vs an explicit lockfile for I4 under parallel
+  agents; how aggressively `land` serializes.
+- **Workspace cleanup semantics** — auto-`forget` on `land`/`abandon` vs leave the dir;
+  what to do if an agent is still cd'd into a landed workspace.
+- **`reconcile` UX** — how much it decides automatically vs asks, given it runs in an
+  agent (non-interactive) context.
+- **`land` ordering** — landing several lanes that touch overlapping files: sequential
+  rebase with conflict surfacing per lane, and stop-vs-continue on the first conflict.

--- a/.scratch/projects/01-vcs-concept-brainstorming/KICKOFF_PROMPT.md
+++ b/.scratch/projects/01-vcs-concept-brainstorming/KICKOFF_PROMPT.md
@@ -1,0 +1,156 @@
+# Gitman — implementation kickoff prompt
+
+> Paste this as the first message in a clean session inside the **new, empty Gitman repo**.
+> Also copy `GITMAN_CONCEPT.md` into that repo (e.g. as `docs/GITMAN_CONCEPT.md`) — it is
+> the canonical spec; this prompt is the orientation + first-moves on top of it.
+
+---
+
+You are implementing **Gitman** (CLI: `gitman`), a new Python library: the single
+version-control interface for coding agents. It wraps **jujutsu (`jj`)** for local
+operations and uses **git as the colocated interop layer** for GitHub/CI/collaborators.
+It is the version-control sibling of an existing tool called **Testee** (a verification
+manager) and deliberately mirrors Testee's shape and philosophy.
+
+**Read `docs/GITMAN_CONCEPT.md` first — it is the authority.** This prompt summarizes the
+spine and tells you how to start; the concept doc has the full detail and rationale.
+
+## The one-sentence thesis
+
+Agents do version control dangerously; jj's data model (auto-snapshot working copy,
+first-class conflicts, total undo via the operation log, stable change IDs, workspaces)
+makes a *safe* policy layer possible, and Gitman is that layer — exposing a small set of
+**intents** over a **canonical "lane" workflow**, returning compact structured reports
+instead of raw porcelain.
+
+## Non-negotiable constraints
+
+- **Agent-first.** Optimize for an agent consumer: compact actionable reports, structured
+  `--json`, exit codes that distinguish failure kinds. Humans/CI are secondary.
+- **Runs only inside a `devenv.sh` shell.** Set up devenv for this repo. All tooling (jj,
+  git, python, tests, linters) runs via `devenv shell -- ...`. Never invoke bare host
+  tools. Pin `jj` from nixpkgs (currently **jj 0.38** — validated below).
+- **jj required + colocated** (`jj git init --colocate`). No plain-git fallback.
+- **Lean base.** Base deps: `pydantic`, `typer` only. `jj`/`git` come from devenv.
+- **GitHub is an optional extra** (`gitman.advanced.github`) — the base never imports it.
+- **Verification is a generic, off-by-default pre-publish hook** — any command; zero
+  coupling to Testee.
+
+## The lane model (the core stance — internalize this)
+
+The repo is always a **set of canonical lanes**. A **lane** = a named unit of work = a
+readable jj **bookmark** (which *is* the git branch) on a trunk descendant, kept linear,
+optionally in its own **jj workspace** (for parallel agents). Invariants:
+
+- **I1** Trunk is resolved once at `init`, written to config, **frozen** (never re-detected).
+- **I2** Every change belongs to exactly one **named lane** — no anonymous/stray changes.
+- **I3** Branch name = the lane's readable name (unique-checked at creation, stable via the
+  bookmark following the change across rewrites).
+- **I4** Gitman is the **sole writer**; mutating ops are serialized by a brief repo lock.
+- **I5** Each lane is **linear on trunk** (rebase-always); trunk advances **only via `land`**.
+
+Enforcement is **by construction**, not documentation:
+
+- Each mutating intent does an **invariant precheck**, then runs **transactionally**:
+  capture the op-id before, act, assert the postcondition *"still canonical"*, and
+  **auto-`jj op restore`** to the captured op if violated. Every command either lands
+  canonical or didn't happen.
+- The one thing you can't prevent (external `jj`/`git` edits) is handled in exactly **one**
+  place: `status` reports **canonical** vs **off-canonical**, and `gitman reconcile` is the
+  single recovery path.
+
+## Intent set (v1, eleven intents)
+
+`status` · `start <name> [--workspace]` · `save [-m]` · `sync [--all]` · `publish` ·
+`land [<lane>…]` · `abandon [<lane>]` · `undo [--op|--list]` · `resolve [--list]` ·
+`version [bump <major|minor|patch>]` · `release [<level>|--version X.Y.Z]`.
+
+Exit codes: `0` ok · `1` VC decision needed (conflict / push rejected / verify blocked /
+off-canonical) · `2` infra/config · `3` invalid usage. **Deferred — do not build:** the
+forge/GitHub extra, stacked PRs, `shape`, `switch`.
+
+## Pre-validated jj facts (from a spike — do NOT re-discover)
+
+Validated against **jj 0.38**:
+
+- `json()` is a template **function** (not a method — `self.json()` errors). It serializes
+  **scalars** and built-in list *keywords* only; it **rejects `.map()` results**
+  (`Serialize` vs `ListTemplate`), and jj has **no list/object literal**.
+- Therefore build state as a **custom JSON object via concatenation**, `json()` on scalar
+  leaves, list fields as `"[" ++ xs.map(|x| json(x)).join(",") ++ "]"`. This template is
+  `json.loads`-clean:
+  ```
+  jj log --no-graph -r 'trunk()..<lane> | <lane>' -T '
+    "{" ++ "\"change_id\":" ++ json(change_id.short())
+        ++ ",\"commit_id\":" ++ json(commit_id.short())
+        ++ ",\"desc\":" ++ json(description.first_line())
+        ++ ",\"empty\":" ++ json(empty)
+        ++ ",\"conflict\":" ++ json(conflict)
+        ++ ",\"bookmarks\":[" ++ bookmarks.map(|b| json(b.name())).join(",") ++ "]"
+        ++ "}\n"'
+  ```
+- `jj op log --no-graph -T 'json(self)'` → `{id,parents,time:{start,end},description,
+  is_snapshot,tags:{args}}`; `tags.args` is the literal command per op (use it for undo
+  descriptions).
+- Conflicts: `jj resolve --list` → `path\tN-sided conflict`; `conflicts()` revset lists
+  conflicted changes; `json(conflict)` → bool. **jj conflict markers differ from git's**
+  (`<<<<<<< conflict 1 of 1` / `%%%%%%%` / `+++++++` / `>>>>>>>`) — match the jj form.
+- Diff numbers aren't in jj templates → use colocated git keyed by `commit_id`:
+  `git show --numstat --format= <id>`, `git rev-list --count <trunk>..<id>`.
+- String escapes: `\x..`, `\t`, `\n` work; `\u{..}` does **not**.
+- `doctor` must **assert the jj version** so a future upgrade that moves a keyword fails
+  loudly.
+
+## Conventions (mirror Testee)
+
+- Adapters keep a pure `parse_*` (unit-tested via **golden fixtures**) separate from the
+  effectful `run_*`. Put **all jj template strings in one module** so they're easy to
+  re-pin on a jj upgrade.
+- Pydantic v2 is the canonical model; reports render from it. Provide `--json`.
+- Suggested layout (see concept §6): `cli.py core.py lanes.py jj.py git.py state.py
+  models.py config.py invariants.py version.py release.py render.py init.py doctor.py
+  reconcile.py`, plus `advanced/` (forge, deferred).
+- Reports are compact and end mutating output with an inline **Undo** line. Honesty notes
+  like Testee ("not done" / staleness).
+
+## How to work
+
+1. **Plan first.** Read the concept doc, then propose a short **milestone plan** and a repo
+   skeleton, and confirm with me before writing implementation code.
+2. **Bootstrap the repo:** `devenv.nix` (python + jj 0.38 + git, deterministic), `jj git
+   init --colocate`, `pyproject.toml` (hatchling, `gitman` console script, lean deps),
+   test setup, and copy the concept doc into `docs/`.
+   - **Reuse Testee's devenv as the starting template.** Gitman and Testee share most of
+     their environment shape (devenv-managed Python venv, deterministic env vars, a
+     reusable `nix/<tool>.nix` module exposing tasks + `enterTest`, the `devenv shell --`
+     batching convention). If the Testee repo is available, copy its `devenv.nix`,
+     `devenv.yaml`, and `nix/testee.nix` as the basis for Gitman's `devenv.nix` /
+     `nix/gitman.nix` and adapt: add `jujutsu` (pin 0.38) + `git` to packages, rename
+     tasks to `gitman:*`, and point `enterTest` at Gitman's verification. Don't reinvent
+     it greenfield. (Ask me for the Testee devenv files if they aren't to hand.)
+3. **Build vertically and dogfood early.** Get the smallest end-to-end slice working, then
+   use Gitman on its own repo as soon as it can do anything.
+4. **Test the parsers with golden fixtures** captured from real jj 0.38 output.
+
+### Suggested milestones (refine in your plan)
+
+- **M0** — devenv + colocated repo + `pyproject` + skeleton + `gitman doctor` (toolchain &
+  jj-version assert) + `models.py` stubs.
+- **M1** — read path: `state.py` capture (the validated templates) + `status` (canonical /
+  off-canonical, lane enumeration) + golden-fixture parser tests.
+- **M2** — lane lifecycle: `start` (+`--workspace`), `save`, `publish` (push, no PR),
+  `land`, `abandon`, with the transactional-rollback wrapper + invariant checks.
+- **M3** — `sync`, `resolve`, `undo`; then `version` + `release`; then `init` (scaffold
+  `gitman.toml` + `.claude/skills/gitman/SKILL.md`) and `reconcile`.
+
+## Guardrails
+
+- Don't build the GitHub/forge extra, stacked PRs, `shape`, or `switch` yet.
+- Don't expose raw destructive primitives (`reset --hard`, blind force-push).
+- Don't run bare host tooling — everything through devenv.
+- Don't add AI-generated attribution to commits/PRs/docs.
+- When in doubt about a design fork, prefer the choice that keeps the lane invariants true
+  by construction, and surface (don't silently assume) any inference.
+
+**Start by reading `docs/GITMAN_CONCEPT.md`, then come back with a milestone plan and the
+repo skeleton for approval.**

--- a/.scratch/projects/02-pyjutsu-pyo3-binding/KICKOFF_PROMPT.md
+++ b/.scratch/projects/02-pyjutsu-pyo3-binding/KICKOFF_PROMPT.md
@@ -1,0 +1,151 @@
+# Pyjutsu — implementation kickoff prompt
+
+> Paste this as the first message in a clean session inside the **new, empty Pyjutsu repo**.
+> Copy `PYJUTSU_CONCEPT.md` into that repo as `docs/PYJUTSU_CONCEPT.md` first — it is the
+> canonical spec. This prompt is the orientation, environment, and first moves on top of it.
+
+---
+
+You are implementing **Pyjutsu** (`import pyjutsu`): a **general-purpose, Pythonic +
+Pydantic binding to jujutsu's Rust engine (`jj-lib`) via PyO3/maturin**. It is **not**
+gitman-specific — gitman is merely one consumer. **Read `docs/PYJUTSU_CONCEPT.md` first; it
+is the authority.** This prompt summarizes the spine and tells you how to start.
+
+## The one-sentence thesis
+
+Python drives jj today by shelling out to the `jj` CLI and parsing template/text output;
+Pyjutsu removes that ceiling by binding `jj-lib` **in-process** — native graph/op-log/working-copy
+access and **real `jj-lib` transactions** (one atomic operation), with no subprocess and no
+text parsing — paying for it with a Rust build and `jj-lib`'s instability, which we tame by
+**pinning the jj version** and **differential-testing against the pinned `jj` CLI**.
+
+## Non-negotiable constraints
+
+- **jj-lib via PyO3, in-process. No subprocess backend, no CLI fallback, no compat shim.**
+  The existing `../Pyjutsu` CLI-wrapper is being **completely replaced** — **zero
+  backwards-compatibility** with its API/models/names/behavior. Design fresh.
+- **Pin jj hard.** `Cargo.toml` pins `jj-lib = "=0.38.0"` (commit `Cargo.lock`). `devenv.nix`
+  pins the Rust toolchain, `maturin`, **and the matching `jj` 0.38.0 CLI binary** (from
+  nixpkgs rev `26eaeac4e409d7b5a6bf6f90a2a2dc223c78d915`, the same pin gitman uses) for
+  differential tests. Pyjutsu's version encodes the jj it targets (`pyjutsu 0.38.*` ↔ jj 0.38).
+- **Runs only inside a `devenv.sh` shell.** All tooling (cargo, maturin, python, jj, pytest)
+  via `devenv shell -- ...`. Never bare host tools.
+- **Thin Rust, rich Python.** `_pyjutsu` (Rust) exposes **opaque handles + plain data only**;
+  **never leak `jj-lib` types to Python**. All Pydantic models, ergonomics, defaults, typing,
+  and the public contract live in pure-Python `pyjutsu`.
+- **Faithful, un-opinionated primitives.** No workflow/policy (no lanes, no "frozen trunk").
+  Mirror jj. Policy belongs to consumers like gitman.
+- **Differential testing against the pinned `jj` CLI is the primary correctness + drift net.**
+
+## Architecture (concept §4) — three layers
+
+```
+pyjutsu   (pure Python, PUBLIC)  → Pydantic models, Workspace/Transaction facade, typing, docs
+_pyjutsu  (Rust, PyO3, THIN)     → opaque handles (PyWorkspace/PyTransaction) + plain data
+jj-lib    (Rust crate, =0.38.0)  → engine: Workspace, ReadonlyRepo/MutableRepo, Commit,
+                                    RevsetExpression, Transaction, OpStore/Operation,
+                                    LocalWorkingCopy, git backend (gix/git2)
+```
+
+- **Stateful things** (`Workspace`, open `Transaction`) cross the FFI as opaque `#[pyclass]`
+  handles; **values** (commits, lists, diff stats) cross as **plain dicts/tuples** that the
+  Python layer feeds to `Model.model_validate(...)`. Keep the Rust surface tiny.
+- jj-lib churn is absorbed in the thin Rust shim → the public Python API stays stable across
+  jj upgrades.
+
+## Public API contract (concept §5, §11) — build to this
+
+Object-oriented around `Workspace`; reads return Pydantic models; mutations run inside a
+transaction that maps to **exactly one jj operation**.
+
+```python
+ws = Workspace.load(path)                       # or Workspace.init(path, colocate=True) / .clone(...)
+ws.working_copy(); ws.resolve("trunk()")        # -> Commit
+ws.log("trunk()..@", limit=50)                  # -> list[Commit]; revset string is jj's own
+ws.bookmarks(); ws.operations(limit=20); ws.diff_stat(id)
+with ws.transaction("msg") as tx:               # == 1 jj operation, atomic
+    c = tx.new(parents=[...]); tx.describe(c, "..."); tx.set_bookmark("feat", c)
+ws.undo(); ws.restore_operation(op); ws.at_operation(op)
+ws.git_fetch(remote="origin"); ws.git_push(bookmark="feat", remote="origin", allow_new=True)
+```
+
+- **Workspaces (jj's worktrees, concept §11):** `ws.workspaces()` lists ALL (from the shared
+  view); `ws.working_copy()` is this handle's `@`. **`add_workspace(path, name, at=...)` is
+  eager** — it does the record-creation transaction **and** the checkout inside the call and
+  returns a ready handle (errors if `path` is non-empty). `forget_workspace(name)` removes the
+  record, not the directory. **Stale-`@` detection is mandatory:** `is_stale()` /
+  `update_stale()`; never mutate a stale working copy silently.
+- **Models (Pydantic v2):** `Commit`, `ChangeId`/`CommitId`, `Bookmark`, `Operation`,
+  `Conflict` (N-sided/`Merge`, faithful — not a bool), `DiffStat`, `Signature`,
+  `WorkspaceInfo`.
+
+## Environment / build setup (do this in M0)
+
+- **Reuse gitman's devenv shape** (rolling nixpkgs, `languages.python` 3.13 + venv + uv with
+  `uv.sync.enable`, a reusable `nix/pyjutsu.nix` task module, quiet non-interactive
+  `enterShell`). Ask for gitman's `devenv.nix`/`nix/gitman.nix` if not to hand. **Add**: a
+  Rust toolchain (`languages.rust.enable` or fenix), `maturin`, and the pinned `jj` 0.38.0
+  binary (the `nixpkgs-jj` input at the rev above).
+- **maturin mixed layout:** `pyproject.toml` with `[build-system] requires=["maturin>=1.5"],
+  build-backend="maturin"`; `Cargo.toml` (crate `_pyjutsu`, `pyo3` with `abi3-py313`,
+  `jj-lib = "=0.38.0"`); `src/lib.rs` (Rust ext); `python/pyjutsu/` (pure-Python package).
+- Dev verification: `pyjutsu:build` (maturin develop), `pyjutsu:test` (pytest +
+  `cargo test`), `pyjutsu:lint` (ruff + clippy), `enterTest` = build + both test suites.
+
+## How to work
+
+1. **Plan first.** Read the concept, propose a milestone plan + repo skeleton, and **confirm
+   before writing implementation code**.
+2. **Spike the binding risk before anything else** (this is M0's heart). Prove the single
+   riskiest slice end to end: from Python, `import pyjutsu; Workspace.load(path)` a real
+   colocated repo via jj-lib and read `@`'s `change_id` / `commit_id` / `description`. This
+   one slice validates: the maturin build, the `jj-lib = 0.38.0` pin actually compiling, the
+   PyO3 opaque-handle model, and the `Arc`/`Send`/lifetime constraints. If jj-lib 0.38 won't
+   build cleanly under the pinned toolchain, surface that immediately — it gates everything.
+3. **Build vertically with a differential test each step:** one read (`log(revset)` →
+   `list[Commit]`) compared against the pinned `jj log`; then one transaction (`describe` as a
+   native jj-lib transaction → one op) compared against `jj`'s op-log effect.
+4. **Then breadth** per concept §12: reads → transactions → op log → workspaces → git interop.
+
+## Suggested milestones (refine in your plan)
+
+- **M0** — devenv (rust + maturin + pinned jj 0.38) + maturin mixed skeleton + `_pyjutsu`
+  returning the linked jj-lib version + `Workspace.load` + read `@` as a `Commit`. Differential
+  harness scaffold (spins up a scratch repo, can invoke the pinned `jj`).
+- **M1** — reads: `resolve`, `log`, `bookmarks`, `operations`, `diff_stat`, conflicts →
+  Pydantic models + differential tests + golden fixtures.
+- **M2** — transactions (native, one op each): `new`/`describe`/`edit`/`abandon`/`rebase`/
+  `squash`/bookmark ops/`snapshot`; op log: `undo`/`restore_operation`/`at_operation`.
+- **M3** — workspaces (`workspaces`/`add_workspace` eager/`forget_workspace`/`is_stale`/
+  `update_stale`) + git interop (`git_fetch`/`git_push`/`git_import`/`git_export`/`remotes`);
+  package the abi3 wheel; CI wheel build.
+
+## Watch out for (concept §8, §11)
+
+- **`jj-lib` is explicitly unstable** → hard pin, thin Rust layer, differential tests,
+  deliberate upgrade cadence; never expose jj-lib types to Python.
+- **FFI panic safety** — a panic across the boundary aborts the process; wrap fallible paths,
+  `catch_unwind`, map jj-lib errors to a `PyjutsuError` hierarchy.
+- **GIL** — release it (`Python::allow_threads`) on snapshot/fetch/push/large revset eval.
+- **`Send`/`Sync` + lifetimes** — `#[pyclass]` handles must be `Send` and must not outlive
+  their repo; the shared repo is `Arc`-shared, working copies are path-affine.
+- **Reads can mutate** — jj snapshots `@` on many ops; provide explicit `snapshot()`, an
+  `ignore_working_copy` read mode, and `at_operation` for side-effect-free reads.
+- **Stale working copy** across workspaces — detect + `update_stale`, never silently operate.
+- **Two concurrency layers** — per-workspace WC lock + op-log optimistic concurrency
+  (divergent operations are real; surface them).
+- **Wheel build matrix** — abi3 to limit it; the git backend (gix/libgit2) is heavy → watch
+  size/build time; ship sdist (needs Rust) + prebuilt wheels.
+- **Stay policy-free** — faithful jj primitives only.
+
+## Guardrails
+
+- Don't add a CLI/subprocess backend, a migration shim, or any old-Pyjutsu compatibility.
+- Don't leak `jj-lib` types across the FFI or put business logic in Rust.
+- Don't bake in workflow policy (lanes, frozen trunk, etc.).
+- Don't run bare host tooling — everything through devenv.
+- Don't add AI-generated attribution to commits/PRs/docs.
+
+**Start by reading `docs/PYJUTSU_CONCEPT.md`, then come back with a milestone plan and the
+repo skeleton (maturin mixed layout + devenv) for approval — and run the M0 jj-lib build
+spike early, since it gates the whole approach.**

--- a/.scratch/projects/02-pyjutsu-pyo3-binding/PYJUTSU_CONCEPT.md
+++ b/.scratch/projects/02-pyjutsu-pyo3-binding/PYJUTSU_CONCEPT.md
@@ -1,0 +1,302 @@
+# Pyjutsu — Concept (PyO3 / jj-lib binding)
+
+**Status:** Concept / pre-implementation.
+**Name:** Pyjutsu · **Import:** `import pyjutsu`
+**What:** A general-purpose, Pythonic + Pydantic binding to **jujutsu's Rust engine
+(`jj-lib`)** via **PyO3**, distributed as a compiled wheel (maturin).
+**Not:** a gitman component. Gitman is one *consumer*; Pyjutsu must stand alone and be
+useful to any Python tool that wants to drive jj programmatically.
+
+---
+
+## 1. Thesis
+
+Today, Python talks to jj by **shelling out to the `jj` CLI** and parsing template/text
+output (this is what gitman's `jj.py` and the existing CLI-wrapper Pyjutsu do). That works
+but has a hard ceiling: process-per-call overhead, a working-copy snapshot on every
+invocation, brittle text/template parsing against an unstable CLI surface, no native
+cross-call transaction, and `json()` template limitations that force hand-built JSON.
+
+Pyjutsu removes that ceiling by binding **`jj-lib` in-process**: read the commit graph,
+op log, working copy, revsets, and conflicts as native Rust data; perform mutations inside
+**`jj-lib`'s real `Transaction`** (one atomic operation), with **no subprocess and no text
+parsing**. The cost is a Rust build and tracking `jj-lib`'s (intentionally unstable) API —
+which we tame by **pinning the jj version** and **differential-testing against the pinned
+`jj` CLI binary**.
+
+## 2. Why PyO3 over the CLI wrapper (and over jj-lib-from-scratch)
+
+| Concern | CLI wrapper (current Pyjutsu/gitman) | PyO3 + jj-lib (this) |
+|---|---|---|
+| Per-op cost | process spawn + repo load + WC snapshot, ×N | in-process; load repo once, reuse |
+| Data access | templates → text → parse → models | native graph access → models |
+| `json()` limits | hand-built JSON, scalar-only | none — read fields directly |
+| Transactions | simulated via op-id capture + `jj op restore` | **native `jj-lib` transaction** = 1 op |
+| Parsing fragility | high (formats move per version) | none (typed Rust API) |
+| API stability | CLI is *relatively* stable | `jj-lib` is **unstable** → must pin |
+| Build/dist | pure Python | Rust toolchain, maturin wheels |
+
+The instability of `jj-lib` is the price; pinning + differential tests pay it. The CLI
+wrapper stays viable as a *fallback backend* (see §9).
+
+## 3. Relationship to the existing Pyjutsu repo
+
+The existing `../../Pyjutsu` (a CLI-wrapper over `sh`/`clinch`) is being **completely
+replaced**. There is **no backwards-compatibility requirement** — not for its API, its
+models, its method names, or its behavior. Design Pyjutsu fresh around jj-lib and what makes
+a clean Pythonic binding; only glance at the old `models.py`/`SPEC.md` if a particular
+model shape happens to be convenient, never as a constraint.
+
+## 4. Architecture — three layers
+
+```
+┌─ pyjutsu (pure Python, public)  ─ Pydantic models, ergonomic facade, docs, typing ─┐
+│      Workspace / Repo / Transaction facades · Commit/Change/Bookmark/Operation/…    │
+│      converts native data ↔ Pydantic; owns all ergonomics & validation              │
+├─ _pyjutsu (Rust, PyO3 native ext)  ─ THIN ───────────────────────────────────────── │
+│      opaque handles: PyWorkspace, PyRepo, PyTransaction                              │
+│      returns plain data (dicts/tuples/bytes) for values; no business logic          │
+├─ jj-lib (Rust crate, pinned)  ─ the engine ──────────────────────────────────────── │
+│      Workspace, ReadonlyRepo/MutableRepo, Commit, RevsetExpression, Transaction,    │
+│      OpStore/Operation, LocalWorkingCopy, git backend (gix/git2)                     │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Design rule: keep the Rust layer thin and dumb.** It mediates `jj-lib` ↔ Python with a
+*minimal, stable, internal* surface (handles + plain data). All ergonomics, Pydantic
+modeling, defaults, and the public contract live in the Python layer. This means:
+
+- jj-lib churn is absorbed almost entirely in the thin Rust layer; the Python public API
+  stays stable across jj upgrades.
+- The Python layer is where consumers (gitman, others) integrate; it's `pip`-friendly,
+  fully typed, and Pydantic-native.
+
+### Value passing across the FFI
+
+- **Stateful things** (`Workspace`, an open `Transaction`) → opaque `#[pyclass]` handles.
+- **Values** (a commit, a list of commits, a diff stat) → **plain Python data**
+  (dicts/lists of primitives) that the Python layer feeds to `Model.model_validate(...)`.
+  This keeps the Rust surface tiny and gives Pydantic validation at the boundary (which
+  also catches jj-lib drift). Hot paths (huge logs) may use `TypedDict` fast-construction
+  to skip per-row validation — measure first (§10).
+
+## 5. The public API (what a developer sees)
+
+Object-oriented around a `Workspace`. Reads return Pydantic models; mutations happen inside
+a transaction context that maps to exactly one jj operation.
+
+```python
+from pathlib import Path
+from pyjutsu import Workspace, Commit, Bookmark, Operation
+
+ws = Workspace.load(Path("my-repo"))            # or Workspace.init(path, colocate=True)
+
+# --- reads (Pydantic models; no mutation with ignore_working_copy=True) ---
+at = ws.working_copy()                           # Commit for @
+trunk = ws.resolve("trunk()")                    # single-revision resolve → Commit
+hist: list[Commit] = ws.log("trunk()..@", limit=50)
+bms: list[Bookmark] = ws.bookmarks()             # local + remote tracking
+ops: list[Operation] = ws.operations(limit=20)   # op log (id, time, description, tags)
+stat = ws.diff_stat(at.commit_id)                # files / insertions / deletions
+conflicts = at.conflicts                          # first-class, N-sided
+
+# --- mutations: one transaction == one jj operation (native, atomic) ---
+with ws.transaction("start feature") as tx:
+    child = tx.new(parents=[trunk.change_id])
+    tx.describe(child, "Add feature")
+    tx.set_bookmark("feature", child)
+op_id = ws.head_operation()                       # the op the tx produced
+
+# --- undo / time travel (native op log) ---
+ws.undo()                                          # revert the last operation
+ws.restore_operation(op_id)                        # restore to any op
+repo_then = ws.at_operation(op_id)                 # read a historical state
+
+# --- git interop (jj-lib git backend) ---
+ws.git_fetch(remote="origin")
+ws.git_push(bookmark="feature", remote="origin", allow_new=True)
+ws.git_export(); ws.git_import()                   # colocated sync
+```
+
+### Surface (v1)
+
+- **Workspace lifecycle:** `init`, `load`, `clone`, `workspaces()`, `add_workspace`,
+  `forget_workspace`.
+- **Reads:** `working_copy`, `resolve`, `log` (revset + limit), `commit(id)`,
+  `bookmarks`, `operations`, `diff_stat`, `diff` (later), conflicts on a `Commit`.
+- **Revsets:** evaluate any jj revset string → `list[Commit]`; a `Revset` builder is a
+  later nicety. The revset string *is* jj's, so power users transfer knowledge directly.
+- **Mutations (in a `Transaction`):** `new`, `describe`, `edit`, `abandon`, `rebase`,
+  `squash`, `restore`, `set_bookmark`/`create_bookmark`/`delete_bookmark`, `snapshot`.
+- **Operations:** `undo`, `restore_operation`, `at_operation`, `head_operation`.
+- **Git:** `git_fetch`, `git_push`, `git_import`, `git_export`, `remotes`.
+
+### Models (Pydantic v2)
+
+`Commit` (change_id, commit_id, description, author/committer `Signature`, parents,
+empty, conflict, bookmarks), `ChangeId`/`CommitId` (validated str newtypes), `Bookmark`
+(name, remote, target, tracked), `Operation` (id, parents, time, description, tags),
+`Conflict` (path, sides/`Merge`), `DiffStat`, `Signature`, `RepoState` (optional
+convenience aggregate). Mirror the existing CLI-wrapper Pyjutsu's shapes where sensible.
+
+## 6. Build, toolchain & pinning
+
+- **maturin** builds `_pyjutsu` into an **abi3** wheel; `pyproject.toml` uses the maturin
+  backend. Pure-Python `pyjutsu/` ships alongside the compiled `_pyjutsu`.
+- **`Cargo.toml` pins `jj-lib` exactly** (`=X.Y.Z`, with `Cargo.lock` committed). This is
+  the real API pin.
+- **`devenv.nix` pins** the Rust toolchain, `maturin`, **and the matching `jj` CLI binary**
+  (same X.Y.Z) so differential tests compare against the exact CLI of the bound library.
+- **Version contract:** Pyjutsu's version encodes the jj it targets (e.g. `pyjutsu
+  0.38.*` ↔ jj 0.38). Consumers (gitman) pin accordingly. Bumping jj = a deliberate
+  Rust-side port + a Pyjutsu minor bump.
+
+## 7. Testing strategy (the safety net for jj-lib instability)
+
+1. **Differential tests vs the pinned `jj` CLI.** For each operation, run it through both
+   Pyjutsu and `jj` (from devenv) on a scratch repo and assert equivalence (same change
+   graph, bookmarks, op log effect). This validates correctness *and* turns a jj upgrade
+   that changes behavior into a loud test failure.
+2. **Property/round-trip tests:** build a repo via Pyjutsu, read it back, assert invariants
+   (parents, ids stable across rewrites, conflicts faithful).
+3. **Rust unit tests** for the thin layer; **Python tests** for models + facade.
+4. **Golden fixtures** for model parsing (as gitman does), regenerated against the pin.
+
+## 8. What to keep an eye on (risks)
+
+1. **`jj-lib` is explicitly unstable.** Mitigate: hard pin, thin Rust layer, differential
+   tests, deliberate upgrade cadence. Never expose `jj-lib` types to Python directly.
+2. **Panic safety across FFI.** A Rust panic over the boundary aborts the process. Wrap
+   fallible paths; map `jj-lib` errors → a `pyjutsu` exception hierarchy
+   (`PyjutsuError`, `RevsetError`, `ConflictError`, `BackendError`, …). Use
+   `catch_unwind` at the boundary.
+3. **GIL.** Release it (`Python::allow_threads`) during I/O-heavy ops (working-copy
+   snapshot, fetch/push, large revset eval) so callers stay responsive.
+4. **`Send`/`Sync` + lifetimes.** `#[pyclass]` must be `Send`. jj-lib uses `Arc` widely
+   (good), but some types/handles may not be `Send`/`Sync`; wrap in `Arc`/`Mutex` or keep
+   thread-affine. Don't hand Python a borrowed handle that outlives its repo.
+5. **Working-copy snapshot mutates.** Many "reads" snapshot @ (creating an op). Provide an
+   explicit `snapshot()` and an `ignore_working_copy=True` read mode (jj's
+   `--ignore-working-copy`) plus `at_operation` for consistent, side-effect-free reads.
+6. **Backend generality.** Support git backend **colocated and non-colocated**, and jj's
+   native backend. Don't bake gitman's "always colocated" assumption into Pyjutsu — that's
+   a consumer policy.
+7. **Build/distribution.** maturin wheels across {linux, macOS} × {x86_64, aarch64}; abi3
+   to limit the matrix; the git backend (gix/libgit2) is a heavy dependency → watch wheel
+   size and build times. Ship sdist (needs Rust to build) + prebuilt wheels.
+8. **Concurrency / op log.** Surface operation-based consistency; concurrent writers create
+   divergent operations — expose them (jj reconciles via the op log), don't hide.
+9. **Conflicts are first-class.** Model the N-sided `Merge` faithfully (path + sides +
+   sources), not just a bool. This is jj's headline feature.
+10. **Stay un-opinionated.** No lanes, no workflow policy, no "trunk is frozen." Pyjutsu =
+    faithful jj primitives. Policy lives in gitman and other consumers.
+11. **Async.** Ship a **sync** API (jj-lib is blocking). Offer an optional async facade
+    later via `asyncio.to_thread`; don't bake async into the core.
+12. **Validation cost.** Per-row Pydantic validation on huge logs can dominate. Offer a
+    fast path (TypedDict / lazy models) where it matters; benchmark before optimizing.
+
+## 9. Backend: jj-lib only
+
+Pyjutsu is **jj-lib via PyO3, period** — no CLI backend, no migration shim, no compat layer
+(the old CLI-wrapper repo is discarded, §3). A subprocess fallback could be revisited *much*
+later only if wheel distribution proves impractical on some platform; it is explicitly **not**
+a v1 goal and carries no compatibility obligation.
+
+## 10. Relationship to gitman
+
+Gitman's `jj.py`/`git.py`/`templates.py` collapse into a thin adapter over Pyjutsu (or
+Pyjutsu becomes a direct dependency). Gitman keeps its lane policy, transactional invariant
+checks, and reports; it stops parsing templates. Pyjutsu's native transaction replaces
+gitman's op-id-capture/op-restore simulation. Pyjutsu must land its read + transaction API
+before gitman migrates.
+
+## 11. Workspaces (jj's "worktrees")
+
+jj's analog of git worktrees is the **workspace**: multiple working copies that **share one
+underlying repo** (one commit store, one op log). This is the substrate for parallel agents
+(gitman's "lane = workspace"), so Pyjutsu must model it faithfully.
+
+### The jj-lib model
+
+- A **repo** is the shared store under `.jj/repo` (backend + op log + view). A **workspace**
+  is a working copy under its own root with its own `@` (working-copy commit) and its own
+  on-disk tree state. The default workspace is named `default`.
+- The repo `View` holds `wc_commit_ids: {WorkspaceId → CommitId}` — i.e. **every
+  workspace's `@` is recorded in the shared repo**, readable from any workspace.
+- In `jj-lib`: a `Workspace` (Rust) is **bound to one working-copy path**; it carries a
+  `WorkspaceId` (the name) and a `LocalWorkingCopy`, and loads the shared repo via its
+  `RepoLoader`. Reading the graph/op-log/bookmarks is shared and identical from any
+  workspace handle; reading/snapshotting `@` is **per-workspace** (needs that path's files).
+
+### How Pyjutsu exposes it
+
+A `Workspace` handle in Pyjutsu == one working copy (one path). The repo behind it is shared.
+
+```python
+ws = Workspace.load(Path("repo"))            # the workspace whose WC is at this path
+ws.workspaces()        # -> list[WorkspaceInfo]{name, path, wc_commit} for ALL workspaces (from the shared view)
+ws.working_copy()      # -> the @ of THIS workspace only
+ws.name                # this workspace's id (e.g. "default")
+
+# create a second working copy sharing the same repo (one jj operation)
+other = ws.add_workspace(path=Path("../repo-feat"), name="feat", at="trunk()")
+#   -> returns a Workspace handle bound to ../repo-feat with its own new @
+
+other.snapshot()       # snapshots ../repo-feat's working copy (that path's files)
+ws.forget_workspace("feat")   # removes the record from the shared view; does NOT delete the dir
+```
+
+**Decision — `add_workspace` is eager.** It returns a ready-to-use `Workspace` handle, with
+the working copy **checked out inside the call**: the Rust layer performs the
+record-creation transaction (allocate the `WorkspaceId`, set its `@` in the shared view)
+**and** the working-copy checkout at `path` as one operation from the caller's view, then
+hands back a handle bound to that path. (Internally this is jj-lib's two steps — create the
+workspace record + check out files — but the binding sequences them so the caller never sees
+a half-created workspace.) If `path` already exists and is non-empty, `add_workspace` errors
+rather than clobbering it.
+
+Key guarantees/semantics to surface (don't hide them — Pyjutsu is faithful, gitman adds policy):
+
+- **One repo, N working copies.** Graph/bookmark/op-log reads are consistent across all
+  handles; only `@` and snapshots are path-local.
+- **A handle is path-bound.** To touch another workspace's files/`@`, load (or hold) that
+  workspace's handle — you can hold several in one process, but each snapshot needs its path.
+- **`forget_workspace` ≠ delete dir.** It removes the workspace's record + its `@` from the
+  view; the directory is left for the caller to remove (mirrors `jj workspace forget`).
+- **Stale working copy.** If a transaction (from this or another workspace) rewrites the
+  commit another workspace's `@` points to, that workspace becomes **stale**. Pyjutsu must
+  (a) detect it (`ws.is_stale()` / a `StaleWorkingCopy` signal) and (b) offer
+  `ws.update_stale()` (the `jj workspace update-stale` equivalent) — never silently operate
+  on a stale `@`.
+- **Two concurrency layers.** Snapshotting takes a **per-workspace working-copy lock**;
+  repo writes use the **op log's optimistic concurrency** (concurrent writers from different
+  workspaces produce *divergent operations* that jj reconciles). Surface divergence; don't
+  pretend it can't happen.
+
+### Why this is much nicer than the CLI for parallel agents
+
+With the CLI, every workspace command reloads the repo and re-snapshots. With Pyjutsu the
+**shared repo store is loaded in-process and reused**: a coordinator process can hold one
+repo view and many lightweight `Workspace` handles, reading all lanes' state cheaply and
+opening transactions without per-call process/load cost. Each parallel agent can still run
+in its own process against its own workspace path; the shared op log coordinates them
+exactly as jj intends.
+
+### Watch-outs specific to workspaces
+
+- **Stale-`@` detection is mandatory** before mutating a workspace whose base moved.
+- **`#[pyclass]` workspace handles must be `Send`** and must not outlive their repo; the
+  shared repo is `Arc`-shared, individual working copies are path-affine.
+- **WorkspaceId uniqueness** within a repo; default name is `default`.
+- **`at_operation` reads** give a historical repo view while the working copy stays current
+  — document the split so callers don't conflate "repo at op X" with "files on disk now".
+
+## 12. Scope — v1 vs later
+
+**v1:** load/init, reads (working_copy/resolve/log/bookmarks/operations/diff_stat +
+conflicts), transactions (new/describe/edit/abandon/rebase/squash/bookmarks/snapshot),
+op log (undo/restore/at_operation), git fetch/push/import/export, the Pydantic model set,
+maturin build + devenv pin + differential tests.
+
+**Later:** revset builder, full diffs/hunks, native backend polish, async facade, CLI
+fallback backend, streaming/iterator log for huge repos, Windows.

--- a/.scratch/projects/03-gitman-pyjutsu-migration/DECISION_LOG.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/DECISION_LOG.md
@@ -1,0 +1,207 @@
+# Decision log — Gitman → Pyjutsu migration (re-evaluation)
+
+Re-derived 2026-06-17 against the **actual** gitman source and the **actual** pyjutsu 0.7.0
+API (built `maturin develop --release`, `JJ_VERSION == 0.38.0`). Every behavioral claim below
+was verified by probing pyjutsu directly (`.scratch/probe_pyjutsu.py`, `probe2.py`, `probe3.py`)
+and by loading gitman's own colocated repo through `Workspace.load`. The original
+`MIGRATION_PLAN.md` is a strong draft; this log records where it holds, where it was wrong, and
+the refinements folded into `MIGRATION_PLAN_v2.md`.
+
+User decisions (AskUserQuestion, 2026-06-17): **distribution = build-from-sibling now**;
+**trunk protection = gitman-enforced only**.
+
+---
+
+## A. Verification harness — what was actually tested
+
+| Probe | Result |
+|---|---|
+| `transaction()` auto-snapshot is a *separate preceding* op | **True.** op log shows `snapshot working copy` then the mutation op. `restore_operation(op_before)` reverts both. |
+| Reads are frozen (no implicit snapshot) | **True.** a brand-new file is absent from `diff_stat`/`diff` until `ws.snapshot()`. |
+| rebase into a conflict | **Does NOT raise** — returns a commit with `has_conflict=True`; `conflicts()` lists the path. First-class conflicts, exactly as jj. |
+| `tx.describe("main", …)` (rewrite trunk tip) | **Succeeds** — pyjutsu does not load jj's default `immutable_heads()`. Only `root()` is protected. |
+| `tx.describe("root()", …)` | **Rust panic** (`PanicException`), not a clean error. `tx.abandon("root()")` *does* raise `ImmutableCommitError`. (pyjutsu rough edge; gitman never targets root.) |
+| empty transaction / describe-to-same-message / already-based rebase | all **succeed and publish an op** — no native "nothing changed" signal. |
+| `ws.undo()` of a dirty-`@` intent | reverts only the head (mutation) op, **leaving the snapshot op** — so `ws.undo()` alone is wrong when `@` was dirty or the intent spans multiple ops. |
+| snapshot-first + `transaction(..., auto_snapshot=False)` | yields a **single** mutation op as head; `ws.undo()` then reverts exactly the intent and preserves the user's snapshotted edits. |
+| `git_push(remote, name, delete=True)` with no such remote ref | raises typed `GitError`. |
+| `Workspace.load(gitman_repo)` + `bookmarks/log/diff_stat/conflicts/operations` | all work in-process on the real repo; `remote` field distinguishes local (`None`) / colocated (`'git'`) / `'origin'`. |
+| workspace add + `is_stale()` | works; new `@` based on root (documented divergence from CLI). |
+
+---
+
+## B. Pressure-test items → decisions
+
+### 1. Do gitman's own report models earn their keep?
+**Decision: keep `RepoState`/`Lane`/`Change`/`Op`/`Conflict`/`TrunkRef`; populate from pyjutsu
+models in one place (`state.py`). Do not re-export pyjutsu models in the report/`--json` surface.**
+
+Rationale: `RepoState`/`Lane`/`TrunkRef` are pure policy — pyjutsu has no equivalent. `Change` is a
+*flattened projection* of `pyjutsu.Commit` + `DiffStat` (inline `files_changed/insertions/deletions`,
+`empty`, `conflict`, `bookmarks`) that the renderer and the `--json` contract depend on; exposing
+`pyjutsu.Commit` directly would leak `author/committer/parent_ids` and split the diff numbers into a
+second model. The `--json` payload is a **user-facing contract** and must stay gitman-shaped. The DRY
+win is real but small and lives entirely at the mapping boundary — keep it there. This is the
+"policy in gitman, primitives in pyjutsu" split applied to the type layer.
+
+### 2. The undo model — can every intent be one undoable unit so `ws.undo()` suffices?
+**Decision: No — keep a persisted whole-intent checkpoint (`op_before`), restored via
+`restore_operation`. Adopt *snapshot-first + `auto_snapshot=False`* as the uniform transaction
+discipline. Rename the op so `undo --list` reads from the op log.**
+
+Rationale (verified): you cannot collapse every intent to one jj op because (a) auto-snapshot is a
+*separate* preceding op, and (b) `add_workspace`, `git_fetch`, `git_push` each publish their **own**
+op outside any transaction — so `start --workspace`, `sync`, `land`(published), `abandon`(workspace)
+are intrinsically multi-op. Since each CLI call is a fresh process, the undo target must persist on
+disk. So `.gitman/last-undo` **stays** — but it now stores just the op-id string from
+`ws.head_operation()` (no jj subprocess). Refinements:
+- The transaction wrapper does `ws.snapshot()` **explicitly first**, then captures `op_before`,
+  then opens `transaction(intent, auto_snapshot=False)`. This makes the mutation a single op with a
+  deterministic parent and decouples the user's unsaved edits (the snapshot) from the intent.
+- `op_before` is captured **before** the explicit snapshot, so `gitman undo` still reverts the whole
+  intent including any working-copy edit it implicitly captured (matches today's "undo = it didn't
+  happen"). `undo` therefore uses `restore_operation(op_before)`, not `ws.undo()` — one lever for
+  all intents (uniformity > a faster path for the single-op subset).
+- Name each op `gitman:<intent>` (pyjutsu commits the transaction with our description; `tags` is
+  empty, so this *replaces* the lost `tags.args` source). `undo --list` = `ws.operations()` filtered
+  to `gitman:*`; `undo --op X` = `restore_operation(X)`.
+
+### 3. The repo lock (I4) — still needed?
+**Decision: keep it. Anchor it (and all `.gitman/` state) at the *shared* repo root, not the
+per-workspace working-copy root.**
+
+Rationale: jj's optimistic op-log concurrency and per-workspace working-copy lock do **not** protect
+gitman's shared invariants — the bookmark namespace, the single trunk advance, and the determinism of
+the `op_before` checkpoint. Two concurrent gitman writers could each succeed at the jj level yet race
+on bookmark creation or trunk fast-forward, and concurrent ops produce a *merged* op log that makes
+"restore to `op_before`" ambiguous. A brief `O_EXCL` lockfile serializes gitman writers so every
+intent sees a linear op log. It is cheap and already implemented. **Bug to fix in the migration:**
+today the lock lives at `resolve_repo_root()/.gitman/lock`; in a secondary workspace that resolves to
+the *workspace* dir, so the lock is per-workspace and the parallel-agents story (the whole reason
+workspaces exist) is unprotected. Anchor `.gitman/` at the primary/shared repo root (derivable from
+the workspace store) so all workspaces contend on one lock.
+
+### 4. Snapshot discipline — where, and who owns the policy?
+**Decision: the `Session` owns snapshot policy. Reads that must reflect on-disk edits call
+`session.snapshot()` first; pure/historical reads use a frozen `head()` view. No scattered
+`ws.snapshot()`.**
+
+Rationale (verified #1 correctness item): reads never snapshot. The spots that must reflect the
+working copy are `status` and `start`'s adopt-check (it inspects `@` for in-progress work). The
+mutation wrapper already snapshots (step in #2). Centralize as `Session.fresh_view()` (=
+`snapshot()` then `head()`) vs `Session.view()` (frozen head) so the choice is explicit and made in
+exactly two read sites.
+
+### 5. Capture consistency / perf — one `RepoView` for a whole `status`?
+**Decision: yes. `capture_state` takes a single `view = session.fresh_view()` and does all reads
+(`bookmarks`, `log`, `diff_stat`, `conflicts`, `operations`) against that one frozen operation.**
+
+Rationale: a `RepoView` is a consistent snapshot at one op; one view removes the read-tearing risk of
+N independent `ws.*` calls and is faster (one head resolution). Verified all reads exist on
+`RepoView`. Per-lane `diff_stat` is still N calls, but all against the same frozen view.
+
+### 6. The tag gap.
+**Decision: keep a tiny `tags.py` git subprocess shim (tag-exists / create-annotated / push-tag).
+It is the only retained subprocess; document why. Note upstreaming tag-create to pyjutsu as future.**
+
+Rationale: jj-lib (so pyjutsu) is read-only on tags, and jj has no annotated-tag *creation* even via
+the `run_jj` escape hatch — annotated tags are a git concept. The shim is the correct boundary for
+v1; lifting `create_annotated_tag`/`push_tag`/`tag_exists` out of today's `git.py` is ~30 lines.
+
+### 7. Invariant enforcement — how much collapses?
+**Decision: keep both the precheck and the postcondition; delete the manual
+exception→`op_restore` *inside* the single-tx sugar (pyjutsu's `with` already rolls back on
+exception). Replace all stderr string-matching with typed catches and explicit `has_conflict`
+checks.**
+
+Rationale: pyjutsu's transaction is atomic — an exception in the body publishes nothing, so the
+"rollback on raise" is automatic for single-tx intents. What remains:
+- **precheck** (refuse to start when already off-canonical → exit 1): still needed.
+- **postcondition** "still canonical": still needed, because pyjutsu happily does things gitman
+  forbids — a rebase that **conflicts** returns a conflict commit (no raise; see #A), and trunk is
+  **not** immutable (see #11). The postcondition is gitman's only catch for "jj succeeded but policy
+  broke," and it gains a new clause: *trunk's commit_id unchanged unless this intent is `land`*.
+- For **multi-op** intents (push/fetch/workspace alongside a tx) the manual `restore_operation(
+  op_before)` on a policy failure stays, since the early op already published.
+Net: `invariants.py` loses the op-id-by-subprocess machinery and the broad `try/except: restore`;
+`core.py` mutation paths lose every `ProcResult.ok`/`"Nothing changed"`/`"immutable"` string check
+in favor of typed exceptions + `commit.has_conflict`.
+
+### 8. Stale working copies — where in the model?
+**Decision: surface staleness in `status` (a per-lane/workspace flag + note), and make
+`reconcile` the recovery (`update_stale` before adopting strays). A stale `@` is reported, not
+silently auto-reconciled. Mutating a stale `@` raises `StaleWorkingCopyError` → exit 1 pointing at
+`reconcile`.**
+
+Rationale: `is_stale()`/`update_stale()` are first-class now. Staleness is not "off-canonical" (the
+repo is fine; this workspace's on-disk `@` lagged), so it gets its own honest note rather than the
+reconcile-for-strays path — but folding the *fix* into `reconcile` keeps "one recovery verb." Add the
+new-capability test: `stale workspace → status reports it`.
+
+### 9. Distribution & pinning.
+**Decision (user): build-from-sibling now.** gitman's devenv adds the Rust toolchain + maturin and
+`maturin develop`s `../Pyjutsu` (uv path dependency). Long-term path stays a prebuilt wheel; revisit
+once pyjutsu stabilizes. The **jj 0.38 pin lives solely in pyjutsu** (`Cargo.toml` + its
+`devenv.nix`); gitman inherits it — there is no second version to reconcile. **Drop gitman's
+`nixpkgs-jj` pin and the `jj` package** from its devenv; keep `git` (for `tags.py`). `doctor` now
+asserts `import pyjutsu` + `pyjutsu.JJ_VERSION == pyjutsu.JJ_LIB_TARGET` instead of shelling
+`jj --version`.
+
+### 10. Bigger swing — does in-process enable a better architecture?
+**Decision: a 1:1 module port + a per-invocation `Session` is the right shape. No daemon, no
+long-lived multi-lane session.**
+
+Rationale: the gitman CLI is one-shot per process (agents invoke it), so a long-lived workspace only
+helps *within* one command — which the `Session` already gives (`land a b c` reuses one `ws`). A
+daemon would add lifecycle/concurrency complexity for no agent-facing benefit. The in-process win is
+overwhelmingly **deletion** (templates, JSON-by-concat, `parse_*`, op-id-by-subprocess) plus typed
+errors and one consistent view — not a re-architecture. The current module boundaries are sound;
+`Session` is the one structural addition.
+
+### 11. (New, from verification) Trunk protection without engine immutability.
+**Decision (user): gitman-enforced only.** Trunk protection is policy: by-construction (only `land`
+fast-forwards trunk; every rebase targets `trunk..lane` onto trunk, never trunk's own commits) plus
+the postcondition assert in #7 (trunk `commit_id` unchanged outside `land`). Do **not** depend on
+`ImmutableCommitError` for anything but the root commit. (Optional future: contribute a
+default-`immutable_heads` / config hook to pyjutsu for defense-in-depth — out of scope.)
+
+### 12. (New, from verification) Conflict handling is check-based, not exception-based.
+**Decision:** after any `tx.rebase`, read the lane head and branch on `commit.has_conflict`
+(exactly as `land`/`sync` do today). Map a genuine `ConflictError` (if pyjutsu raises one elsewhere)
+to exit 1, but do not expect rebase to raise it. Remove the bogus "ConflictError on rebase" row from
+the plan's error table.
+
+### 13. (New) Error-code mapping, corrected.
+| pyjutsu | gitman exit | when |
+|---|---|---|
+| `ImmutableCommitError` | 1 | only realistically the root; trunk protection is gitman's own precheck/postcondition |
+| `StaleWorkingCopyError` | 1 | → `gitman reconcile` |
+| `GitError` (push/fetch rejected, auth, missing remote ref) | 1 | VC decision / remote state |
+| `RevsetError` | 3 | invalid usage (bad lane/revset) |
+| `WorkspaceError` / `BackendError` | 2 | infra/config |
+| `ConflictError` | 1 | if raised by a non-rebase op; **rebase conflicts are detected via `has_conflict`, not caught** |
+| `JjCliError` | 2 | only if the `run_jj` escape hatch is ever used (it should not be) |
+
+---
+
+## C. Net effect on the codebase
+
+- **Delete:** `jj.py` (296 LOC), `templates.py` (44 LOC), most of `git.py` (→ ~30-line `tags.py`),
+  `tests/test_parse_jj.py`, `tests/test_parse_git.py`, `tests/fixtures/`, `scripts/gen_fixtures.py`.
+- **Add:** `session.py` (ws + config + repo_root + snapshot/view policy), `tags.py`.
+- **Rewrite (smaller):** `state.py` (one view → models), `invariants.py` (native tx + typed errors
+  + trunk-unchanged postcondition + shared-root lock), `core.py` intents (typed errors, no string
+  matching), `doctor.py` (assert pyjutsu, not `jj` CLI).
+- **Unchanged:** `config.py`, `render.py`, `models.py` (minus a possible `stale` flag on `Lane`),
+  the exit-code contract, the report formats, the `--json` shape.
+
+## D. Open risks carried into implementation
+1. **Shared-root `.gitman/` anchoring** for the lock under workspaces (decision #3) — get this right
+   or parallel agents aren't actually serialized.
+2. **Explicit snapshot** before `status`/adopt-check (decision #4) — the top correctness item.
+3. **pyjutsu rough edges**: rewriting `root()` panics; `add_workspace` bases `@` on root not the
+   current parents (cosmetic for gitman, which creates the lane bookmark explicitly). Neither blocks
+   gitman, but note them.
+4. **Remote-branch deletion on `land`**: pyjutsu `git_push(remote, lane, delete=True)` needs the
+   remote-tracking ref to still exist — order the deletion before dropping local tracking, unlike
+   today's "delete local bookmark then push deletion."

--- a/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_IMPLEMENTATION.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_IMPLEMENTATION.md
@@ -1,0 +1,105 @@
+# Kickoff — implement the Gitman → Pyjutsu migration
+
+> Paste this as the first message in a clean session **in the gitman repo**
+> (`/home/andrew/Documents/Projects/gitman`). The plan has already been re-evaluated, pressure-tested
+> against the real APIs, and **approved**. Your job is to **execute** it — not to re-litigate the
+> design. Where the approved plan and the code disagree, trust the code and flag it; otherwise build.
+
+## What's approved (read these first — they are authoritative)
+
+In `.scratch/projects/03-gitman-pyjutsu-migration/`:
+1. **`MIGRATION_PLAN_v2.md`** — the refined, sign-off-ready plan. This is your spec. (The older
+   `MIGRATION_PLAN.md` is the superseded draft; ignore conflicts in it.)
+2. **`DECISION_LOG.md`** — every design decision + the *why*, plus the verification matrix.
+3. **`UPSTREAM_pyjutsu_immutability.md`** — context only; an upstream report. Do **not** wait on or
+   depend on any pyjutsu change. gitman enforces trunk protection itself (see below).
+
+Also read, as before: `docs/GITMAN_CONCEPT.md`, `CLAUDE.md`, the current `src/gitman/` source, and
+`../Pyjutsu/README.md` + `../Pyjutsu/python/pyjutsu/` (the public API). The behavior probes used to
+validate the plan are in `.scratch/probe_pyjutsu.py`, `probe2.py`, `probe3.py` — rerun them if you
+want to re-confirm any pyjutsu behavior yourself.
+
+## Two settled decisions (do not re-ask)
+
+- **Distribution = build-from-sibling now.** gitman's devenv adds the Rust toolchain + maturin and
+  `maturin develop`s `../Pyjutsu` (uv path dependency). Drop gitman's `nixpkgs-jj` pin and the `jj`
+  package; keep `git` (for `tags.py`). The jj 0.38 pin lives solely in pyjutsu; gitman inherits it.
+- **Trunk protection = gitman-enforced only.** Do not rely on pyjutsu/jj-lib immutability (it
+  protects only the root commit). Enforce trunk protection in gitman policy: by-construction (only
+  `land` advances trunk; every rebase targets `trunk..lane`) **plus** a transactional postcondition
+  asserting trunk's `commit_id` is unchanged unless the intent is `land`.
+
+## Verified pyjutsu facts you must build around (don't re-derive; do sanity-check)
+
+1. **Reads are frozen** — a new/edited file is invisible to `diff_stat`/`log` until `ws.snapshot()`.
+   So `status` and `start`'s adopt-check must snapshot first. (#1 correctness item.)
+2. **`ws.transaction()` auto-snapshots a dirty `@` as a *separate preceding* op.** Use
+   **snapshot-first + `transaction(intent, auto_snapshot=False)`** so each intent is exactly one
+   mutation op with a deterministic parent.
+3. **Rebase into a conflict does NOT raise** — it returns a commit with `has_conflict=True`. Branch
+   on `head.has_conflict` after every rebase (as `land`/`sync` do today). There is no rebase
+   exception to catch.
+4. **No native "nothing changed" signal** — empty tx / already-based rebase succeed and publish an
+   op. Delete all `"Nothing changed"`/`"immutable"` stderr string-matching; use typed exceptions +
+   `has_conflict`.
+5. **`ws.undo()` alone is wrong for multi-op intents.** Keep `.gitman/last-undo` (op-id string) and
+   undo via `restore_operation(op_before)`, uniformly. Name ops `gitman:<intent>` so `undo --list`
+   reads from `ws.operations()` (pyjutsu leaves `tags` empty but keeps your description verbatim).
+6. **Capture a whole `status` from ONE frozen `RepoView`** (`view = fresh_view()`, then
+   `view.bookmarks()/log()/diff_stat()/conflicts()/operations()`) for consistency + speed.
+7. **Lane published?** = a `Bookmark` row with `remote not in (None, "git")`. Local lane =
+   `remote is None`. (`ws.bookmarks()` replaces the `--all-remotes` parsing hack.)
+8. **Tags:** jj-lib is read-only on tags and jj has no annotated-tag creation — keep a ~30-line
+   `tags.py` git subprocess (the only retained subprocess).
+
+## Critical correctness items (the things most likely to bite)
+
+- **Anchor `.gitman/` (lock + undo checkpoint) at the SHARED repo root**, not
+  `resolve_repo_root()` — in a secondary workspace the latter is the workspace dir, so today's lock
+  doesn't serialize parallel agents. Fix this as part of `session.py`.
+- **Explicit snapshot** before working-copy-reflecting reads (item 1).
+- **Trunk-unchanged postcondition** (the trunk-protection decision).
+- **Conflicts are commits, not exceptions** (item 3).
+- **Remote-branch delete on `land`:** `git_push(remote, lane, delete=True)` needs the remote-tracking
+  ref present — order the deletion before dropping local tracking.
+
+## Working rules
+
+- **Everything runs inside devenv.** Batch commands: `devenv shell -- bash -c '...'`. Building
+  pyjutsu the first time is ~6 min (jj-lib); it caches after.
+- **Dogfood:** route gitman's own version control through `gitman` once each milestone is green;
+  never raw `jj`/`git`.
+- **Keep the split sacred:** primitives in pyjutsu, policy in gitman. Don't push lane/canonicity
+  concepts into pyjutsu.
+- **Don't regress the contract:** report formats, exit codes (0/1/2/3), and the `--json` shape are
+  user-facing — keep them byte-stable where possible; flag any unavoidable change.
+- **No AI-generated attribution** in commits/PRs/docs.
+- Work **milestone by milestone** (below); after each, run `devenv shell -- bash -c 'gitman:lint &&
+  gitman:test'` (or `devenv test`) and dogfood the milestone's gate before moving on.
+
+## Milestones (from MIGRATION_PLAN_v2.md §10 — follow it for detail)
+
+- **MP0 — wiring + read path.** gitman devenv builds pyjutsu (sibling); add `session.py` (shared-root
+  resolution + snapshot/view policy); rewrite `state.py` over one `fresh_view()`; rewrite `status` +
+  `doctor`. Delete `templates.py` + jj read/parse + git numstat/rev_count as they fall out.
+  *Gate:* `gitman status`/`doctor` green on gitman's own repo + integration reads pass.
+- **MP1 — mutating intents + invariants.** Rewrite `invariants.py` (`canonical_tx`: shared-root lock
+  + snapshot-first + `auto_snapshot=False` + canonical/trunk-unchanged postcondition); migrate
+  `start`/`save`/`land`/`abandon`/`sync`; `undo` over the op-log; typed errors replace string
+  matching. *Gate:* full lane lifecycle dogfood + conflict-via-`has_conflict` + stale handling + undo
+  round-trips.
+- **MP2 — publish, version, release, init, reconcile.** `publish` → `ws.git_push`; `version`/`release`
+  over pyjutsu tx + `tags.py`; `init` trunk bookmark via tx; `reconcile` via `view.log` + tx +
+  `update_stale`. Delete the rest of `git.py`.
+- **MP3 — delete & polish.** Remove `jj.py`, `templates.py`, dead tests/fixtures
+  (`test_parse_jj.py`, `test_parse_git.py`, `tests/fixtures/`, `scripts/gen_fixtures.py`); update
+  `CLAUDE.md`/`README`/concept; drop the jj pin; re-dogfood end-to-end (a real
+  publish→land→release against the remote); `devenv test` green; cut a clean release.
+
+## Start here
+
+1. Read `MIGRATION_PLAN_v2.md` + `DECISION_LOG.md` and skim the current `src/gitman/` + pyjutsu API.
+2. Build pyjutsu (`cd ../Pyjutsu && devenv shell -- maturin develop --release`) and confirm
+   `import pyjutsu` reports `JJ_VERSION 0.38.0`.
+3. Begin **MP0**. Show me the devenv wiring + `session.py` design before deleting any read-path code,
+   then proceed through the gate. Stop at each milestone gate for a quick check-in.

--- a/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_MP1.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_MP1.md
@@ -1,0 +1,104 @@
+# Kickoff — MP1: mutating intents + invariants on pyjutsu
+
+> Paste this as the first message in a clean session **in the gitman repo**
+> (`/home/andrew/Documents/Projects/gitman`). MP0 (wiring + read path) is **done and green**. Your job
+> is to execute **MP1** — migrate the mutating intents and the transactional invariants onto pyjutsu.
+> The design is already worked out and probe-verified; **build it**, don't re-litigate it. Where the
+> guide and the code disagree, trust the code and flag it.
+
+## Read these first (authoritative, in order)
+
+In `.scratch/projects/03-gitman-pyjutsu-migration/`:
+1. **`MP1_IMPLEMENTATION_GUIDE.md`** — your step-by-step spec for MP1. Concrete, with verified code
+   recipes for `canonical_tx`/`canonical_guard`, the error mapper, and every intent
+   (`save`/`start`/`land`/`abandon`/`sync`/`undo`/`resolve`). **This is the primary document.**
+2. **`MIGRATION_PLAN_v2.md`** §4 (invariants), §5 (snapshot), §8 (error mapping) — the why.
+3. **`DECISION_LOG.md`** B.2 (undo model), B.7 (invariant enforcement), B.11 (trunk protection),
+   B.12 (conflicts are checks), B.13 (error codes).
+
+Also skim: the current `src/gitman/` (esp. `session.py`, `state.py`, `invariants.py`, `core.py`,
+`lanes.py`), `docs/GITMAN_CONCEPT.md` §11–12, and the pyjutsu API in
+`../Pyjutsu/python/pyjutsu/` (`workspace.py`, `transaction.py`, `repo_view.py`, `errors.py`,
+`models.py`). Behavior probes: `.scratch/probe_pyjutsu.py`, `probe2.py`, `probe3.py` — rerun to
+re-confirm anything.
+
+## Where MP0 left the tree (don't re-derive)
+
+- **devenv builds pyjutsu** from `../Pyjutsu` (editable uv path dep + Rust/maturin); **`jj` is NOT on
+  PATH** — every remaining `jj.run_jj` / `git.run_git` mutating call is dead code MP1 replaces.
+- **Done & must be preserved:** `session.py` (`Session(ws, config, repo_root[shared])` +
+  `view()`/`fresh_view()`/`is_stale()`), `state.py` (`capture_state(session)` from one frozen view; +
+  helpers `find_strays`/`_lane_index`/`_change`/`_op`/`_is_colocated`), `doctor.py` (asserts pyjutsu,
+  not the `jj` CLI), `cli.status`. `gitman status`/`doctor` are green on gitman's own repo.
+- **`capture_state` now takes a `Session`** (not `(repo_root, config)`) — all callers must pass one.
+- **Still old jj-subprocess code (MP1 rewrites the first three):** `invariants.py`, `core.py` do_*,
+  `lanes.py`. `init.py`/`reconcile.py`/`version.py`/`release.py` are **MP2 — leave them**; their
+  imports of `invariants`/`state`/`jj` are all **local (in-function)**, so rewriting `invariants.py`/
+  `core.py` won't break collection (their skipped tests stay skipped until MP2).
+- **Do NOT delete** `jj.py`, `templates.py`, `git.py`, `test_parse_jj.py`, `tests/fixtures/` in MP1 —
+  MP2/MP3 do that once nothing references them.
+
+## Settled decisions (do not re-ask)
+
+- **Trunk protection = gitman-enforced.** Postcondition asserts `after.trunk.commit_id ==
+  before.trunk.commit_id` **unless** `intent == "land"`. Don't rely on engine immutability.
+- **Undo = whole-intent checkpoint.** Persist `op_before` (op-id string) in `.gitman/last-undo` at the
+  **shared** root; `gitman undo` = `restore_operation(op_before)`. Name ops `gitman:<intent>` so
+  `undo --list` filters the op-log on `description.startswith("gitman:")`.
+- **Snapshot-first + `transaction(intent, auto_snapshot=False)`** → exactly one mutation op with a
+  deterministic parent. `op_before` captured **after** the explicit snapshot (undo also discards the
+  user's just-snapshotted edit — matches today's "undo = it didn't happen").
+- **Conflicts are commits, not exceptions** — branch on `commit.has_conflict` after every `rebase`;
+  never `except ConflictError` a rebase.
+
+## Verified recipes (already probed — build on these)
+
+- **LAND** (one tx): `rebased = tx.rebase(lane, onto=trunk, mode="branch")` → if
+  `rebased.has_conflict` refuse (exit 1, no trunk move) → else `tx.set_bookmark(trunk, lane)` (trunk
+  advances to lane head) → `tx.delete_bookmark(lane)`. Then (multi-op) workspace forget + best-effort
+  `git_push(remote, lane, delete=True)`.
+- **ABANDON** (one tx): abandon every `trunk..lane` **change_id** (stable across rewrites), then
+  `tx.delete_bookmark(target)` — the bookmark auto-moves to trunk's commit, delete succeeds, no
+  strays. Workspaced lanes use `canonical_guard` (forget is its own op).
+- **SYNC** (multi-op): `git_fetch` (own op) then one tx of `rebase`s; collect `has_conflict` lanes —
+  **don't raise** (non-blocking; exit 1 + note; change applied).
+- **SAVE/START** are single-tx. **`start --workspace`** is the riskiest (add_workspace bases `@` on
+  root; sub-workspace tx) — **probe it first**; on failure forget + rmtree the half-made workspace.
+
+## Working rules
+
+- **Everything inside devenv.** Batch: `devenv shell -- bash -c '...'`. Verify with
+  `devenv shell -- bash -c 'gitman:lint && gitman:test'` (or `devenv test`).
+- **Typed errors, no string-matching.** Add `map_pyjutsu_error(exc) -> GitmanError` (guide §3) and
+  catch `PyjutsuError` in `cli.main()`. Delete all `"Nothing changed"`/`"immutable"`/`.ok` stderr
+  checks from the migrated paths.
+- **Don't regress the contract:** `IntentResult` shape, outcomes, exit codes (0/1/2/3), the inline
+  `Undo:` line, and `--json` are user-facing — byte-stable where possible; flag any change.
+- **Dogfood** the lifecycle through `gitman` once green; never raw `jj`/`git`.
+- **No AI-attribution** in commits/PRs/docs.
+
+## MP1 gate (stop and check in when all green)
+
+1. `gitman:lint && gitman:test` green.
+2. Full lifecycle dogfood on a scratch pyjutsu repo: `start feat → save -m → status → land`
+   round-trips; `abandon`; `sync`; each intent's `gitman undo` reverts it; `undo --list` shows
+   `gitman:*` ops.
+3. Conflict via `has_conflict`: `land` refuses (exit 1, trunk unmoved); `sync` reports not-blocked
+   (exit 1, change applied).
+4. Stale `@` → mutating raises `StaleWorkingCopyError` → exit 1 (→ reconcile).
+5. Trunk-rewrite attempt outside `land` → postcondition restores `op_before`, exit 1.
+6. Lifecycle/m3/remote tests rebuilt on pyjutsu and **unskipped**; new conflict/stale/trunk-revert/
+   undo tests added and passing.
+
+## Start here
+
+1. Read `MP1_IMPLEMENTATION_GUIDE.md` end-to-end; skim the current `src/gitman/` mutating paths.
+2. Rewrite `invariants.py` (`canonical_tx` + `canonical_guard` + helpers; lock at `session.repo_root`)
+   and `lanes.py` (over `Session`/view). Add `map_pyjutsu_error`. Show me this core before migrating
+   all the intents.
+3. Migrate the intents per the guide's recipes; wire `cli.py`. Probe `start --workspace` before
+   wiring it.
+4. Rebuild + unskip the mutating tests on pyjutsu; add the new-capability tests; run the gate; dogfood.
+   **Stop at the MP1 gate for a check-in** before MP2 (publish/version/release/init/reconcile +
+   `tags.py`).
+```

--- a/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_MP2.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_MP2.md
@@ -1,0 +1,110 @@
+# Kickoff — MP2: publish / version / release / init / reconcile + `tags.py` on pyjutsu
+
+> Paste this as the first message in a clean session **in the gitman repo**
+> (`/home/andrew/Documents/Projects/gitman`). MP0 (wiring + read path) and MP1 (mutating lane intents
+> + transactional invariants) are **done and green** (33 passed, 4 skipped). Your job is to execute
+> **MP2** — migrate the remaining intents (`publish`/`version`/`release`/`init`/`reconcile`) off the
+> dead `jj`/`git` subprocess path onto pyjutsu, and add **`tags.py`** (the one retained colocated-git
+> module, for annotated tags). The design is worked out and probe-verified; **build it**, don't
+> re-litigate it. Where the guide and the code disagree, trust the code and flag it.
+
+## Read these first (authoritative, in order)
+
+In `.scratch/projects/03-gitman-pyjutsu-migration/`:
+1. **`MP2_IMPLEMENTATION_GUIDE.md`** — your step-by-step spec for MP2. Concrete, with verified code
+   recipes for `tags.py`, `init`, `reconcile`, the `version`-bump snapshot flow (`bump_change_on_lane`),
+   `release`, and `publish`. **This is the primary document.**
+2. **`MP1_IMPLEMENTATION_GUIDE.md`** — the just-completed slice; its §2 (`canonical_tx`/
+   `canonical_guard`) and §3 (`map_pyjutsu_error`) are the machinery you build on.
+3. **`MIGRATION_PLAN_v2.md`** and **`DECISION_LOG.md`** — the why (esp. version/release/tags = concept
+   §13; reconcile = §11/§20; trunk freeze I1 = §15).
+
+Also skim the current `src/gitman/` — especially `invariants.py`, `lanes.py`, `core.py`, `session.py`,
+`state.py` (the MP1 machinery you reuse) and the four MP2 files you're rewriting (`init.py`,
+`reconcile.py`, `version.py`, `release.py`) + `do_publish` in `core.py`. The pyjutsu API is in
+`../Pyjutsu/python/pyjutsu/` (`workspace.py`, `transaction.py`, `repo_view.py`, `errors.py`). Behavior
+probe: **`.scratch/probe5_mp2.py`** (version-bump flow + git annotated tag + reconcile) — rerun to
+re-confirm. MP1 probes (`probe_pyjutsu.py`, `probe2.py`, `probe3.py`, `probe4.py`) and the MP1 dogfood
+(`.scratch/dogfood_mp1.py`) are still there for reference.
+
+## Where MP1 left the tree (don't re-derive)
+
+- **Done & must be preserved:** `invariants.py` (`canonical_tx`/`canonical_guard`/`precheck_canonical`/
+  `_postcondition`/`_assert_fresh`/`repo_lock`/`*_undo_checkpoint`/`ensure_state_dir`), `lanes.py`
+  (all over `Session`), `core.py` (`map_pyjutsu_error`, `pick_remote`, `_cleanup_workspace`, the
+  migrated lane intents; CLI builds `Session` per command via `cli._session()` and catches
+  `PyjutsuError`), `session.py`/`state.py`/`doctor.py`. Lane lifecycle dogfoods green through the real
+  `gitman` CLI.
+- **`capture_state(session)`**, **`find_strays(view, trunk)`**, **`_lane_index(view)`**,
+  **`_is_colocated(root)`** are the read helpers (all take a view/session/root — NOT `repo_root`).
+- **Still old jj/git-subprocess code (MP2 rewrites all):** `init.py`, `reconcile.py`, `version.py`,
+  `release.py`, and `core.do_publish`. Their `jj`/`git`/`invariants.transaction` imports are all
+  **local (in-function)**, so the tree collects today (their tests skip via the `@MP2` mark). MP3
+  deletes `jj.py`/`git.py`/`templates.py`/`test_parse_jj.py`/`tests/fixtures/` — **leave them in MP2.**
+
+## Settled decisions (do not re-ask)
+
+- **`tags.py` is git-side and retained.** pyjutsu binds no tag write, so annotated tags stay on the
+  `git` subprocess (on PATH in devenv; `doctor` asserts it). It's the *only* raw-git surface left
+  after MP3. Take an explicit `remote` (from `core.pick_remote(session.ws)`); tags are one-way (`undo`
+  reverts a bump, never a tag).
+- **version/release bump = a dedicated change via the snapshot flow.** `tx.new("@")` → write the
+  version file → `ws.snapshot()` (folds it in) → `tx.describe + set_bookmark`. Multi-op ⇒
+  **`canonical_guard`**, never `canonical_tx`. Factor `bump_change_on_lane(session, lane, new)` in
+  `version.py`; `release` reuses it. Verified: probe5 A (undo reverts the file too).
+- **`reconcile` runs WITHOUT precheck** (off-canonical by definition): manual `repo_lock` → snapshot →
+  `op_before` → one tx adopting (`create_bookmark` per stray `change_id`) or abandoning → undo
+  checkpoint → re-capture. A `PARTIAL` is reported, never rolled back. Verified: probe5 C.
+- **`init` is the bootstrap** — no canonical wrappers (no frozen trunk yet), no undo checkpoint;
+  `repo_lock` + one bare tx to create the trunk bookmark, then write `gitman.toml` + `SKILL.md`.
+- **Verify before any write in `release`** — a blocked verify leaves no tag and no bump.
+
+## Verified recipes (already probed — build on these)
+
+- **VERSION bump** (multi-op, `canonical_guard`): `with tx(auto_snapshot=False): tx.new("@")` →
+  `write_version(...)` → `ws.snapshot()` → `with tx(auto_snapshot=False): tx.describe("@", "Bump
+  version to X"); tx.set_bookmark(lane, "@")`. (Read `require_current_lane` **before** `tx.new`.)
+- **RELEASE**: verify → `tags.tag_exists` guard → (bump via `bump_change_on_lane` under guard if
+  `new != current`, else `release_point = trunk`) → `head = session.view().resolve(release_point)`;
+  refuse if `head.is_empty` → `tags.create_annotated_tag(repo_root, tag, msg, head.commit_id)` →
+  `tags.push_tag(repo_root, pick_remote(ws), tag)` if `push_tag` and a remote exists.
+- **PUBLISH** (`canonical_guard`): refuse if no `session.ws.remotes()` → verify (block/warn) →
+  `session.ws.git_push(pick_remote(ws), lane, allow_new=True)` (map a `PyjutsuError` to exit 1).
+- **RECONCILE**: see §4 of the guide (no precheck).
+- **INIT**: `detect_trunk(session)` = local bookmarks ∩ (main/master/trunk), else
+  `tags.remote_default_branch`, else `"main"`; create it with one bare `tx.create_bookmark(trunk,"@")`.
+
+## Working rules
+
+- **Everything inside devenv.** Batch: `devenv shell -- bash -c '...'`. Verify with `devenv test` (or
+  `"$DEVENV_STATE"/venv/bin/ruff check src tests && "$DEVENV_STATE"/venv/bin/pytest -q`).
+- **Typed errors, no string-matching.** Reuse `map_pyjutsu_error` at the CLI boundary; `tags.py`
+  raises `GitmanError` with the right exit code. Delete every `from gitman import jj`/`git` +
+  `invariants.transaction` from the migrated paths.
+- **Don't regress the contract:** `IntentResult` shape, outcomes, exit codes (0/1/2/3), the inline
+  `Undo:` line, and `--json` are user-facing — byte-stable where possible; flag any change.
+- **Dogfood** the extended flow through `gitman` once green; never raw `jj`/`git`.
+- **No AI-attribution** in commits/PRs/docs.
+
+## MP2 gate (stop and check in when all green)
+
+1. `devenv test` green.
+2. The 4 `@MP2`-skipped tests (`test_init_*`/`test_version_*`/`test_release_*`/`test_reconcile_*`)
+   rebuilt through pyjutsu and **unskipped**, passing; new version-undo/release-bump/release-verify-
+   block/reconcile-abandon/reconcile-undo/publish tests added and passing.
+3. Extended dogfood on a scratch pyjutsu repo: `init → start → save → version bump minor → publish
+   (bare remote) → release → reconcile (recover a stray)`, with `gitman undo` where applicable.
+4. `release` verify-blocks before any write (no tag, no bump); `version bump`/`release` bump create a
+   dedicated "Bump version to X" change and `undo` reverts the bump **and** the file.
+5. **grep proves zero production importers of `gitman.jj`/`gitman.git`** (only `jj.py`/`git.py`
+   themselves) → MP3 is pure deletion.
+
+## Start here
+
+1. Read `MP2_IMPLEMENTATION_GUIDE.md` end-to-end; rerun `.scratch/probe5_mp2.py` to re-confirm the
+   bump/tag/reconcile mechanics.
+2. Add `tags.py` (guide §2) and the `version.py` `bump_change_on_lane` helper (guide §5). **Show me
+   these two before migrating the rest** — they're the load-bearing new pieces.
+3. Migrate `init`/`reconcile`/`version`/`release`/`do_publish`; wire `cli.py`.
+4. Unskip + rebuild the 4 MP2 tests on pyjutsu; add the new tests; run the gate; dogfood; run the MP3-
+   readiness grep. **Stop at the MP2 gate for a check-in** before MP3 (the deletions).

--- a/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_PROMPT.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/KICKOFF_PROMPT.md
@@ -1,0 +1,90 @@
+# Kickoff — re-evaluate & refine the Gitman → Pyjutsu migration
+
+> Paste this as the first message in a clean session **in the gitman repo**
+> (`/home/andrew/Documents/Projects/gitman`). Its job is to **critically re-evaluate and
+> refine** the migration concept/plan/architecture *before* implementation — not to rubber-stamp
+> it and not (yet) to write migration code. Treat the existing plan as a strong draft to
+> pressure-test, improve, or partly replace. Aim: the cleanest, most elegant end state.
+
+## What exists (study it first — verify, don't trust the prose)
+
+1. **Gitman** (this repo) — an agent-first VCS policy layer (the "lane" model) currently built
+   on the **`jj` CLI**: `src/gitman/jj.py` + `templates.py` (jj templates → JSON → models),
+   `git.py` (colocated git: numstat, tags, push), `state.py`, `invariants.py`
+   (lock + op-id-capture transaction), `core.py` (intents), `cli.py`, `render.py`,
+   `config.py`, `lanes.py`, `version.py`, `release.py`, `init/doctor/reconcile`. Read
+   `docs/GITMAN_CONCEPT.md`, `CLAUDE.md`, and the source. Gitman self-manages its own repo and
+   has integration tests + golden fixtures.
+
+2. **Pyjutsu** (`../Pyjutsu`, a sibling repo) — a general-purpose **PyO3/jj-lib** binding
+   (in-process, no subprocess): `import pyjutsu` exposes `Workspace`/`RepoView`/`Transaction`,
+   frozen Pydantic reads, native one-op transactions, op-log time travel, workspaces (+ stale
+   detection), and git interop. **Verified 2026-06-17:** builds clean
+   (`devenv shell -- maturin develop --release`, ~6 min — jj-lib is a heavy compile), **201
+   tests pass**, `import pyjutsu` reports `binds jj 0.38.0`. Read `../Pyjutsu/README.md`,
+   `../Pyjutsu/docs/PYJUTSU_CONCEPT.md`, `../Pyjutsu/python/pyjutsu/` (the public API +
+   `_pyjutsu.pyi`), and its tests. **Build it and poke the API yourself** before trusting docs.
+   Known limitation: **no git-tag creation** (jj-lib's tag support is read-only).
+
+3. **The artifacts to refine:**
+   - `.scratch/projects/03-gitman-pyjutsu-migration/MIGRATION_PLAN.md` — the current plan
+     (Session object; gitman keeps report models populated from pyjutsu; invariants over
+     native transactions; `tags.py` shim; drop gitman's jj pin; prebuilt-wheel distribution;
+     milestones MP0–MP3; watch-outs).
+   - `.scratch/projects/02-pyjutsu-pyo3-binding/` — the pyjutsu concept + kickoff (note: the
+     real `../Pyjutsu` has since advanced past this; treat the running code as ground truth).
+
+## Your task
+
+Re-derive the migration from first principles against the **actual** gitman code and the
+**actual** pyjutsu API, then produce a **refined plan + a decision log** for sign-off. It is a
+success to conclude "the plan is right" — but only after genuinely trying to break it. Surface
+disagreements explicitly; propose the more elegant alternative where one exists.
+
+## Pressure-test these decisions specifically
+
+- **Do gitman's own report models earn their keep?** Keep `RepoState`/`Lane`/`Change` as a
+  policy projection, or compose/re-export pyjutsu's models more directly? Where's the cleanest
+  DRY-vs-separation line?
+- **The undo model.** The plan keeps an `op_before` checkpoint for whole-intent undo because an
+  intent can be multiple ops (transaction auto-snapshots `@` as a *separate preceding* op;
+  `land` adds a push). **Can we instead make every gitman intent map to exactly one undoable
+  unit** (e.g. snapshot-then-transact so the op_before is the snapshot, or fold push out of the
+  undoable unit), so `ws.undo()` alone is correct and the `.gitman/last-undo` file disappears?
+- **The repo lock (I4).** Given pyjutsu/jj's op-log optimistic concurrency + per-workspace WC
+  lock, is gitman's lockfile still needed, or can it go? What exactly does it protect that jj
+  doesn't?
+- **Snapshot discipline.** Reads are frozen/no-snapshot; only transactions auto-snapshot. Where
+  must gitman snapshot explicitly (status, start-adopt)? Should the `Session` own a snapshot
+  policy rather than scattering `ws.snapshot()` calls?
+- **Capture consistency/perf.** Should a whole `status` come from a single `ws.head()`
+  `RepoView` (one consistent operation) instead of many `ws.*` calls?
+- **The tag gap.** `tags.py` git shim vs. contributing tag-create upstream to pyjutsu vs. living
+  without annotated tags. Is the shim genuinely the right boundary?
+- **Invariant enforcement simplification.** With native transactions + typed
+  `PyjutsuError`s (`ImmutableCommitError`, `ConflictError`, `StaleWorkingCopyError`), how much
+  of `invariants.py`/`core.py` collapses? Is the precheck/postcondition still both needed?
+- **Stale working copies** are now first-class — where do they belong in the model (a new
+  `status` state? off-canonical? a `reconcile` path)?
+- **Distribution & pinning.** Prebuilt wheel vs build-from-sibling in gitman's devenv; how the
+  jj-0.38 pin stays single-sourced in pyjutsu; what `doctor` should assert now.
+- **Bigger swing:** does in-process pyjutsu enable a *better* gitman architecture than a 1:1
+  port of the current modules — e.g. a long-lived workspace/session driving multiple lanes, or
+  a cleaner intent core? Don't anchor to the current shape if a better one exists.
+
+## Deliverable & working rules
+
+- Produce: (a) a **decision log** (each pressure-test item → decision + rationale), and (b) an
+  **updated `MIGRATION_PLAN.md`** (or a clearly-marked successor) reflecting it. Use
+  `AskUserQuestion` for genuine forks; **confirm the refined plan before writing migration
+  code.**
+- Everything runs inside **devenv** (`devenv shell -- …`); building pyjutsu needs the Rust
+  toolchain its devenv provides. Don't run bare host tooling.
+- Keep the split sacred: **primitives in pyjutsu, policy in gitman** — resist pushing lane /
+  canonicity concepts down into pyjutsu.
+- Don't regress the user-facing contract (report formats, exit codes 0/1/2/3) without flagging.
+- No AI-generated attribution in commits/PRs/docs.
+
+**Start by reading `docs/GITMAN_CONCEPT.md`, `../Pyjutsu/README.md` + its API, and
+`MIGRATION_PLAN.md`; build pyjutsu and try the API; then come back with your decision log and a
+refined plan for approval.**

--- a/.scratch/projects/03-gitman-pyjutsu-migration/MIGRATION_PLAN.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/MIGRATION_PLAN.md
@@ -1,0 +1,202 @@
+# Gitman → Pyjutsu migration plan
+
+**Goal:** replace gitman's hand-rolled jj-CLI/template/colocated-git substrate with the
+in-process **Pyjutsu** (`import pyjutsu`, jj-lib via PyO3) binding — deleting all template
+strings, JSON-by-concatenation, subprocess parsing, and the op-id-by-subprocess machinery —
+while keeping gitman's *policy* (the lane model, canonicity, transactional invariants,
+compact reports) intact and, where pyjutsu allows, simpler. Outcome: the **best, cleanest**
+gitman — a thin policy layer over a faithful jj engine, with **one** tiny retained subprocess
+(git tags).
+
+Pyjutsu status (verified 2026-06-17): v0.7.0, builds clean, **201 tests pass**, binds jj
+0.38.0, differential-tested vs the pinned `jj` CLI. Its API covers gitman's substrate needs
+1:1 except git tag creation (jj-lib's tag support is read-only).
+
+---
+
+## 1. Target architecture
+
+```
+src/gitman/
+  cli.py        Typer intents; builds a Session; maps PyjutsuError + GitmanError → exit codes
+  session.py    NEW — the per-invocation context: { ws: pyjutsu.Workspace, config, repo_root }
+  core.py       intents (do_*): orchestration over Session + pyjutsu
+  invariants.py canonical precheck + transactional wrapper (lock + op_before + ws.transaction
+                + postcondition) + undo checkpoint
+  lanes.py      lane registry helpers over pyjutsu reads
+  state.py      RepoState capture: pyjutsu models → gitman report models
+  models.py     gitman REPORT models (RepoState/Lane/Change/IntentResult) — populated from pyjutsu
+  config.py     [tool.gitman] policy (UNCHANGED — no VCS calls)
+  version.py    semver math + version-source read/write (pure) + do_version (pyjutsu tx)
+  release.py    do_release (pyjutsu tx for bump) + tag flow via tags.py
+  tags.py       NEW, tiny — the ONLY retained git subprocess: tag exists/create/push
+  render.py     compact reports (UNCHANGED — renders gitman models)
+  init.py doctor.py reconcile.py
+
+DELETED:  jj.py (296 LOC), templates.py (44 LOC), git.py (110 LOC → ~30 LOC tags.py)
+```
+
+**Net deletion: ~420 LOC of adapter/parser code** replaced by direct pyjutsu calls + a
+~30-line tag shim. No `-T` templates, no `json.loads` of jj output, no `parse_*`, no
+subprocess except `git tag`.
+
+## 2. The boundary: a `Session`, gitman models from pyjutsu models
+
+- **`session.py`** introduces one object built per CLI invocation:
+  `Session(ws: pyjutsu.Workspace, config: GitmanConfig, repo_root: Path)`. It replaces today's
+  pattern of passing `(repo_root, config)` and re-resolving everything; `ws` is loaded once
+  (`Workspace.load(repo_root)`) and reused for all reads/transactions in that command.
+- **gitman keeps its own report models** (`RepoState`, `Lane`, `IntentResult`) — these encode
+  *policy* (lanes, canonicity, undo lines) that pyjutsu deliberately doesn't have. They are
+  **populated from** pyjutsu models at the `state.py` boundary. `gitman.Change` becomes a
+  projection of `pyjutsu.Commit` + `pyjutsu.DiffStat`; `gitman.Conflict`/`Op` project
+  `pyjutsu.Conflict`/`Operation`. Mapping lives in exactly one place (`state.py`).
+
+## 3. Substrate mapping (what each old call becomes)
+
+| Old gitman (jj.py/git.py) | Pyjutsu |
+|---|---|
+| `capture_changes(revset)` / `current_change_id` | `ws.log(revset)` / `ws.resolve(revset)` / `ws.working_copy()` |
+| `list_bookmarks` / `bookmark_names` / `remote_lane_names` | `ws.bookmarks()` → `Bookmark{name, remote, …}` (kills the `--all-remotes` parsing hack entirely) |
+| `op_log` / `current_op_id` / `op_restore` | `ws.operations()` / `ws.head_operation()` / `ws.restore_operation(op)` |
+| `resolve_list` | `ws.conflicts(revset)` → `list[Conflict]` (N-sided, faithful) |
+| `workspace_list` / `workspace_add` / `workspace_forget` | `ws.workspaces()` / `ws.add_workspace()` (eager) / `ws.forget_workspace()` (+ `is_stale`/`update_stale`) |
+| `new_change`/`describe`/`bookmark_create`/`set`/`delete`/`rebase`/`abandon`/`edit` | `tx.new`/`describe`/`create_bookmark`/`set_bookmark`/`delete_bookmark`/`rebase`/`abandon`/`edit` inside `with ws.transaction(...) as tx` |
+| `git_push` / `git_push_delete` | `ws.git_push(remote, bookmark, allow_new=…)` (deletion via `tx.delete_bookmark` + push) |
+| `git.numstat` / `parse_numstat` | `ws.diff_stat(rev)` → `DiffStat{files, insertions, deletions}` |
+| `git.ahead_behind` / `rev_count` | `len(ws.log(f"{trunk}..{lane}"))` and `len(ws.log(f"{lane}..{trunk}"))` |
+| `git.has_remote` / `default_remote` | `ws.remotes()` |
+| `jj_version` / version assert | `pyjutsu.JJ_VERSION` (pyjutsu self-asserts `== JJ_LIB_TARGET` at import) |
+| `git.tag_exists`/`create_annotated_tag`/`push_tag` | **stays** in `tags.py` (the gap, §6) |
+
+## 4. The transactional-invariant model on pyjutsu
+
+Gitman's enforcement (precheck → act → "still canonical" → rollback) stays, but the *act* and
+*rollback* ride on pyjutsu's native one-op transactions instead of the op-id-capture
+simulation.
+
+```python
+@contextmanager
+def canonical_tx(session, intent: str):
+    with repo_lock(session.repo_root):                 # I4 — serialize gitman writers (keep)
+        before = session.ws.head_operation()           # whole-intent undo target
+        precheck_canonical(session)                    # refuse if already off-canonical → exit 1
+        with session.ws.transaction(intent) as tx:     # pyjutsu: atomic; auto-snapshots @;
+            yield tx                                    #   rolls back on ANY exception
+        # one operation published here (or none, if body raised → already rolled back)
+        state = capture_state(session)
+        if not state.canonical:                         # succeeded at jj level but broke policy
+            session.ws.restore_operation(before)        # roll back via op log
+            raise GitmanError("reverted: …off-canonical…", exit_code=1)
+        record_undo_checkpoint(session.repo_root, before, intent)
+```
+
+- **`gitman undo`** = `restore_operation(checkpoint)` (whole-intent: reverts the auto-snapshot
+  op *and* the mutation op). Keep the lightweight `.gitman/last-undo` (now just stores the op
+  id from `head_operation()` — no jj subprocess). `undo --list` = `ws.operations()`;
+  `undo --op X` = `ws.restore_operation(X)`.
+- **Complex intents** (`land`'s per-lane loop + remote-branch delete; `publish`'s push;
+  `release`'s tag) use the lower-level pieces (`repo_lock`, `head_operation`, an explicit
+  `ws.transaction()` where a tx is needed, `capture_state` postcondition) rather than the
+  single `canonical_tx` sugar — same shape as today, fewer moving parts.
+- **Pyjutsu raises `ImmutableCommitError`** when rebasing onto/over pushed-immutable commits —
+  gitman catches it and maps to its messaging (this is what manually blocked the bad `land`
+  during the v0.1 dogfood; now it's a typed exception, not stderr string-matching).
+
+## 5. Snapshot semantics (important behavior change)
+
+Pyjutsu **reads never snapshot** (frozen, side-effect-free); **`ws.transaction()` auto-snapshots
+a dirty `@`** as a separate preceding op (matching the CLI). The old jj-CLI auto-snapshotted on
+*every* call, so gitman relied on it implicitly. Post-migration gitman must snapshot
+**deliberately**:
+
+- **Reads that must reflect on-disk edits** (`status`, and `start`'s adopt check that inspects
+  `@` for in-progress work) call `session.ws.snapshot()` first. `status` snapshots so the
+  report reflects reality; this is the one spot to get right.
+- **Mutations** need no manual snapshot — `ws.transaction()` does it (and `op_before` captured
+  before it covers the snapshot op for undo).
+
+This is cleaner (explicit > implicit) but is the **#1 migration correctness item** — audit
+every read for "does this need current on-disk state?".
+
+## 6. The tag gap → `tags.py`
+
+`release` needs an annotated tag + push; jj-lib (so pyjutsu) is **read-only on tags**. Keep a
+~30-line `src/gitman/tags.py` doing `git tag -a` / `git push <remote> <tag>` / tag-exists via
+subprocess (lifted from today's `git.py`). It is the **only** subprocess gitman retains;
+document why. (Future: contribute tag-create to pyjutsu, then delete `tags.py` — out of scope.)
+
+## 7. Dependencies & devenv
+
+- **gitman depends on `pyjutsu`** (the built wheel). gitman's runtime no longer needs the `jj`
+  CLI at all (the binding embeds jj-lib) — **drop gitman's `nixpkgs-jj` pin and the `jj` package**
+  from its devenv; keep `git` (for `tags.py`).
+- **Build/install path** (pick in MP0): either (a) gitman's devenv adds the Rust toolchain +
+  maturin and builds pyjutsu from the sibling path (`maturin develop`/`uv` editable), or
+  (b) pyjutsu produces a wheel that gitman installs (keeps gitman's devenv lean, no Rust).
+  **Recommend (b)** long-term (gitman stays a pure-Python policy layer); (a) is fine for
+  dogfooding now. Either way the **jj 0.38 pin lives in pyjutsu** — gitman just inherits it,
+  so there's no version to reconcile.
+- `pyproject.toml`: base dep becomes `pydantic`, `typer`, `pyjutsu` (path/git/wheel). `doctor`
+  validates `import pyjutsu` + `pyjutsu.JJ_VERSION` instead of shelling `jj --version`.
+
+## 8. Error mapping (PyjutsuError → gitman exit codes)
+
+Map pyjutsu's typed exceptions at the `core.py`/`cli.py` boundary:
+
+| Pyjutsu | gitman exit | meaning |
+|---|---|---|
+| `ConflictError` / conflict on rebase | 1 | VC decision needed |
+| `ImmutableCommitError` | 1 | refuse to rewrite trunk/pushed |
+| `StaleWorkingCopyError` | 1 | run `update_stale` / reconcile |
+| `GitError` (push rejected, auth) | 1 | VC decision / infra |
+| `WorkspaceError` / `BackendError` | 2 | infra/config |
+| `RevsetError` | 3 | invalid usage |
+
+This replaces today's `"Nothing changed"`/`"immutable"` stderr string matching with typed
+catches — a real robustness win.
+
+## 9. Testing changes
+
+- **Delete** `tests/test_parse_jj.py`, `tests/test_parse_git.py`, `tests/fixtures/`,
+  `scripts/gen_fixtures.py` — there are no templates/parsers/golden fixtures to test anymore;
+  that correctness burden now lives in pyjutsu's differential suite.
+- **Keep + expand** the policy/integration tests (`test_lifecycle_integration`,
+  `test_m3_integration`, `test_status_integration`, `test_remote_stray`) — they now drive
+  pyjutsu directly and assert gitman *policy* (canonicity, lane invariants, reports, exit
+  codes, undo round-trips). Add a `stale workspace → status reports it` test (new capability).
+- gitman tests stop needing the `jj` CLI; they need `pyjutsu` installed (+ `git` for tags).
+
+## 10. Milestones
+
+- **MP0 — wiring + read path.** Add pyjutsu dep + build path to devenv; add `session.py`;
+  rewrite `state.py` + `status` + `doctor` over pyjutsu (with the explicit `snapshot()` on
+  status). Delete `templates.py` and jj.py read/parse functions + git numstat/rev_count as they
+  fall out. Gate: `gitman status`/`doctor` green on gitman's own repo + integration tests pass.
+- **MP1 — mutating intents + invariants.** Rewrite `invariants.py` (`canonical_tx` over
+  `ws.transaction`); migrate `start`/`save`/`land`/`abandon`/`sync`; simplify `undo`
+  (op-log). Delete jj.py mutation/push functions. Gate: full lane lifecycle dogfood + conflict
+  rollback + stale handling.
+- **MP2 — publish, version, release, init, reconcile.** `publish` → `ws.git_push`; `version`
+  bump + `release` over pyjutsu tx + `tags.py`; `init` trunk bookmark via tx; `reconcile` via
+  `ws.log` + tx. Delete the rest of `git.py` (→ `tags.py`).
+- **MP3 — delete & polish.** Remove `jj.py`, `templates.py`, dead tests/fixtures; update
+  `CLAUDE.md`/`README`/concept; drop the gitman jj pin; re-dogfood end-to-end (incl. a real
+  publish→land→release against the remote); ensure `devenv test` green; cut a clean release.
+
+## 11. Watch-outs
+
+1. **Explicit snapshot** before working-copy-reflecting reads (§5) — the top correctness item.
+2. **Whole-intent undo** needs `op_before` captured before the auto-snapshotting transaction
+   (§4) — don't naively use `ws.undo()` for multi-op intents (`land`+push, save's snapshot+describe).
+3. **Tag gap** → `tags.py` is the only retained subprocess (§6).
+4. **pyjutsu build/distribution** in gitman's env (§7); decide wheel-vs-build-from-source.
+5. **Stale working copies** are now first-class (`is_stale`/`update_stale`) — fold into
+   `status` (a stale lane is a reportable state) and `reconcile`.
+6. **Frozen reads** mean a `RepoView`/operation is a consistent snapshot — capture all of a
+   `status` from **one** `ws.head()` view (`session.ws.head()` then `view.log/bookmarks/…`)
+   rather than several `ws.*` calls, for both consistency and speed.
+7. **Keep policy in gitman, primitives in pyjutsu** — resist pushing lane/canonicity concepts
+   down into pyjutsu; the clean split is the whole point.
+8. **Don't regress reports/exit codes** — the renderer and exit-code contract are the
+   user-facing surface; they should be byte-stable across the migration where possible.

--- a/.scratch/projects/03-gitman-pyjutsu-migration/MIGRATION_PLAN_v2.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/MIGRATION_PLAN_v2.md
@@ -1,0 +1,215 @@
+# Gitman → Pyjutsu migration plan — v2 (refined, sign-off ready)
+
+> Successor to `MIGRATION_PLAN.md`, re-derived 2026-06-17 against the **actual** gitman source and
+> **actual** pyjutsu 0.7.0 API, with every load-bearing behavior probe-verified. Read
+> `DECISION_LOG.md` alongside this for the *why* behind each change. v1 was a strong draft; this
+> keeps its architecture and corrects four wrong assumptions (rebase-conflict, trunk-immutability,
+> noop-detection, undo-via-`ws.undo()`), adds the snapshot/session discipline, and fixes a latent
+> lock-anchoring bug.
+
+**Goal (unchanged):** replace gitman's jj-CLI/template/colocated-git substrate with in-process
+**pyjutsu** (`import pyjutsu`, jj-lib via PyO3) — deleting all templates, JSON-by-concatenation,
+`parse_*`, and op-id-by-subprocess — while keeping gitman's *policy* (lanes, canonicity,
+transactional invariants, compact reports) intact and simpler. One retained subprocess: git tags.
+
+**User decisions:** distribution = **build-from-sibling now**; trunk protection = **gitman-enforced
+only**.
+
+---
+
+## 1. Target architecture
+
+```
+src/gitman/
+  cli.py        Typer intents; builds a Session; maps PyjutsuError + GitmanError → exit codes
+  session.py    NEW — per-invocation context: { ws, config, repo_root(shared) }; snapshot/view policy
+  core.py       intents (do_*): orchestration over Session + pyjutsu; typed-error handling
+  invariants.py canonical precheck + transactional wrapper (shared-root lock + snapshot-first +
+                op_before + auto_snapshot=False tx + canonical/trunk-unchanged postcondition) + undo
+  lanes.py      lane registry helpers over pyjutsu reads
+  state.py      RepoState capture from ONE frozen RepoView: pyjutsu models → gitman report models
+  models.py     gitman REPORT models (RepoState/Lane/Change/IntentResult) — + Lane.stale flag
+  config.py     [tool.gitman] policy (UNCHANGED — no VCS calls)
+  version.py    semver math + version-source read/write (pure) + do_version (pyjutsu tx)
+  release.py    do_release (pyjutsu tx for bump) + tag flow via tags.py
+  tags.py       NEW, tiny — the ONLY retained git subprocess: tag exists/create/push
+  render.py     compact reports (UNCHANGED — renders gitman models)
+  doctor.py     asserts `import pyjutsu` + JJ_VERSION==JJ_LIB_TARGET (no `jj` CLI)
+  init.py reconcile.py
+
+DELETED:  jj.py (296), templates.py (44), most of git.py (110 → ~30 in tags.py),
+          tests/test_parse_jj.py, tests/test_parse_git.py, tests/fixtures/, scripts/gen_fixtures.py
+```
+
+Net: **~420 LOC of adapter/parser deleted**, replaced by direct pyjutsu calls + a ~30-line tag shim.
+No `-T` templates, no `json.loads` of jj output, no `parse_*`, no subprocess except `git tag`.
+
+## 2. The boundary: a `Session`, gitman models from pyjutsu models
+
+- **`session.py`** — one object per CLI invocation:
+  `Session(ws: pyjutsu.Workspace, config: GitmanConfig, repo_root: Path)`.
+  - `repo_root` is the **shared** repo root (so `.gitman/` lock + undo checkpoint are global across
+    workspaces — see §4). `ws` is loaded once via `Workspace.load(cwd)` and reused.
+  - Owns **snapshot policy**: `Session.view()` → frozen `ws.head()` (historical/pure reads);
+    `Session.fresh_view()` → `ws.snapshot()` then `ws.head()` (reads that must reflect on-disk edits:
+    `status`, `start`'s adopt-check). No `ws.snapshot()` calls scatter through `core.py`.
+- **gitman keeps its own report models** (`RepoState`/`Lane`/`Change`/`Op`/`Conflict`/`TrunkRef`) —
+  policy projections with no pyjutsu equivalent. They are **populated from** pyjutsu models in one
+  place (`state.py`): `gitman.Change` ← `pyjutsu.Commit` + `DiffStat`; `gitman.Conflict` ←
+  `pyjutsu.Conflict` (grouped by lane); `gitman.Op` ← `pyjutsu.Operation`. The `--json` payload stays
+  gitman-shaped (it is a user-facing contract). pyjutsu models are **not** re-exported in reports.
+
+## 3. Substrate mapping (verified)
+
+| Old gitman (jj.py/git.py) | Pyjutsu |
+|---|---|
+| `capture_changes(revset)` / `current_change_id` | `view.log(revset)` / `view.resolve(revset)` / `view.working_copy()` |
+| `list_bookmarks` / `bookmark_names` / `remote_lane_names` | `view.bookmarks()` → `Bookmark{name, remote, tracked, target_ids}`. Local lane = `remote is None`; **published** = a row with `remote not in (None, "git")`. Kills `--all-remotes` parsing. |
+| `op_log` / `current_op_id` / `op_restore` | `view.operations()` / `ws.head_operation()` / `ws.restore_operation(op)` |
+| `resolve_list` | `view.conflicts(revset)` → `list[Conflict]{path,num_sides,num_bases}` (N-sided, faithful) |
+| `workspace_list` / `workspace_add` / `workspace_forget` | `ws.workspaces()` / `ws.add_workspace()` / `ws.forget_workspace()` (+ `is_stale()`/`update_stale()`) |
+| `new`/`describe`/`bookmark_create`/`set`/`delete`/`rebase`/`abandon`/`edit` | `tx.new`/`describe`/`create_bookmark`/`set_bookmark`/`delete_bookmark`/`rebase(…, mode="branch")`/`abandon`/`edit` inside `with ws.transaction(intent, auto_snapshot=False) as tx` |
+| `git_push` / `git_push_delete` | `ws.git_push(remote, lane, allow_new=True)` / `ws.git_push(remote, lane, delete=True)` |
+| `git.numstat` / `parse_numstat` | `view.diff_stat(rev)` → `DiffStat{files, total_insertions, total_deletions}` |
+| `git.ahead_behind` / `rev_count` | `len(view.log(f"{trunk}..{lane}"))` (ahead) and `len(view.log(f"{lane}..{trunk}"))` (behind) |
+| `git.has_remote` / `default_remote` | `ws.remotes()` → pick `"origin"` else first |
+| `jj_version` / version assert | `pyjutsu.JJ_VERSION` (self-asserted `== JJ_LIB_TARGET` at import) |
+| `tag_exists`/`create_annotated_tag`/`push_tag` | **stays** in `tags.py` (§6) |
+
+## 4. Transactional invariants on pyjutsu (corrected)
+
+```python
+@contextmanager
+def canonical_tx(session, intent: str):
+    with repo_lock(session.repo_root):              # I4 — shared-root lockfile (see below)
+        session.ws.snapshot()                       # fold dirty @ into its own op (explicit)
+        precheck_canonical(session)                 # frozen read; refuse if off-canonical → exit 1
+        op_before = session.ws.head_operation()     # whole-intent undo target (after snapshot)
+        with session.ws.transaction(f"gitman:{intent}", auto_snapshot=False) as tx:
+            yield tx                                 # ONE op published; pyjutsu rolls back on raise
+        state = capture_state(session)              # postcondition
+        if not state.canonical or _trunk_moved(state, intent):
+            session.ws.restore_operation(op_before) # jj-succeeded-but-policy-broke
+            raise GitmanError("reverted: …", exit_code=1)
+        record_undo_checkpoint(session.repo_root, op_before, intent)
+```
+
+Corrections vs v1:
+- **No `try/except: op_restore` around the body** — `with ws.transaction()` already rolls back on any
+  exception (verified). The manual `restore_operation` is only for the **postcondition** failure and
+  for multi-op orchestration.
+- **Snapshot-first + `auto_snapshot=False`** makes the transaction exactly one op with a deterministic
+  parent (verified). `op_before` is captured *after* the explicit snapshot's op but the snapshot is
+  itself reverted by restoring to it only if we want; we capture `op_before` to revert the **mutation**
+  while leaving the user's pre-intent edits — except we still want "undo = it didn't happen", so
+  `op_before` is taken right after the snapshot and `gitman undo` = `restore_operation(op_before)`.
+  *(If a future call wants "undo also discards my unsaved edit," capture before the snapshot instead —
+  one-line choice, documented.)*
+- **Trunk-unchanged postcondition** (`_trunk_moved`): trunk's `commit_id` must equal the frozen
+  config trunk's, **unless** `intent == "land"`. This is the gitman-enforced trunk protection that
+  replaces the (non-existent) engine immutability.
+- **Conflicts are NOT exceptions.** After `tx.rebase(...)`, read the lane head and branch on
+  `head.has_conflict` (land refuses; sync reports "not blocked"). There is no rebase exception to
+  catch.
+
+**Undo:**
+- `.gitman/last-undo` **stays** (fresh process per CLI call), now storing just the op-id string.
+- `gitman undo` = `restore_operation(checkpoint.op)`. Uniform for all intents (single- and multi-op).
+- `undo --list` = `ws.operations()` filtered to `gitman:*` descriptions (replaces the lost
+  `tags.args`; pyjutsu leaves `tags` empty but commits our description verbatim — verified).
+- `undo --op X` = `restore_operation(X)`.
+
+**The lock (I4):** keep it — jj's op-log concurrency + per-workspace WC lock do **not** protect the
+shared bookmark namespace / single trunk advance / `op_before` determinism. **Fix:** anchor
+`.gitman/` (lock + checkpoint) at the **shared repo root**, not `resolve_repo_root()` (which in a
+secondary workspace is that workspace's dir → a per-workspace lock that doesn't serialize parallel
+agents). Derive the shared root from the workspace store / default workspace.
+
+**Multi-op intents** (`start --workspace`, `sync`, `land`-published, `abandon`-workspace) capture
+`op_before` before their first op and use the lower-level pieces (lock, `head_operation`, explicit
+`transaction`, `capture_state` postcondition, `restore_operation` on failure) rather than the
+`canonical_tx` sugar.
+
+## 5. Snapshot semantics (the #1 correctness item — verified)
+
+Reads are frozen (a new file is invisible to `diff_stat` until `ws.snapshot()`); only `snapshot()`
+and a (auto_snapshot) transaction write a snapshot op. Therefore:
+- **`status`** and **`start`'s adopt-check** use `Session.fresh_view()` (snapshot then head).
+- **Mutations** snapshot explicitly in `canonical_tx` (§4); the tx itself runs `auto_snapshot=False`.
+- **Historical/op-log reads** (`undo --list`, `reconcile`'s capture after acting) use `Session.view()`.
+
+## 6. The tag gap → `tags.py`
+
+jj-lib (and so pyjutsu) is read-only on tags, and jj has no annotated-tag *creation* even via
+`run_jj` — annotated tags are git. Keep a ~30-line `src/gitman/tags.py`: `tag_exists` (git rev-parse),
+`create_annotated_tag` (`git tag -a`), `push_tag` (`git push <remote> <tag>`), plus a `pick_remote`
+(`ws.remotes()`-driven). The **only** subprocess gitman retains; document why. Future: contribute
+tag-create upstream to pyjutsu, then delete `tags.py`.
+
+## 7. Dependencies & devenv (build-from-sibling)
+
+- gitman depends on **pyjutsu**; its runtime no longer needs the `jj` CLI (jj-lib is embedded).
+  **Drop gitman's `nixpkgs-jj` pin and the `jj` package**; keep `git` (for `tags.py`).
+- gitman's `devenv.nix` adds the **Rust toolchain + maturin** and `maturin develop`s `../Pyjutsu`
+  (uv path dependency on the sibling). The first build is ~6 min (jj-lib); cached after.
+- The **jj 0.38 pin lives solely in pyjutsu** (`Cargo.toml` + its `devenv.nix`); gitman inherits it —
+  no second version to reconcile.
+- `pyproject.toml` base deps: `pydantic`, `typer`, `pyjutsu` (path). `doctor` validates `import
+  pyjutsu` + `pyjutsu.JJ_VERSION == pyjutsu.JJ_LIB_TARGET`.
+- (Long-term, deferred: switch to a prebuilt wheel to keep gitman's devenv pure-Python.)
+
+## 8. Error mapping (corrected — see DECISION_LOG §B.13)
+
+`ImmutableCommitError`→1 (root only; trunk is gitman-enforced) · `StaleWorkingCopyError`→1
+(→reconcile) · `GitError`→1 · `RevsetError`→3 · `WorkspaceError`/`BackendError`→2 ·
+`ConflictError`→1 (non-rebase only; **rebase conflicts via `has_conflict`, not caught**) ·
+`JjCliError`→2 (should never occur — escape hatch unused). Map at the `core.py`/`cli.py` boundary;
+this replaces all `"Nothing changed"`/`"immutable"` stderr matching.
+
+## 9. Testing changes
+
+- **Delete** `test_parse_jj.py`, `test_parse_git.py`, `tests/fixtures/`, `gen_fixtures.py` — no
+  templates/parsers/golden fixtures remain (that correctness now lives in pyjutsu's differential
+  suite).
+- **Keep + expand** policy/integration tests (`test_lifecycle_integration`, `test_m3_integration`,
+  `test_status_integration`, `test_remote_stray`) — they drive pyjutsu directly and assert gitman
+  *policy*: canonicity, lane invariants, report formats, exit codes, undo round-trips.
+- **Add:** `stale workspace → status reports it`; `rebase-into-conflict → land refuses, sync reports
+  not-blocked` (no exception); `trunk-rewrite attempt → postcondition reverts`; `parallel writers →
+  shared-root lock serializes`.
+- Tests stop needing the `jj` CLI; they need `pyjutsu` installed (+ `git` for tags).
+
+## 10. Milestones
+
+- **MP0 — wiring + read path.** gitman devenv builds pyjutsu (sibling); add `session.py` (incl.
+  shared-root resolution + snapshot/view policy); rewrite `state.py` over **one** `fresh_view()`;
+  rewrite `status` + `doctor`. Delete `templates.py` + jj read/parse + git numstat/rev_count.
+  *Gate:* `gitman status`/`doctor` green on gitman's own repo + integration reads pass.
+- **MP1 — mutating intents + invariants.** Rewrite `invariants.py` (`canonical_tx`: shared-root lock
+  + snapshot-first + `auto_snapshot=False` + canonical/trunk-unchanged postcondition); migrate
+  `start`/`save`/`land`/`abandon`/`sync`; `undo` over op-log. Typed errors replace string matching.
+  *Gate:* full lane lifecycle dogfood + conflict-via-`has_conflict` + stale handling + undo
+  round-trips.
+- **MP2 — publish, version, release, init, reconcile.** `publish` → `ws.git_push`; `version`/`release`
+  over pyjutsu tx + `tags.py`; `init` trunk bookmark via tx; `reconcile` via `view.log` + tx +
+  `update_stale`. Delete the rest of `git.py`.
+- **MP3 — delete & polish.** Remove `jj.py`, `templates.py`, dead tests/fixtures; update
+  `CLAUDE.md`/`README`/concept; drop the jj pin; re-dogfood end-to-end (real publish→land→release
+  against the remote); `devenv test` green; cut a clean release.
+
+## 11. Watch-outs (re-ranked)
+
+1. **Shared-root `.gitman/` anchoring** for the lock under workspaces — or parallel agents aren't
+   serialized (latent bug today). §4.
+2. **Explicit snapshot** before `status`/adopt-check — the top correctness item. §5.
+3. **Trunk protection is gitman's job** — postcondition asserts trunk unchanged outside `land`;
+   don't rely on engine immutability. §4, DECISION_LOG §B.11.
+4. **Rebase conflicts are commits, not exceptions** — branch on `has_conflict`. §4, §8.
+5. **Whole-intent undo** uses a persisted `op_before` + `restore_operation` (not `ws.undo()`); name
+   ops `gitman:<intent>` for `undo --list`. §4.
+6. **Remote-branch delete on `land`**: `git_push(remote, lane, delete=True)` needs the remote-tracking
+   ref present — order before dropping local tracking.
+7. **pyjutsu rough edges** (note, non-blocking): rewriting `root()` panics; `add_workspace` bases `@`
+   on root not current parents (gitman sets the lane bookmark explicitly, so cosmetic).
+8. **Keep policy in gitman, primitives in pyjutsu**; **don't regress** report formats / exit codes /
+   `--json` shape (byte-stable where possible).

--- a/.scratch/projects/03-gitman-pyjutsu-migration/MP1_IMPLEMENTATION_GUIDE.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/MP1_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,586 @@
+# MP1 Implementation Guide — mutating intents + invariants on pyjutsu
+
+> Successor step to MP0 (done). Authoritative specs remain `MIGRATION_PLAN_v2.md` (esp. §4, §5, §8)
+> and `DECISION_LOG.md` (esp. B.2, B.7, B.11–B.13). This guide is the **concrete, verified** plan for
+> MP1, derived against the real pyjutsu 0.7.0 API and probed behavior. Where this guide and the plan
+> disagree, this guide is newer and code-checked — but **flag** any further drift you find.
+
+---
+
+## 0. State of the tree after MP0 (start here)
+
+What is already done and must be **preserved**:
+
+- **`session.py`** — `Session(ws, config, repo_root[shared])` with `view()` (frozen head) /
+  `fresh_view()` (snapshot-then-head, guarded by `is_stale()`) / `is_stale()`. `Session.load(repo,
+  config=None)` resolves the **shared** root (default workspace path) and loads config from it.
+- **`state.py`** — `capture_state(session: Session) -> RepoState` from **one** `fresh_view()`.
+  Helpers you will reuse: `find_strays(view, trunk)`, `_lane_index(view)→(local,published)`,
+  `_change(commit, stat)`, `_op(operation)`, `_is_colocated(root)`. **`capture_state` now takes a
+  `Session`, not `(repo_root, config)`** — every caller must pass a `Session`.
+- **`doctor.py`** — asserts `import pyjutsu` + `JJ_VERSION==JJ_LIB_TARGET`; no `jj` CLI.
+- **devenv** builds pyjutsu from `../Pyjutsu`; **`jj` is not on PATH**. So every remaining
+  `jj.run_jj(...)` / `git.run_git(...)` mutating call is **dead** (no binary) — that is exactly what
+  MP1 replaces.
+
+What is still the OLD jj-subprocess code (MP1 rewrites the first three; MP2 the rest):
+
+- **`invariants.py`** — old `transaction()` using `jj.current_op_id`/`jj.op_restore`. **Rewrite.**
+- **`core.py`** `do_start/do_save/do_land/do_abandon/do_sync/do_resolve/do_undo` — call `jj.*` +
+  `invariants.transaction`. **Rewrite.**
+- **`lanes.py`** — `jj.bookmark_names`/`jj.capture_changes`. **Rewrite over `Session`/view.**
+- `init.py`, `reconcile.py`, `version.py`, `release.py` — **leave for MP2.** They reference
+  `invariants.transaction` / `invariants.repo_lock` / `jj.*` via **local imports inside functions**
+  (verified), so rewriting `invariants.py`/`core.py` will NOT break their import/collection; their
+  runtime paths stay broken-but-skipped until MP2.
+- `jj.py`, `templates.py`, `git.py` (most of it), `test_parse_jj.py`, `tests/fixtures/` — **do not
+  delete in MP1.** They are deleted in MP3 once nothing references them. After MP1, `core.py`/
+  `lanes.py` stop using `jj` read/parse, but `init/reconcile/version/release` still do — so the final
+  delete waits.
+
+### The one hard constraint: don't break test collection
+
+All `from gitman.invariants import ...` and `from gitman.state import ...` in `core/init/reconcile/
+version/release` are **local (in-function) imports** — verified. So you may rewrite `invariants.py`
+freely **provided you keep these public names importable** (MP2 files import them locally):
+
+- `repo_lock(repo_root)`, `ensure_state_dir(repo_root)`
+- `read_undo_checkpoint(repo_root)`, `clear_undo_checkpoint(repo_root)`, `write_undo_checkpoint(...)`
+
+The old `transaction(...)` symbol is **replaced** by `canonical_tx`/`canonical_guard`. `version.py`
+and `release.py` import `transaction` locally — they will raise `ImportError` only **when their
+(skipped) code runs**, which is fine until MP2. Do not add a back-compat shim; MP2 migrates them.
+
+---
+
+## 1. Goal & gate
+
+**Goal:** every mutating local intent runs through pyjutsu transactions under gitman's policy
+(canonicity precheck + transactional rollback + trunk-unchanged postcondition + whole-intent undo),
+with typed errors replacing all stderr string-matching and `has_conflict` replacing
+"Nothing changed" detection.
+
+**MP1 gate (stop and check in when all green):**
+
+1. `devenv shell -- bash -c 'gitman:lint && gitman:test'` green.
+2. **Full lane lifecycle dogfood** on a scratch repo (built via pyjutsu or `gitman init` once MP2
+   lands — for MP1 build the scratch repo through pyjutsu in a test/script): `start → save → (status)
+   → land`, plus `abandon`, plus `sync`.
+3. **Conflict via `has_conflict`**: a rebase that conflicts → `land` refuses (exit 1, no trunk move);
+   `sync` reports "not blocked" (exit 1, change applied).
+4. **Stale handling**: mutating a stale `@` → `StaleWorkingCopyError` mapped to exit 1 pointing at
+   `reconcile`.
+5. **Undo round-trips**: each intent's `gitman undo` restores to `op_before` (it didn't happen);
+   `undo --list` shows `gitman:*` ops; `undo --op X` restores to X.
+6. **Trunk-rewrite attempt reverts**: a non-`land` intent that would move trunk → postcondition
+   restores `op_before` and raises exit 1.
+
+Note: `init/version/release/reconcile` integration tests still **skip** in MP1 (they need MP2). Add
+the new MP1 tests (§8) and unskip the lifecycle/m3 tests by rebuilding their fixtures through pyjutsu.
+
+---
+
+## 2. The new `invariants.py` (full design)
+
+Two entry points share one set of helpers:
+
+- **`canonical_tx(session, intent)`** — sugar for a **single-transaction** intent (`save`, simple
+  `start`, simple `land`, simple `abandon`). Yields the pyjutsu `Transaction`.
+- **`canonical_guard(session, intent)`** — for **multi-op** intents (`start --workspace`, `sync`,
+  `land` with publish/workspace, `abandon` with workspace) that interleave non-tx ops
+  (`git_fetch`/`git_push`/`add_workspace`/`forget_workspace`) with one or more transactions. Yields a
+  small handle; the caller opens its own `ws.transaction(..., auto_snapshot=False)` blocks.
+
+Both: take the **shared-root lock**, **snapshot first**, **precheck canonical**, capture
+`op_before` + `trunk_before`, run the body, then assert the **postcondition** (still canonical AND
+trunk unchanged unless `intent == "land"`), restoring to `op_before` on any failure, and finally
+record the undo checkpoint.
+
+```python
+"""Invariant prechecks + transactional wrappers + the shared-root repo lock (concept §11, plan §4).
+
+Each mutating intent: take the shared-root lock (I4) → snapshot the dirty @ explicitly → assert
+canonical BEFORE (precheck) → capture op_before + trunk_before → act in a pyjutsu transaction
+(auto_snapshot=False, so exactly one mutation op with a deterministic parent) → assert canonical AND
+trunk-unchanged-unless-land AFTER (postcondition) → record the whole-intent undo checkpoint. pyjutsu's
+`with ws.transaction()` already rolls back the *body* on any exception; the manual restore_operation
+is for the postcondition and for multi-op intents whose earlier op already published.
+"""
+from __future__ import annotations
+
+import json, os, time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from gitman.core import GitmanError
+
+LOCK_PATH = ".gitman/lock"
+LAST_UNDO_PATH = ".gitman/last-undo"
+
+# --- state dir + undo checkpoint (UNCHANGED API; now stores an op-id string) ---------
+
+def ensure_state_dir(repo_root: Path) -> Path: ...          # keep MP0 body verbatim
+def write_undo_checkpoint(repo_root: Path, op_before: str, intent: str) -> None: ...  # keep (JSON {op,intent})
+def read_undo_checkpoint(repo_root: Path) -> dict | None: ...
+def clear_undo_checkpoint(repo_root: Path) -> None: ...
+
+# --- the shared-root lock (UNCHANGED body; now ALWAYS called with session.repo_root) -
+@contextmanager
+def repo_lock(repo_root: Path) -> Iterator[None]: ...        # keep MP0 body verbatim
+
+# --- precheck + postcondition -------------------------------------------------------
+
+def precheck_canonical(session) -> "RepoState":
+    """Refuse to start when already off-canonical → exit 1. Returns the before-state (for
+    trunk_before). Imported lazily to avoid a state↔invariants import cycle."""
+    from gitman.state import capture_state
+    before = capture_state(session)            # NOTE: capture_state calls fresh_view() → snapshots.
+    if not before.canonical:
+        raise GitmanError(
+            f"refusing: repo is off-canonical ({before.off_canonical}) — run `gitman reconcile`.",
+            exit_code=1,
+        )
+    return before
+
+def _postcondition(session, intent: str, trunk_before: str | None, op_before: str) -> "RepoState":
+    from gitman.state import capture_state
+    after = capture_state(session)
+    trunk_moved = (after.trunk.commit_id != trunk_before) and intent != "land"
+    if not after.canonical or trunk_moved:
+        session.ws.restore_operation(op_before)
+        reason = after.off_canonical or f"trunk moved outside a land ({trunk_before} → {after.trunk.commit_id})"
+        raise GitmanError(f"reverted: {reason}; no change applied.", exit_code=1)
+    return after
+
+@dataclass
+class Canon:
+    op_before: str
+    state: object | None = None
+    notes: list[str] = field(default_factory=list)
+    @property
+    def undo_command(self) -> str:
+        return "gitman undo"
+
+# --- single-transaction sugar -------------------------------------------------------
+
+@contextmanager
+def canonical_tx(session, intent: str) -> Iterator["Transaction"]:
+    with repo_lock(session.repo_root):
+        before = precheck_canonical(session)            # snapshots + asserts canonical
+        trunk_before = before.trunk.commit_id
+        op_before = session.ws.head_operation()         # after the snapshot → deterministic parent
+        with session.ws.transaction(f"gitman:{intent}", auto_snapshot=False) as tx:
+            yield tx                                     # body raises ⇒ pyjutsu rolls back, op_before intact
+        state = _postcondition(session, intent, trunk_before, op_before)
+        write_undo_checkpoint(session.repo_root, op_before, intent)
+        # expose post-state to the caller via a closure attr if needed (see note)
+
+# --- multi-op guard -----------------------------------------------------------------
+
+@contextmanager
+def canonical_guard(session, intent: str) -> Iterator[Canon]:
+    with repo_lock(session.repo_root):
+        before = precheck_canonical(session)
+        trunk_before = before.trunk.commit_id
+        op_before = session.ws.head_operation()
+        canon = Canon(op_before=op_before)
+        try:
+            yield canon                                  # caller runs its own tx(s) + git/workspace ops
+        except Exception:
+            session.ws.restore_operation(op_before)      # an earlier op may have already published
+            raise
+        canon.state = _postcondition(session, intent, trunk_before, op_before)
+        write_undo_checkpoint(session.repo_root, op_before, intent)
+```
+
+**Notes & decisions baked in:**
+
+- `canonical_tx` yields the pyjutsu `tx`; the caller calls `tx.new/describe/create_bookmark/...`.
+  To get the post-state (`IntentResult.state`) and `undo_command` out, either (a) have the caller
+  call `capture_state(session)` again after the `with` (one more frozen read — fine), or (b) make
+  `canonical_tx` yield a small object carrying both the `tx` and a post-hook. Recommended: keep it
+  simple — yield `tx`, and after the `with` block in `core.py` do `state = capture_state(session)` for
+  the report. (The postcondition already captured one; a second read is cheap and keeps the API
+  obvious. If you prefer zero extra reads, return the postcondition's state via a `Canon`-like holder.)
+- **`op_before` is captured AFTER the explicit snapshot** (inside `precheck_canonical`'s
+  `fresh_view`). So `gitman undo` reverts the mutation **and** the user's just-snapshotted edits —
+  matching today's "undo = it didn't happen" (DECISION_LOG B.2). Documented; one-line change if you
+  ever want "undo keeps my unsaved edit."
+- **No `try/except: restore` inside `canonical_tx`** — `with ws.transaction()` rolls the body back on
+  raise (verified). The explicit `restore_operation` lives only in the postcondition and in
+  `canonical_guard` (whose earlier op already published).
+- **Trunk-unchanged** compares `after.trunk.commit_id` to `before.trunk.commit_id` (config stores only
+  the trunk *name*; the frozen commit is the pre-intent one). `land` is the sole exemption.
+
+---
+
+## 3. Error mapping (typed → exit code) — plan §8 / DECISION_LOG B.13
+
+Add to `core.py`:
+
+```python
+def map_pyjutsu_error(exc: "PyjutsuError") -> GitmanError:
+    from pyjutsu.errors import (
+        BackendError, ConflictError, GitError, ImmutableCommitError, JjCliError,
+        RevsetError, StaleWorkingCopyError, WorkingCopyError, WorkspaceError,
+    )
+    if isinstance(exc, StaleWorkingCopyError):
+        return GitmanError("working copy is stale — run `gitman reconcile`.", exit_code=1)
+    if isinstance(exc, ImmutableCommitError):
+        return GitmanError(f"immutable commit: {exc}", exit_code=1)
+    if isinstance(exc, ConflictError):
+        return GitmanError(f"conflict: {exc}", exit_code=1)            # NON-rebase; rebase uses has_conflict
+    if isinstance(exc, GitError):
+        return GitmanError(f"git operation failed: {exc}", exit_code=1)
+    if isinstance(exc, RevsetError):
+        return GitmanError(f"bad revision/revset: {exc}", exit_code=3)
+    if isinstance(exc, (WorkspaceError, BackendError, WorkingCopyError, JjCliError)):
+        return GitmanError(f"infra/config: {exc}", exit_code=2)
+    return GitmanError(str(exc), exit_code=2)                          # base PyjutsuError
+```
+
+Wire it at the **CLI boundary** so any uncaught `PyjutsuError` becomes a clean message + exit code.
+In `cli.py::main()`:
+
+```python
+def main() -> None:
+    from pyjutsu import PyjutsuError
+    try:
+        app()
+    except GitmanError as exc:
+        print(str(exc), file=sys.stderr); sys.exit(exc.exit_code)
+    except PyjutsuError as exc:
+        ge = map_pyjutsu_error(exc); print(str(ge), file=sys.stderr); sys.exit(ge.exit_code)
+```
+
+Catch specific pyjutsu errors **inside** intents only where you can add useful context (e.g.
+`create_bookmark` collision → exit 3 "lane exists"); otherwise let them bubble to `main()`.
+
+> ⚠️ Rebase conflicts do **not** raise — never wrap a rebase in `except ConflictError`. Read the
+> returned commit's `.has_conflict` (verified: probe #2/#5).
+
+---
+
+## 4. `lanes.py` over `Session`/view
+
+Replace `jj.*` reads with view reads. Keep signatures taking a `Session` (or a `RepoView` + trunk).
+
+```python
+def lane_names(session, trunk: str) -> set[str]:
+    local, _ = _lane_index(session.view())          # reuse state._lane_index, or inline
+    return local - {trunk}
+
+def current_lane(session, trunk: str) -> str | None:
+    wc = session.view().working_copy()
+    return next((b for b in wc.bookmarks if b != trunk), None)
+
+def require_current_lane(session, trunk: str) -> str:
+    lane = current_lane(session, trunk)
+    if lane is None:
+        raise GitmanError("not on a lane — run `gitman start <name>` first.", exit_code=1)
+    return lane
+
+def ensure_unique(session, trunk: str, name: str) -> None:
+    if name == trunk:
+        raise GitmanError(f"lane name '{name}' collides with trunk.", exit_code=3)
+    if name in lane_names(session, trunk) | {trunk}:
+        raise GitmanError(f"lane '{name}' already exists.", exit_code=3)
+
+# resolve_workspace_path(repo_root, config, lane) — UNCHANGED (pure path math).
+```
+
+`_lane_index` lives in `state.py`; either import it or duplicate the 6 lines. Reading inside a
+`canonical_tx` body is fine — `session.view()` reflects the snapshot taken by the precheck (pre-tx
+state), which is what collision/lane checks want.
+
+---
+
+## 5. `core.py` intent migrations (recipes)
+
+Every intent builds a `Session` once (`session = Session.load(repo)` — but see CLI note below) and
+returns an `IntentResult` (unchanged model). The **CLI** should build the `Session` and pass it in,
+or each `do_*` builds it from `(repo, config)`. Recommended: change `do_*` signatures to take a
+`Session`, and have `cli.py` build it: `session = Session.load(_repo_root())`. This removes the
+`(repo_root, config)` threading. (`config` is on `session.config`.)
+
+### 5.1 `save`
+```python
+def do_save(session, message):
+    trunk = require_trunk(session.config)
+    lane = require_current_lane(session, trunk)
+    if message is None:
+        wc = session.fresh_view().working_copy()      # reflect on-disk edits for the echo
+        return IntentResult(intent="save", outcome="NOOP", lane=lane,
+            messages=[f'current change: "{wc.description.rstrip(chr(10)) or "(no description)"}"  (pass -m to set it)'])
+    with canonical_tx(session, "save") as tx:
+        tx.describe("@", message)
+    state = capture_state(session)
+    return IntentResult(intent="save", outcome="SAVED", lane=lane,
+        messages=[f'described: "{message}"'], undo_command="gitman undo", state=state)
+```
+
+### 5.2 `start` (simple, adopt, workspace)
+- **Simple:** `with canonical_tx(session, "start") as tx: tx.new(trunk); tx.create_bookmark(name, "@")`.
+- **Adopt** (`_adoptable_work` true — `@` non-empty, no bookmark, descended from trunk):
+  `with canonical_tx(...): tx.create_bookmark(name, "@")`.
+- **`--workspace` (multi-op):** `add_workspace` publishes its own op and (pyjutsu rough edge) bases the
+  new `@` on **root**. Recipe (probe to confirm before relying):
+  ```python
+  with canonical_guard(session, "start") as canon:
+      ensure_unique(session, trunk, name)
+      wpath = resolve_workspace_path(session.repo_root, session.config, name)
+      session.ws.add_workspace(str(wpath), name=name)        # own op; new @ on root
+      sub = Workspace.load(wpath)
+      with sub.transaction("gitman:start", auto_snapshot=False) as tx:
+          tx.new(trunk)                                       # put the new workspace's @ on trunk
+          tx.create_bookmark(name, "@")
+  ```
+  The bookmark namespace is shared, so the lane shows up in `status` from the default workspace.
+  ⚠️ **Probe this flow first** (`add_workspace` @-placement + that `sub`'s tx lands on the shared
+  op-log so `op_before`/postcondition still see it). On guard failure, also `forget_workspace(name)` +
+  `rmtree(wpath)` before re-raising (add to the `except` path or do it in the cleanup).
+
+`ensure_unique` for non-workspace start runs inside the `canonical_tx` body (before the mutations).
+
+`_adoptable_work(session, trunk)`:
+```python
+def _adoptable_work(session, trunk):
+    wc = session.fresh_view().working_copy()
+    if wc.is_empty or wc.bookmarks:
+        return False
+    return bool(session.view().log(f"@ & ({trunk}..)"))
+```
+(Note: `canonical_tx`'s precheck already snapshotted; calling `fresh_view` again is a harmless second
+snapshot/no-op. If you want to avoid it, read `view().working_copy()` instead since the snapshot
+already happened.)
+
+### 5.3 `land` (verified recipe)
+Per lane (loop, `break` on first block, as today). Use `canonical_guard` (land moves trunk; may also
+push-delete + forget workspace — multi-op). The **single-tx core** is verified:
+
+```python
+was_published = lane in published_set            # from _lane_index(session.view())
+with canonical_guard(session, "land") as canon:
+    if lane not in lane_names(session, trunk):
+        raise GitmanError(f"no such lane '{lane}'.", exit_code=3)
+    with session.ws.transaction("gitman:land", auto_snapshot=False) as tx:
+        rebased = tx.rebase(lane, onto=trunk, mode="branch")
+        if rebased.has_conflict:
+            raise GitmanError(
+                f"lane '{lane}' conflicts with trunk — `gitman resolve`, then `gitman land {lane}`.",
+                exit_code=1)
+        tx.set_bookmark(trunk, lane)             # advance trunk to the lane head (verified)
+        tx.delete_bookmark(lane)                 # retire the lane
+    canon.notes += _cleanup_workspace(session, lane)         # forget + rmtree (own op)
+    if was_published:                            # remote-branch delete (best-effort, one-way)
+        try:
+            session.ws.git_push(pick_remote(session.ws), lane, delete=True)
+            canon.notes.append(f"deleted remote branch '{lane}'.")
+        except PyjutsuError as exc:
+            canon.notes.append(f"remote branch '{lane}' not deleted (delete manually): {exc}")
+```
+- The conflict `raise` inside the inner `with` rolls back the tx (no partial); the `guard`'s `except`
+  then `restore_operation(op_before)` (a no-op here since the tx already rolled back, but correct if a
+  prior op published). Net: **trunk does not move on conflict** (gate #3). ✓
+- **Remote-delete ordering** (watch-out #6): `git_push(..., delete=True)` needs the remote-tracking
+  ref, **not** the local bookmark. We delete the local bookmark in the tx; the `lane@origin`
+  remote-tracking ref persists until pruned, so the delete-push works *after* the tx. ✓
+- `pick_remote(ws)` = `"origin"` if present in `ws.remotes()` else the first remote (move to `tags.py`
+  in MP2; for MP1 a 3-line local helper is fine).
+- The trunk-move postcondition is **allowed** for `intent == "land"`. By construction trunk only
+  fast-forwards to a lane that was rebased onto it, so it advances (descendant). (Optionally assert
+  `trunk_after ∈ trunk_before::` for defense-in-depth; not required for MP1.)
+
+### 5.4 `abandon` (verified recipe)
+```python
+def do_abandon(session, lane):
+    trunk = require_trunk(session.config)
+    target = lane or require_current_lane(session, trunk)
+    notes = []
+    if target not in lane_names(session, trunk):
+        raise GitmanError(f"no such lane '{target}'.", exit_code=3)
+    change_ids = [c.change_id for c in session.view().log(f"{trunk}..{target}")]
+    with canonical_tx(session, "abandon") as tx:           # use guard if a workspace must be forgotten
+        for cid in change_ids:
+            tx.abandon(cid)                                # change_ids are stable across rewrites
+        tx.delete_bookmark(target)                         # bookmark auto-moved to trunk's commit (verified)
+    notes += _cleanup_workspace(session, target)           # if workspaced (then prefer canonical_guard)
+    return IntentResult(intent="abandon", outcome="ABANDONED", lane=target,
+        messages=[f"discarded lane '{target}'."], notes=notes,
+        undo_command="gitman undo", state=capture_state(session))
+```
+- Verified: abandoning all `trunk..lane` change_ids in one tx moves the lane bookmark **back onto
+  trunk's commit** (it doesn't disappear), so `delete_bookmark(target)` succeeds and `(trunk..) ~
+  ::(bookmarks|remote_bookmarks) ~ @` is empty afterwards (canonical). ✓
+- If `@` was on the lane, abandoning `@`'s change advances `@` to a fresh empty commit on trunk
+  (pyjutsu `abandon` semantics) — still canonical.
+- If the lane has a **workspace**, switch to `canonical_guard` (forget + rmtree is its own op).
+
+### 5.5 `sync` (multi-op, conflicts non-blocking)
+```python
+def do_sync(session, all_):
+    trunk = require_trunk(session.config)
+    targets = sorted(lane_names(session, trunk)) if all_ else [require_current_lane(session, trunk)]
+    messages, notes, conflicted = [], [], []
+    with canonical_guard(session, "sync") as canon:
+        remotes = session.ws.remotes()
+        if remotes:
+            session.ws.git_fetch(pick_remote(session.ws))   # own op
+            messages.append("fetched remote.")
+        else:
+            notes.append("no remote — rebasing onto local trunk only.")
+        with session.ws.transaction("gitman:sync", auto_snapshot=False) as tx:
+            for lane in targets:
+                rebased = tx.rebase(lane, onto=trunk, mode="branch")
+                if rebased.has_conflict:
+                    conflicted.append(lane)                 # DO NOT raise — sync is non-blocking
+    if targets: messages.append(f"rebased {', '.join(targets)} onto {trunk}.")
+    if conflicted: notes.append(f"conflicts in {', '.join(conflicted)} — not blocked; `gitman resolve`, then continue.")
+    return IntentResult(intent="sync", outcome="CONFLICT" if conflicted else "SYNCED",
+        messages=messages, notes=notes, exit_code=1 if conflicted else 0,
+        undo_command="gitman undo", state=canon.state)
+```
+- A conflicting rebase **commits a conflict commit** (no raise); `capture_state` still reports
+  **canonical** (first-class conflicts ≠ off-canonical), trunk unmoved → postcondition passes → sync
+  is **not** reverted. Exit 1 + note, matching today. ✓
+
+### 5.6 `undo`
+```python
+def do_undo(session, op, list_):
+    if list_:
+        ops = [o for o in session.view().operations(30) if o.description.startswith("gitman:")][:15]
+        rows = [f"{o.id[:12]}  {o.description}" for o in ops]
+        return IntentResult(intent="undo", outcome="LIST", messages=rows or ["no gitman operations."])
+    with repo_lock(session.repo_root):
+        if op:
+            target, what = op, f"op {op[:12]}"
+        else:
+            rec = read_undo_checkpoint(session.repo_root)
+            if not rec:
+                session.ws.undo()                           # fallback: revert head op
+                return IntentResult(intent="undo", outcome="UNDONE",
+                    messages=["undid the last operation (no recorded intent checkpoint)."])
+            target, what = rec["op"], f"intent '{rec.get('intent','?')}'"
+        session.ws.restore_operation(target)
+        clear_undo_checkpoint(session.repo_root)
+    return IntentResult(intent="undo", outcome="UNDONE", messages=[f"reverted {what}."],
+        notes=["older intents: `gitman undo --list`, then `gitman undo --op <id>`."])
+```
+- `undo --list` filters the op-log to `gitman:*` descriptions (pyjutsu commits our description
+  verbatim; `tags` is empty — verified probe E). `restore_operation`/`undo` may raise `PyjutsuError`
+  → mapped at the boundary.
+
+### 5.7 `resolve` (read-only)
+```python
+def do_resolve(session, list_):
+    require_trunk(session.config)
+    state = capture_state(session)                          # tolerates off-canonical
+    view = session.view()
+    files = view.conflicts("@") if state.current_lane else []
+    conflicted_lanes = [l.name for l in state.lanes if l.conflict]
+    if not files and not conflicted_lanes:
+        return IntentResult(intent="resolve", outcome="CLEAN", messages=["no conflicts."])
+    msgs = []
+    if files:
+        msgs.append("conflicts at @:"); msgs += [f"  {c.path} ({c.num_sides}-sided)" for c in files]
+    if conflicted_lanes:
+        msgs.append(f"conflicted lanes: {', '.join(conflicted_lanes)}")
+    msgs.append("Not blocked — edit the files (jj markers: <<<<<<< %%%%%%% +++++++ >>>>>>>), then continue.")
+    return IntentResult(intent="resolve", outcome="CONFLICTS", messages=msgs, exit_code=1)
+```
+
+### 5.8 `_cleanup_workspace(session, lane)`
+Port to pyjutsu: `session.ws.workspaces()` for membership; `session.ws.forget_workspace(lane)`;
+`resolve_workspace_path`; `rmtree` unless cwd is inside it (keep today's "forgotten but kept" note).
+This publishes its own op → only call it inside a `canonical_guard` body, never a `canonical_tx`.
+
+---
+
+## 6. CLI wiring (`cli.py`)
+
+- Build the `Session` per command and pass to `do_*`:
+  `session = Session.load(_repo_root())` then e.g. `_finish_intent(do_start(session, name, workspace))`.
+  (`config` rides on `session.config`; drop `_config(root)` plumbing for migrated commands.)
+- Add the `PyjutsuError` catch in `main()` (§3).
+- `status`/`doctor` already done in MP0.
+
+---
+
+## 7. Tests (§9 of the plan)
+
+- **Rebuild fixtures through pyjutsu** for `test_lifecycle_integration.py`, `test_m3_integration.py`,
+  `test_remote_stray.py` (drop the `skipif jj` marker; build repos via `Workspace.init` + transactions
+  like `tests/test_status_integration.py` does). Drive the intents via `do_*` with a `Session`, assert
+  report outcomes, exit codes, canonicity, and undo round-trips.
+- **Add the new-capability tests** (plan §9): 
+  - rebase-into-conflict → `land` refuses (exit 1, trunk unmoved) / `sync` reports not-blocked (exit 1,
+    change applied);
+  - trunk-rewrite attempt (a doctored intent that moves trunk outside land) → postcondition reverts;
+  - stale `@` → mutating raises `StaleWorkingCopyError` → exit 1;
+  - undo round-trip for each intent;
+  - `undo --list` shows `gitman:*` ops.
+- Keep `test_parse_jj.py`, `tests/fixtures/`, `test_status_integration.py`, `test_version_unit.py`,
+  `test_version_parse.py` as-is (parse tests deleted in MP3).
+- For remote tests (`publish`/remote-delete), use a **bare git repo as `origin`** via
+  `ws.add_remote("origin", file_url)` + `ws.git_push(...)`. (Publish itself is MP2, but `land`'s
+  remote-delete can be exercised by pushing a lane first.)
+
+---
+
+## 8. Verified pyjutsu facts MP1 relies on (re-confirm if in doubt)
+
+| Behavior | Verified result | Source |
+|---|---|---|
+| `transaction(auto_snapshot=False)` after explicit `snapshot()` | single mutation op, deterministic parent; `restore_operation(op_before)` reverts the intent | probe3 A |
+| rebase into conflict | returns commit with `has_conflict=True`, **no raise** | probe1 #2, probe3 C |
+| empty tx / already-based rebase / same-desc describe | succeed, publish an op (no native noop signal) | probe1 #4/#5, probe2 #5 |
+| reads frozen until `snapshot()` | new/edited file invisible to `diff_stat`/`log` | probe1 #6, probe3 B |
+| op description preserved verbatim, `tags` empty | `undo --list` filters on `description.startswith("gitman:")` | probe3 E |
+| **LAND** `rebase(branch)`→`set_bookmark(trunk,lane)`→`delete_bookmark(lane)` (1 tx) | trunk advances to lane head; lane gone; `trunk..@` clean | this guide's probe |
+| **ABANDON** abandon each `trunk..lane` change_id (1 tx) then `delete_bookmark` | lane bookmark auto-moves to trunk's commit; delete ok; no strays | this guide's probe |
+| `is_stale()` / `update_stale()` first-class; stale across workspaces | works | probe2 #9 |
+| `git_push(remote, lane, delete=True)` | needs remote-tracking ref, not local bookmark; raises `GitError` if absent | docstring + probe2 #7 |
+
+---
+
+## 9. Watch-outs (ranked for MP1)
+
+1. **Conflicts are commits, not exceptions** — branch on `has_conflict` after every `rebase`; never
+   `except ConflictError` a rebase.
+2. **Postcondition trunk check** — compare `after.trunk.commit_id` to the pre-intent commit; exempt
+   only `land`. This is gitman's trunk protection (engine does not protect trunk).
+3. **`op_before` after the explicit snapshot** (inside `precheck`/`fresh_view`) so undo = "it didn't
+   happen" including the snapshotted edit.
+4. **Multi-op intents** (`start --workspace`, `sync`, published/workspaced `land`, workspaced
+   `abandon`) must use `canonical_guard`, not `canonical_tx` — their `git_*`/`workspace_*` ops publish
+   outside any tx, and the guard's `except: restore_operation(op_before)` is what unwinds a partial.
+5. **`start --workspace`** is the riskiest path (add_workspace bases `@` on root; sub-workspace tx).
+   **Probe it** before wiring; on failure, `forget_workspace` + `rmtree` the half-made workspace.
+6. **Remote-delete ordering** on `land` — delete the local bookmark in the tx, then `git_push(delete=
+   True)` using the still-present remote-tracking ref.
+7. **Don't regress the contract** — `IntentResult` shape, outcomes (`SAVED`/`STARTED`/`LANDED`/
+   `BLOCKED`/`ABANDONED`/`SYNCED`/`CONFLICT`/`NOOP`/`UNDONE`), exit codes, and the inline `Undo:` line
+   are user-facing. Keep them byte-stable; flag any change.
+8. **Keep `repo_lock`/`*_undo_checkpoint`/`ensure_state_dir` names** so MP2 files' local imports
+   resolve; do **not** delete `jj.py`/`templates.py`/`git.py`/`test_parse_jj.py` in MP1.
+
+---
+
+## 10. Gate checklist (stop and check in)
+
+- [ ] `invariants.py` rewritten (`canonical_tx` + `canonical_guard` + helpers; lock at shared root).
+- [ ] `lanes.py` over `Session`/view.
+- [ ] `core.py`: `save`, `start` (+adopt, +workspace), `land`, `abandon`, `sync`, `undo`, `resolve`
+      migrated; `map_pyjutsu_error` added; `cli.py` builds `Session` + catches `PyjutsuError`.
+- [ ] No `jj.run_jj` / `git.run_git` / `"Nothing changed"` / `"immutable"` string-matching left in the
+      migrated paths.
+- [ ] `gitman:lint && gitman:test` green; lifecycle/m3/remote tests rebuilt on pyjutsu + unskipped;
+      new conflict/stale/trunk-revert/undo tests pass.
+- [ ] **Dogfood** on a scratch pyjutsu repo: `start feat → save -m → status → land` round-trips;
+      `abandon`; `sync`; each intent's `gitman undo` reverts it; `undo --list` shows `gitman:*`.
+- [ ] Flag any plan/code drift discovered.
+
+When all green: summarize and hand off to **MP2** (publish/version/release/init/reconcile + `tags.py`).
+```

--- a/.scratch/projects/03-gitman-pyjutsu-migration/MP2_IMPLEMENTATION_GUIDE.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/MP2_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,552 @@
+# MP2 Implementation Guide — publish / version / release / init / reconcile + `tags.py`
+
+> Successor step to MP1 (done & green). MP1 migrated the **mutating lane intents** (save / start /
+> land / abandon / sync / undo / resolve) and the transactional invariants (`canonical_tx` /
+> `canonical_guard`) onto pyjutsu. MP2 migrates the **remaining intents** —
+> `publish` / `version` / `release` / `init` / `reconcile` — off the dead `jj`/`git` subprocess
+> path and onto pyjutsu, and adds **`tags.py`** (the one retained colocated-git subprocess module,
+> for annotated tags). Authoritative specs remain `MIGRATION_PLAN_v2.md` and `DECISION_LOG.md`; this
+> guide is the **concrete, verified** plan, derived against real pyjutsu 0.7.0 and probed behavior
+> (`.scratch/probe5_mp2.py`). Where this guide and the plan disagree, this guide is newer and
+> code-checked — but **flag** any further drift.
+
+---
+
+## 0. State of the tree after MP1 (start here)
+
+**Done & green (preserve):**
+
+- **`invariants.py`** — `canonical_tx(session, intent)` (single-tx sugar) and
+  `canonical_guard(session, intent)` (multi-op), sharing `precheck_canonical`, `_postcondition`
+  (canonical **and** trunk-unchanged-unless-`land`), `_assert_fresh` (explicit stale guard →
+  `StaleWorkingCopyError`), the shared-root `repo_lock`, and `write/read/clear_undo_checkpoint` +
+  `ensure_state_dir`. **Reuse these verbatim.**
+- **`lanes.py`** — `lane_names` / `current_lane` / `require_current_lane` / `ensure_unique` /
+  `resolve_workspace_path`, all over a `Session`/view. **All take a `Session` now.**
+- **`core.py`** — `map_pyjutsu_error(exc) -> GitmanError` (typed→exit code, wired in `cli.main()`),
+  `pick_remote(ws)`, `_cleanup_workspace(session, lane)`, and the migrated lane intents. The CLI
+  builds one `Session` per command via `cli._session()` and catches `PyjutsuError` at the boundary.
+- **`session.py` / `state.py` / `doctor.py`** — unchanged from MP0/MP1. `capture_state(session)`,
+  `find_strays(view, trunk)`, `_lane_index(view)`, `_is_colocated(root)` are the read helpers.
+- Tests: `test_lifecycle_integration.py`, `test_m3_integration.py` (sync+undo unskipped),
+  `test_remote_stray.py` rebuilt on pyjutsu and green. **33 passed, 4 skipped** — the 4 skips are the
+  MP2 intents (`@MP2` mark in `test_m3_integration.py`).
+
+**Still OLD jj/git-subprocess code (MP2 rewrites all of these):**
+
+- **`init.py`** `do_init(repo_root, config, trunk_opt)` — uses `jj.bookmark_names/bookmark_create`,
+  `git.is_colocated`, `git.run_git symbolic-ref origin/HEAD`.
+- **`reconcile.py`** `do_reconcile(repo_root, config, abandon_)` — uses `jj.current_op_id`,
+  `jj.bookmark_names`, `jj.abandon`, `jj.bookmark_create`, `find_strays(repo_root, …)` (OLD
+  signature), `capture_state(repo_root, config)` (OLD signature).
+- **`version.py`** `do_version(config, repo_root, action, level)` — uses `jj.new_change/describe/`
+  `bookmark_set` + the removed `invariants.transaction`. (`bump`/`parse_semver`/`read_version`/
+  `write_version` are pure — **keep them as-is.**)
+- **`release.py`** `do_release(config, repo_root, level, set_version)` — uses `jj.*` + `git.*` tags +
+  removed `invariants.transaction`.
+- **`core.py`** `do_publish(repo_root, config)` — the lone core.py MP2 holdover; uses `git.has_remote`,
+  `jj.git_push`, removed `invariants.transaction`. **Migrate it in core.py.**
+
+**The hard constraint (same as MP1): don't break collection.** `init/reconcile/version/release`
+import `jj`/`git`/`invariants.transaction` via **local (in-function) imports** — verified — so the
+tree currently collects (their tests just skip). As you migrate each, **delete those local imports**
+and replace with pyjutsu + `tags.py`. After MP2, **no production module imports `gitman.jj` or
+`gitman.git`** (MP3 then deletes `jj.py`, `git.py`, `templates.py`, `test_parse_jj.py`,
+`tests/fixtures/`). MP2's gate proves this with a grep.
+
+**Do NOT delete** `jj.py`/`git.py`/`templates.py`/`test_parse_jj.py`/`tests/fixtures/` in MP2 — that
+is MP3, once the grep confirms zero production importers.
+
+---
+
+## 1. Goal & gate
+
+**Goal:** every remaining intent runs through pyjutsu (+ `tags.py` for annotated git tags) under
+gitman's policy, with typed errors and no `jj`/`git` subprocess in any migrated path; the 4 skipped
+MP2 tests are rebuilt on pyjutsu and unskipped; new version/release/publish/reconcile tests pass.
+
+**MP2 gate (stop and check in when all green):**
+
+1. `devenv test` (≡ `gitman:lint && gitman:test`) green.
+2. The 4 `@MP2`-skipped tests (`test_init_*`, `test_version_*`, `test_release_*`,
+   `test_reconcile_*`) **rebuilt through pyjutsu and unskipped**, passing.
+3. **Full extended dogfood** on a scratch pyjutsu repo (script or CLI): `init` → `start` → `save` →
+   `version bump minor` → `publish` (to a bare remote) → `release` → `reconcile` (recover a stray),
+   each with a working `gitman undo` where applicable.
+4. **`release` verify-blocks before any write** (no tag, no bump) when the verify hook fails.
+5. **`version bump` / `release` bump** create a dedicated "Bump version to X" change on the lane;
+   `gitman undo` reverts the bump **and** the file edit.
+6. **No production importer of `gitman.jj` / `gitman.git`** remains (grep clean) → MP3 is pure
+   deletion.
+
+---
+
+## 2. `tags.py` — the one retained colocated-git module
+
+pyjutsu has **no tag-write API** (jj tag support is read-only), so annotated tags stay on `git`
+(present on PATH in devenv; `doctor` asserts it "for tags.py"). Build a small, typed module — the
+*only* surviving raw-git subprocess in production after MP3 deletes `git.py`.
+
+```python
+"""Colocated-git annotated tags — the one git-subprocess surface gitman retains (concept §13).
+
+pyjutsu binds no tag write, so release tags live on the git side of the colocated repo. git is on
+PATH in devenv (doctor asserts it). Verified: `git tag -a <tag> <commit>` works on a jj-authored
+commit_id — colocated repos write commit objects into the git store (probe5 B).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gitman.core import GitmanError
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=repo_root, capture_output=True, text=True)
+
+
+def tag_exists(repo_root: Path, tag: str) -> bool:
+    return _git(repo_root, "rev-parse", "-q", "--verify", f"refs/tags/{tag}").returncode == 0
+
+
+def create_annotated_tag(repo_root: Path, tag: str, message: str, commit: str) -> None:
+    r = _git(repo_root, "tag", "-a", tag, "-m", message, commit)
+    if r.returncode != 0:
+        raise GitmanError(f"failed to create tag {tag}:\n{r.stderr.strip()}", exit_code=2)
+
+
+def push_tag(repo_root: Path, remote: str, tag: str) -> None:
+    r = _git(repo_root, "push", remote, f"refs/tags/{tag}")
+    if r.returncode != 0:
+        raise GitmanError(f"tag push failed:\n{r.stderr.strip()}", exit_code=1)
+
+
+def remote_default_branch(repo_root: Path, remote: str) -> str | None:
+    """`origin/HEAD` short name (e.g. 'main'), for init's trunk detection. None if unset."""
+    r = _git(repo_root, "symbolic-ref", "--quiet", f"refs/remotes/{remote}/HEAD")
+    return r.stdout.strip().rsplit("/", 1)[-1] if r.returncode == 0 and r.stdout.strip() else None
+```
+
+Notes:
+- Take an **explicit `remote`** (resolve it with `core.pick_remote(session.ws)`); don't re-derive it
+  with raw git.
+- Tag creation/push are **one-way** (git side, no jj op) — `gitman undo` reverts a *bump*, never a
+  tag. Keep that note in the release report (byte-stable with today's).
+
+---
+
+## 3. `init.py` — `do_init(session, trunk_opt)`
+
+`init` is the **bootstrap**: it runs before a trunk is frozen, so it does **not** use the canonical
+wrappers (there's no trunk to be canonical about) and writes **no undo checkpoint** (matches today).
+Take the `repo_lock`, create the trunk bookmark in one bare tx, write the files.
+
+```python
+def do_init(session, trunk_opt):
+    from gitman.invariants import repo_lock
+    from gitman.models import IntentResult
+    from gitman.state import _is_colocated
+
+    config = session.config
+    repo_root = session.repo_root
+    if config.trunk:
+        raise GitmanError(f"already initialized (trunk '{config.trunk}' is frozen).", exit_code=3)
+    if not _is_colocated(repo_root):
+        raise GitmanError("not a colocated jj repo — run `jj git init --colocate` first.", exit_code=2)
+
+    messages = []
+    with repo_lock(repo_root):
+        trunk = trunk_opt or detect_trunk(session)
+        local = {b.name for b in session.view().bookmarks() if b.remote is None}
+        if trunk not in local:
+            with session.ws.transaction("gitman:init", auto_snapshot=False) as tx:
+                tx.create_bookmark(trunk, "@")
+            messages.append(f"created trunk bookmark '{trunk}' at @.")
+        else:
+            messages.append(f"using existing trunk bookmark '{trunk}'.")
+        # ... _version_scaffold + write gitman.toml + SKILL.md exactly as today (plain file IO) ...
+    return IntentResult(intent="init", outcome="INITIALIZED", messages=messages,
+        notes=["trunk is frozen (I1); `gitman doctor` validates it."])
+
+
+def detect_trunk(session) -> str:
+    from gitman.core import pick_remote
+    from gitman import tags
+
+    local = {b.name for b in session.view().bookmarks() if b.remote is None}
+    for cand in TRUNK_CANDIDATES:           # ("main", "master", "trunk")
+        if cand in local:
+            return cand
+    if session.ws.remotes():
+        head = tags.remote_default_branch(session.repo_root, pick_remote(session.ws))
+        if head:
+            return head
+    return "main"
+```
+
+- Keep `SKILL_MD`, `_version_scaffold`, `TRUNK_CANDIDATES` verbatim. Only the jj/git reads change.
+- `_is_colocated` lives in `state.py` (and `doctor.py`); import the `state` one (don't reach into
+  `git.py`).
+- The bare `tx.create_bookmark(trunk, "@")` publishes one op but no undo checkpoint — init is not an
+  "undoable intent" (re-init is refused by the frozen-trunk check, I1).
+
+---
+
+## 4. `reconcile.py` — `do_reconcile(session, abandon_)`
+
+Recovery path: the repo is **off-canonical by definition**, so it runs **without** `precheck` (no
+`canonical_tx`/`canonical_guard`). Manual shape: lock → snapshot → capture `op_before` → one tx that
+adopts (`create_bookmark` on each stray `change_id`) or abandons each stray → undo checkpoint →
+re-capture state → report `RECONCILED`/`PARTIAL`. **Verified** (probe5 C): adopting a bookmark per
+stray drives strays → 0 (canonical).
+
+```python
+def do_reconcile(session, abandon_):
+    from gitman.invariants import repo_lock, write_undo_checkpoint
+    from gitman.models import IntentResult
+    from gitman.state import capture_state, find_strays
+
+    trunk = require_trunk(session.config)
+    with repo_lock(session.repo_root):
+        view = session.fresh_view()                     # snapshot dirty @ first
+        strays = find_strays(view, trunk)               # NEW signature: (view, trunk)
+        if not strays:
+            return IntentResult(intent="reconcile", outcome="CLEAN",
+                messages=["already canonical — no strays."])
+        op_before = session.ws.head_operation()
+        existing = {b.name for b in view.bookmarks() if b.remote is None}
+        actions = []
+        with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
+            for change in strays:
+                if abandon_:
+                    tx.abandon(change.change_id)
+                    actions.append(f"abandoned {change.change_id}")
+                else:
+                    name = f"adopted-{change.change_id[:8]}"
+                    if name in existing:
+                        name = f"adopted-{change.change_id}"
+                    tx.create_bookmark(name, change.change_id)
+                    existing.add(name)
+                    actions.append(f"adopted {change.change_id} → lane '{name}'")
+        write_undo_checkpoint(session.repo_root, op_before, "reconcile")
+        state = capture_state(session)
+
+    canonical = state.canonical
+    return IntentResult(intent="reconcile", outcome="RECONCILED" if canonical else "PARTIAL",
+        messages=actions, notes=[] if canonical else [f"still off-canonical: {state.off_canonical}"],
+        exit_code=0 if canonical else 1, undo_command="gitman undo")
+```
+
+- `find_strays` **already takes `(view, trunk)`** (MP0/MP1) — the OLD `reconcile.py` passed
+  `(repo_root, trunk)` which never matched; fix it.
+- `op_before` is captured **after** the explicit `fresh_view()` snapshot, so `gitman undo` reverts
+  the adoption (and the snapshotted dirty @) — same "it didn't happen" semantics as the lane intents.
+- Don't add a postcondition that *reverts* — reconcile is the recovery; a `PARTIAL` is **reported**,
+  not rolled back.
+
+---
+
+## 5. `version.py` — `do_version(session, action, level)` (the snapshot bump flow)
+
+Keep `parse_semver` / `bump` / `read_version` / `write_version` / `_pattern_regex` **verbatim**
+(pure). Only `do_version` changes. The riskiest mechanic in MP2 is folding the written version file
+into a **dedicated** new change with `auto_snapshot=False`. **Verified** (probe5 A): the 3-op flow
+`tx.new("@")` → write file → `ws.snapshot()` → `tx.describe + set_bookmark` produces a non-empty
+"Bump version to X" change on the lane, and `restore_operation(op_before)` reverts the file too.
+
+Factor the bump so `release` reuses it:
+
+```python
+def bump_change_on_lane(session, lane: str, new: str, op_desc: str = "gitman:version") -> None:
+    """Add a dedicated 'Bump version to <new>' change on top of @ and advance `lane` to it.
+    Three ops (new → snapshot the written file → describe+set_bookmark); call inside a
+    canonical_guard body (multi-op). Verified: probe5 A."""
+    with session.ws.transaction(op_desc, auto_snapshot=False) as tx:
+        tx.new("@")                                     # dedicated empty change on the lane head
+    write_version(session.config, session.repo_root, new)   # writes the file on the new @
+    session.ws.snapshot()                               # own op: fold the file into @
+    with session.ws.transaction(op_desc, auto_snapshot=False) as tx:
+        tx.describe("@", f"Bump version to {new}")
+        tx.set_bookmark(lane, "@")                      # lane head = the bump change
+
+
+def do_version(session, action, level):
+    from gitman.invariants import canonical_guard
+    from gitman.lanes import require_current_lane
+    from gitman.models import IntentResult
+
+    current = read_version(session.config, session.repo_root)
+    if action is None:
+        return IntentResult(intent="version", outcome="OK", messages=[f"version {current}"])
+    if action != "bump":
+        raise GitmanError(f"unknown version action {action!r} (use: bump <major|minor|patch>).", exit_code=3)
+    if not level:
+        raise GitmanError("specify a level: `gitman version bump <major|minor|patch>`.", exit_code=3)
+
+    new = bump(current, level)
+    trunk = require_trunk(session.config)
+    with canonical_guard(session, "version") as canon:
+        lane = require_current_lane(session, trunk)     # @ must be on a lane (read pre-mutation)
+        bump_change_on_lane(session, lane, new)
+    return IntentResult(intent="version", outcome="BUMPED", lane=lane,
+        messages=[f"{current} → {new}"], undo_command="gitman undo", state=canon.state)
+```
+
+- **`canonical_guard`, not `canonical_tx`** — the bump is multi-op (the mid-flow `ws.snapshot()`
+  publishes its own op between the two transactions).
+- `require_current_lane(session, trunk)` reads `session.view()` (pre-mutation @) — call it *inside*
+  the guard body but *before* `bump_change_on_lane` (after `tx.new`, @ no longer carries the lane
+  bookmark).
+- Determinism caveat (MP1 memory): a bump that recreates a byte-identical commit after an undo
+  collides (`BackendError: already exists`). Real bumps change the version string, so the bump commit
+  differs — fine. Just don't write tests that undo-then-redo an identical bump.
+
+---
+
+## 6. `release.py` — `do_release(session, level, set_version)`
+
+Same shape as today, but the bump uses `bump_change_on_lane` and tags use `tags.py`. **Verify FIRST**
+(before any write or tag — concept §13). Keep `_target_version` (already in `release.py`, pure) as-is.
+
+```python
+def do_release(session, level, set_version):
+    from gitman.invariants import canonical_guard
+    from gitman.lanes import require_current_lane
+    from gitman.models import IntentResult
+    from gitman.core import pick_remote, run_verify
+    from gitman.version import bump_change_on_lane
+    from gitman import tags
+
+    config, repo_root = session.config, session.repo_root
+    trunk = require_trunk(config)
+    current, new = _target_version(config, repo_root, level, set_version)   # local helper, this module
+
+    verify_cmds = config.release.verify if config.release.verify is not None else config.publish.verify
+    ok, out = run_verify(verify_cmds, repo_root)
+    if not ok:
+        raise GitmanError(f"verify failed — release blocked (no tag, no bump):\n{out}", exit_code=1)
+
+    tag = config.release.tag_format.format(version=new)
+    if tags.tag_exists(repo_root, tag):
+        raise GitmanError(f"tag {tag} already exists.", exit_code=3)
+
+    messages, notes, undo = [], [], None
+    if new != current:
+        with canonical_guard(session, "release") as canon:
+            lane = require_current_lane(session, trunk)
+            bump_change_on_lane(session, lane, new, op_desc="gitman:release")
+        undo = canon.undo_command
+        messages.append(f"bumped {current} → {new}")
+        release_point = "@"
+    else:
+        release_point = trunk                            # tag the landed trunk head, not empty @
+
+    head = session.view().resolve(release_point)         # frozen read reflects the bump
+    if head.is_empty:
+        raise GitmanError(
+            f"nothing to release: {release_point} is an empty commit (land a change to trunk first).",
+            exit_code=1)
+    commit = head.commit_id
+    tags.create_annotated_tag(repo_root, tag, f"Release {new}", commit)   # raises exit 2 on fail
+    messages.append(f"tagged {tag} @ {commit}")
+    notes.append("a git tag was created (one-way; `gitman undo` reverts a bump, not the tag).")
+
+    if config.release.push_tag:
+        if not session.ws.remotes():
+            notes.append("no remote — tag created locally but not pushed.")
+        else:
+            tags.push_tag(repo_root, pick_remote(session.ws), tag)        # raises exit 1 on fail
+            messages.append(f"pushed tag {tag}")
+            notes.append("a pushed tag is one-way.")
+
+    return IntentResult(intent="release", outcome="RELEASED", messages=messages, notes=notes,
+        undo_command=undo)
+```
+
+- After the guard, `session.view().resolve("@")` is the bump commit (frozen read reflects the
+  committed bump). For the no-bump path, `resolve(trunk)` is the landed head.
+- The empty-commit guard is preserved (don't tag an empty @ / empty trunk).
+- Byte-stable with today's report: same messages/notes/order/outcomes.
+
+---
+
+## 7. `core.py` — `do_publish(session)`
+
+Migrate the lone core.py holdover. Push the current lane via pyjutsu (`ws.git_push(remote, lane,
+allow_new=True)`), verify-gated, under a guard (records undo; push is one-way so the note stays).
+
+```python
+def do_publish(session):
+    from pyjutsu import PyjutsuError
+    from gitman.invariants import canonical_guard
+    from gitman.lanes import require_current_lane
+    from gitman.models import IntentResult
+
+    trunk = require_trunk(session.config)
+    if not session.ws.remotes():
+        raise GitmanError("no git remote configured — cannot publish.", exit_code=2)
+
+    notes = []
+    ok, out = run_verify(session.config.publish.verify, session.repo_root)
+    if not ok:
+        if session.config.publish.on_fail == "block":
+            raise GitmanError(f"verify failed — publish blocked:\n{out}", exit_code=1)
+        notes.append("verify failed (on_fail=warn) — publishing anyway.")
+
+    with canonical_guard(session, "publish") as canon:
+        lane = require_current_lane(session, trunk)
+        try:
+            session.ws.git_push(pick_remote(session.ws), lane, allow_new=True)
+        except PyjutsuError as exc:                       # rejected push, missing-new gate, etc.
+            raise GitmanError(f"push rejected:\n{exc}", exit_code=1) from exc
+    notes.append("push is one-way: `gitman undo` reverts local state only, not the remote branch.")
+    return IntentResult(intent="publish", outcome="PUBLISHED", lane=lane,
+        messages=[f"pushed lane '{lane}'."], notes=notes, undo_command="gitman undo", state=canon.state)
+```
+
+- Delete `do_publish`'s `from gitman import git, jj` / `from gitman.invariants import transaction`
+  local imports and the deferred-MP2 comment.
+- `git_push` raising `GitError` is also handled at the CLI boundary by `map_pyjutsu_error` (exit 1);
+  the inline `try` just adds the "push rejected" context to match today's message.
+
+---
+
+## 8. CLI wiring (`cli.py`)
+
+Switch the five commands to `_session()` (already defined in MP1):
+
+- `init`:      `_finish_intent(do_init(_session(), trunk))`
+- `reconcile`: `_finish_intent(do_reconcile(_session(), abandon_))`
+- `version`:   `_finish_intent(do_version(_session(), action, level))`
+- `release`:   `_finish_intent(do_release(_session(), level, set_version))`
+- `publish`:   `_finish_intent(do_publish(_session()))`
+
+Drop the `_config(root)`/`root` plumbing from these. After this, `_config` may be unused — remove it
+if so (ruff will flag). `main()`'s `PyjutsuError` catch already covers these paths.
+
+> `init` runs on a not-yet-frozen repo: `Session.load` still works (the repo is a colocated jj
+> workspace; config just has `trunk=None`). `do_init` reads `session.config.trunk` to refuse re-init.
+
+---
+
+## 9. Tests
+
+### 9.1 Unskip + rebuild the 4 MP2 tests (`test_m3_integration.py`)
+
+Remove the `@MP2` marks; rebuild `_fresh` **through pyjutsu** (no `jj`/`git` CLI), drive the intents
+with a `Session`. Pattern (mirror `_base` already in the file):
+
+```python
+def _fresh(d: Path) -> Workspace:
+    ws = Workspace.init(d, colocate=True)
+    (d / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "1.2.3"\n')
+    (d / "app.py").write_text("print(1)\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")            # NO bookmark yet — init freezes trunk
+    return ws
+```
+
+- `test_init_*`: `do_init(_sess(d), None)` → `INITIALIZED`; `load_config(d).trunk == "main"`;
+  `gitman.toml` + `.claude/skills/gitman/SKILL.md` exist; re-init raises. (Session config is loaded
+  at `Session.load` time, *before* `do_init` writes `gitman.toml`; build a **fresh** `_sess(d)` after
+  init when you need the frozen-trunk config.)
+- `test_version_*`: after `do_init`, build a `Session` whose config has the frozen trunk; `do_version
+  (_sess, None, None)` shows `version 1.2.3`; `do_start` a lane, `do_version(_sess, "bump", "minor")`
+  → `BUMPED`, `read_version == "1.3.0"`, lane `change_count == 2`.
+- `test_release_*`: `do_release(_sess, None, None)` tags the trunk head (needs a non-empty trunk —
+  build one), assert `tags.tag_exists` / `git tag -l`.
+- `test_reconcile_*`: build a genuine stray through pyjutsu (see `test_precheck_refuses_off_canonical`
+  in the lifecycle file for the stray recipe), `do_reconcile(_sess, abandon_=False)` → `RECONCILED`,
+  canonical, an `adopted-*` lane present.
+
+> `do_init`/`do_version`/`do_release`/`do_reconcile` all take a **`Session`** now — the old
+> `(repo_root, config)` / `(config, repo_root)` calls in these tests must all change.
+
+### 9.2 New capability tests (add)
+
+- **version-bump undo round-trip**: `version bump` then `undo` → version string back, lane back to 1
+  change, file reverted.
+- **release with bump**: bump + tag in one call; tag exists; the bump change is on the lane.
+- **release verify-blocks before write**: a failing `release.verify` hook → exit 1, **no tag, no
+  bump** (assert `tag_exists` False and version unchanged).
+- **reconcile `--abandon`**: strays discarded → canonical, no `adopted-*` lane.
+- **reconcile undo round-trip**: after `RECONCILED`, `undo` restores the off-canonical state.
+- **publish to a bare remote**: `git init --bare`, `ws.add_remote`, `do_publish` → remote has the
+  lane branch (`git ls-remote`); `on_fail="warn"` verify path still publishes with a note.
+
+Keep `test_version_unit.py` / `test_version_parse.py` (pure) as-is. **Don't** touch
+`test_parse_jj.py` / `tests/fixtures/` (MP3 deletes them).
+
+---
+
+## 10. MP3 readiness (don't do MP3 — just leave it clean)
+
+After MP2, prove the tree is ready for MP3's deletions:
+
+```
+grep -rn "from gitman import jj\|from gitman import git\|from gitman.jj\|from gitman.git\|from gitman import templates" src/gitman/*.py
+```
+
+The only hits should be **inside `jj.py` (←templates) and `git.py` (←jj)** themselves. Zero hits in
+`init/reconcile/version/release/core/cli/doctor/state/lanes/session`. If that holds, MP3 is purely:
+delete `jj.py`, `git.py`, `templates.py`, `test_parse_jj.py`, `tests/fixtures/`, and any now-dead
+`models` (`ProcResult` lives in `jj.py`; `ConflictFile`/`Op` in `models.py` are still used by
+`state.py` — keep those). Flag anything that resists deletion.
+
+---
+
+## 11. Verified facts MP2 relies on (re-confirm if in doubt — `.scratch/probe5_mp2.py`)
+
+| Behavior | Verified result | Source |
+|---|---|---|
+| version-bump: `tx.new("@")` → write file → `ws.snapshot()` → `tx.describe+set_bookmark` | dedicated non-empty "Bump version to X" change on the lane; `restore_operation(op_before)` reverts the file too | probe5 A |
+| `git tag -a <tag> <commit_id>` on a **jj-authored** commit (colocated) | succeeds (rc 0); tag resolvable — colocated repos write commit objects to the git store | probe5 B |
+| reconcile: one tx of `tx.create_bookmark(adopted-…, change_id)` per stray | strays → 0 (canonical), no precheck needed | probe5 C |
+| `find_strays(view, trunk)` / `_lane_index(view)` / `_is_colocated(root)` | the read helpers MP2 reuses (state.py) | MP1 |
+| `session.ws.git_push(remote, lane, allow_new=True)` | publishes the lane branch to the remote (one op) | MP1 land/remote tests |
+| reused stale `Workspace` handle for a checkout-op after other handles moved @ | `WorkingCopyError: Concurrent checkout` — tests must `Workspace.load` a fresh handle before raw ops following `do_*` | MP1 memory |
+
+---
+
+## 12. Watch-outs (ranked for MP2)
+
+1. **version/release bump is multi-op** (new → snapshot → describe) — use `canonical_guard`, never
+   `canonical_tx`. The mid-flow `ws.snapshot()` is the op that folds the written file into the change.
+2. **Read `require_current_lane` before `tx.new`** in the bump — after `new`, @ no longer carries the
+   lane bookmark.
+3. **`find_strays` takes `(view, trunk)`**, not `(repo_root, trunk)` — the old `reconcile.py` was
+   already wrong against the MP1 signature; fix it.
+4. **`init` doesn't use the canonical wrappers** (no frozen trunk yet) — `repo_lock` + a bare tx only;
+   no undo checkpoint.
+5. **Verify before any write in `release`** — a blocked verify must leave no tag and no bump.
+6. **Tags are git-side and one-way** — `undo` reverts a bump, never a tag. Keep that note byte-stable.
+7. **Don't regress the contract** — outcomes (`INITIALIZED`/`RECONCILED`/`PARTIAL`/`CLEAN`/`OK`/
+   `BUMPED`/`PUBLISHED`/`RELEASED`), exit codes, messages, and the inline `Undo:` line are
+   user-facing. Keep byte-stable; flag any change.
+8. **Session at `init` time has `trunk=None`** — refuse re-init by reading `session.config.trunk`; in
+   tests, reload the `Session` after `do_init` to pick up the frozen-trunk `gitman.toml`.
+9. **Leave `jj.py`/`git.py`/`templates.py`/`test_parse_jj.py`/`tests/fixtures/`** for MP3; just prove
+   zero production importers remain.
+
+---
+
+## 13. Gate checklist (stop and check in)
+
+- [ ] `tags.py` added (annotated tag create/exists/push + `remote_default_branch`); takes an explicit
+      remote from `pick_remote`.
+- [ ] `init` / `reconcile` / `version` / `release` migrated to `Session`; `do_publish` migrated in
+      `core.py`; all `from gitman import jj`/`git` + `invariants.transaction` local imports deleted
+      from these paths.
+- [ ] `cli.py` wires all five through `_session()`; `_config` removed if unused.
+- [ ] `bump_change_on_lane` factored in `version.py` and reused by `release`.
+- [ ] 4 `@MP2` tests rebuilt on pyjutsu + unskipped; new version/release/publish/reconcile tests pass.
+- [ ] `devenv test` green; extended dogfood round-trips (`init → start → save → version bump →
+      publish → release → reconcile`), bump-undo reverts the file, release verify-block leaves no tag.
+- [ ] grep proves **zero** production importers of `gitman.jj`/`gitman.git` → MP3 is pure deletion.
+- [ ] Flag any plan/code drift discovered.
+
+When all green: summarize and hand off to **MP3** (delete `jj.py`/`git.py`/`templates.py`/
+`test_parse_jj.py`/`tests/fixtures/` + final sweep; the deferred `advanced/github` forge extra stays
+out of scope).
+```

--- a/.scratch/projects/03-gitman-pyjutsu-migration/UPSTREAM_pyjutsu_immutability.md
+++ b/.scratch/projects/03-gitman-pyjutsu-migration/UPSTREAM_pyjutsu_immutability.md
@@ -1,0 +1,220 @@
+# Upstream report for pyjutsu — commit immutability / trunk protection
+
+**To:** pyjutsu maintainers · **From:** gitman (a downstream policy layer being ported onto
+pyjutsu) · **Against:** pyjutsu 0.7.0, jj-lib 0.38.0 · **Date:** 2026-06-17
+
+This is an evaluation request, not a bug demand. While porting gitman onto pyjutsu we found that
+pyjutsu enforces **only root-commit** immutability, not jj's configurable `immutable_heads()`
+(trunk / tags / untracked remote bookmarks). We also found one outright **bug** (a rewrite path
+that *panics* instead of raising) that we think should be fixed regardless of how you decide the
+larger policy question. Everything below was verified by probing the built extension and reading
+the Rust source; file:line references are into pyjutsu's tree.
+
+---
+
+## TL;DR
+
+- **Issue A (bug, please fix regardless):** `PyTransaction::describe` rewrites its target with **no
+  root-commit guard**, so `tx.describe("root()", …)` triggers a jj-lib `assert!` and surfaces as a
+  `pyo3_runtime.PanicException` across the FFI boundary — while `abandon`/`rebase`/`squash`/`restore`
+  guard the root explicitly and `edit` maps the error cleanly. Inconsistent, and a Rust panic across
+  PyO3 is hostile (it can poison the in-flight `MutableRepo`). It should raise `ImmutableCommitError`
+  like its siblings.
+- **Issue B (policy gap, for your evaluation):** pyjutsu deliberately does not replicate jj's
+  configurable immutability (the code comment in `src/transaction.rs:260` says so). The result is
+  that an in-process consumer can silently rewrite **trunk** or a **tagged release commit** with no
+  error — the headline safety property of "a faithful jj engine" is absent. We outline four options
+  (do-nothing → expose-a-query → opt-in-enforcement → seed-the-aliases) with trade-offs and a
+  recommendation that stays consistent with pyjutsu's "primitives, not workflow policy" philosophy.
+
+gitman itself will enforce trunk protection in its own policy layer either way, so **this is not a
+blocker for us** — it's about ecosystem correctness and removing a foot-gun for every future
+consumer.
+
+---
+
+## Background: how jj enforces immutability (and where the layers split)
+
+In jujutsu, "you can't rewrite trunk/tags" is **not** enforced by `jj-lib`. jj-lib hard-protects
+only the **root commit** (the synthetic empty commit with no parents). Everything else —
+`immutable_heads()`, `trunk()`, tags, untracked remote bookmarks — is enforced by the **CLI crate**:
+
+- The CLI's *built-in config* defines the revset aliases (jj 0.38, paraphrased):
+  ```toml
+  [revset-aliases]
+  'builtin_immutable_heads()' = 'present(trunk()) | tags() | untracked_remote_bookmarks()'
+  'immutable_heads()'         = 'builtin_immutable_heads()'
+  'immutable()'               = '::(immutable_heads() | root())'
+  'mutable()'                 = '~immutable()'
+  ```
+- Before any rewrite, the CLI evaluates `immutable()` once and refuses if a to-be-rewritten commit
+  is a member (`cli/src/cli_util.rs::check_rewritable`, using a `containing_fn()` for cheap
+  membership). jj-lib's `MutableRepo::rewrite_commit` / `record_abandoned_commit` themselves do **no
+  such check** — they only assert on the root.
+
+So a binding that talks to `jj-lib` directly (pyjutsu, by design) gets **root protection for free**
+and **nothing else** unless it reproduces the CLI's policy. That's the crux of Issue B.
+
+---
+
+## Reproduction (verified against the built extension)
+
+```python
+from pyjutsu import Workspace
+from pyjutsu import errors as E
+
+ws = Workspace.init("/tmp/r", colocate=True)
+# ... make a commit, bookmark it "main" (acting as trunk), put @ on a child ...
+
+# Issue B: trunk is freely rewritable — NO error.
+with ws.transaction("rewrite trunk tip") as tx:
+    tx.describe("main", "rewrote the trunk tip")     # succeeds; main's commit_id changes
+
+# Issue A: rewriting root panics instead of raising.
+with ws.transaction("rewrite root") as tx:
+    tx.describe("root()", "x")
+    # -> pyo3_runtime.PanicException: assertion failed: !commit.parents.is_empty()
+
+# Contrast: abandon/rebase/squash/restore DO raise cleanly on root.
+with ws.transaction("abandon root") as tx:
+    tx.abandon("root()")                              # ImmutableCommitError: cannot abandon the root commit
+```
+
+Observed: `describe(main)` and `describe(root())` confirm both issues; `abandon(root())` confirms
+the sibling paths already do the right thing.
+
+---
+
+## Root-cause analysis (file:line)
+
+**Config loading is fine but incomplete for this purpose.** `src/workspace.rs:104
+load_user_settings` builds `StackedConfig::with_defaults()` + user config (`JJ_CONFIG` / platform
+dir) + the repo's `.jj/repo/config.toml`. But `with_defaults()` is **jj-lib's** defaults — it does
+**not** include the CLI's `builtin_immutable_heads()` / `immutable_heads()` aliases (those live in
+the cli crate). So unless the *user's own* config happens to define `immutable_heads()`, the alias is
+simply unresolvable in pyjutsu, and even a consumer who wanted to check it can't.
+
+**Enforcement is root-only, and inconsistently so.** In `src/transaction.rs`:
+- `abandon` (`:262`), `rebase` (`:309`), `squash` (`:366`), `restore` (`:419`) each **explicitly
+  guard** `target.id() == repo.store().root_commit_id()` and return `ImmutableCommitError`.
+- `edit` (`:238`) maps `EditCommitError::RewriteRootCommit → ImmutableCommitError`
+  (`src/errors.rs:87`).
+- **`describe` (`:161`)** calls `repo.rewrite_commit(&commit).set_description().write()`
+  (`:175–179`) with **no root guard** → hits jj-lib's `assert!(!commit.parents.is_empty())` in the
+  store → `PanicException`. This is the bug.
+- The comment at `src/transaction.rs:260` states the policy choice explicitly: *"Only the root is
+  enforced — jj's configurable `immutable_heads()` set is CLI workflow policy, which the thin layer
+  deliberately does not replicate."* — i.e. Issue B is a known, intentional omission, which is why
+  we're raising it as an evaluation rather than a bug.
+
+---
+
+## Issue A — fix the panic (recommended unconditionally)
+
+Add the same root guard `describe` is missing, and audit every rewrite entry point so **no** path
+can panic across FFI:
+
+- In `describe`, before `rewrite_commit`, guard `target.id() == root_commit_id()` →
+  `ImmutableCommitError("cannot rewrite the root commit")` (matching the sibling wording).
+- Sweep `transaction.rs` for any `rewrite_commit`/`record_abandoned_commit`/`assert*`/`unwrap`
+  reachable from a public method; ensure each maps to a typed error, never a panic. (Rationale: a
+  Rust panic that unwinds through PyO3 becomes a `BaseException` the Python consumer can't reasonably
+  handle, and it may leave the borrowed `MutableRepo` half-mutated for the rest of the `with` block.)
+
+Low risk, strictly-better, independent of the Issue B decision. A regression test per rewrite verb
+against `root()` (`with pytest.raises(ImmutableCommitError)`) would lock it in.
+
+---
+
+## Issue B — configurable immutability: four options
+
+Ordered from least to most engine involvement. They are **not** mutually exclusive — (4) is a
+prerequisite that makes (2)/(3) faithful, and our recommendation combines (4)+(2).
+
+### Option 1 — Status quo + documentation
+Keep root-only enforcement; document clearly that *all* other immutability is the consumer's
+responsibility, and that `immutable_heads()` is unavailable unless the consumer defines it in config.
+
+- **Pro:** maximally thin; matches the stated philosophy; zero engine work (beyond Issue A).
+- **Con:** every consumer re-implements the same `immutable()` membership check; the "faithful jj
+  engine" promise is materially weaker than the CLI for the one operation users most fear (a silent
+  trunk/tag rewrite); the alias isn't even resolvable, so consumers can't easily match jj semantics.
+
+### Option 2 — Expose immutability as a read-only query (recommended baseline)
+Add a non-enforcing primitive so consumers can ask the engine, cheaply and faithfully, whether a
+commit is immutable — leaving *enforcement* as consumer policy:
+
+```python
+view.is_immutable("main")            # -> bool, evaluates the configured immutable() set
+view.immutable_heads()               # -> list[Commit] (or the resolved revset), optional
+```
+
+Implementation: build the `immutable()` `RevsetExpression` once per `RepoView`/call, evaluate to a
+`containing_fn()` (as the CLI does), and test membership. Pair with Option 4 so `immutable_heads()`
+resolves to jj's builtin by default.
+
+- **Pro:** stays "primitives, not policy"; composable; jj-faithful; lets gitman/others check before
+  mutating without re-deriving the revset; trivial to reason about.
+- **Con:** opt-in — doesn't prevent the foot-gun for a consumer who forgets to call it; needs
+  Option 4 (or a user-defined alias) to be meaningful.
+
+### Option 3 — Opt-in enforcement in transactions
+A flag that makes the binding evaluate `immutable()` and raise `ImmutableCommitError` on any rewrite
+of a member, mirroring the CLI's `check_rewritable`:
+
+```python
+with ws.transaction("…", enforce_immutable=True) as tx:   # default off (thin) or on (jj-faithful)
+    tx.describe("main", "…")   # -> ImmutableCommitError
+```
+
+Evaluate the immutable set **once** when the transaction opens and reuse a `containing_fn()` across
+all rewrites in that tx (avoid per-call revset evaluation — that's the CLI's perf model too).
+
+- **Pro:** real protection; closest to jj parity; one switch instead of per-call checks.
+- **Con:** moves workflow policy into the binding (philosophy tension); needs Option 4; a default-on
+  choice would be a behavior change; must decide semantics for a rewrite that *moves* an immutable
+  commit only as a descendant rebase, etc. (match the CLI's "rewrite set" definition exactly).
+
+### Option 4 — Seed jj's builtin immutability aliases into the config stack (enabler)
+Today `load_user_settings` omits the CLI's builtin revset-aliases. Seed
+`builtin_immutable_heads()` / `immutable_heads()` / `immutable()` / `mutable()` (vendored from jj's
+CLI default config, version-pinned alongside the jj-lib pin) as a **built-in (lowest-precedence)**
+layer, so a user/repo config can still override `immutable_heads()` exactly as in jj.
+
+- **Pro:** makes `immutable_heads()`/`immutable()` *resolvable and jj-identical* — required for (2)
+  and (3) to mean what they mean in jj; also lets consumers who write their own revsets reference
+  `immutable()` directly.
+- **Con:** these aliases are CLI-crate config, not jj-lib, so pyjutsu must vendor/track the TOML and
+  re-pin it on jj upgrades (one more thing pinned to the jj version — but you already pin jj-lib, so
+  it slots into the same discipline).
+
+---
+
+## Recommendation
+
+1. **Do Option A now** (the describe root-guard + a no-panic audit) — it's a clean bug fix.
+2. **Do Option 4 + Option 2** as the philosophy-consistent baseline: seed the builtin aliases so
+   `immutable()` is jj-faithful, and expose `is_immutable(rev)` as a read-only query. This gives
+   every consumer a cheap, correct membership check without pyjutsu taking on enforcement policy.
+3. **Consider Option 3** (opt-in `enforce_immutable`, default **off**) as a follow-up convenience for
+   consumers that want engine-level guarantees without writing the check themselves. Defaulting it
+   **on** would be the most jj-faithful but is a behavior change worth a deliberate major-version
+   call.
+
+This keeps pyjutsu thin (enforcement stays opt-in / consumer-side) while restoring jj parity for the
+*detection* of immutable commits and removing the silent-trunk-rewrite foot-gun.
+
+## What gitman will do regardless
+gitman enforces trunk protection in its own policy layer (only its `land` intent advances trunk; all
+rebases target `trunk..lane`; a transactional postcondition asserts trunk's `commit_id` is unchanged
+outside a land). So we are **not blocked**. If Option 2 lands we'd switch our postcondition to call
+`view.is_immutable(...)` for a jj-faithful check; if Option 3 lands we'd turn it on as
+defense-in-depth. Issue A's panic is the only item that actively bites us today (we simply never
+target `root()`, so it's low-severity for us, but it's a sharp edge for the next consumer).
+
+## Suggested tests (whichever options you take)
+- `describe(root())` → `ImmutableCommitError` (Issue A); same for every rewrite verb.
+- With builtin aliases seeded: `is_immutable("trunk()")` / a tagged commit → `True`; a normal lane
+  commit → `False`; a user config overriding `immutable_heads()` changes the result.
+- With `enforce_immutable=True`: rewriting trunk/tag/untracked-remote-bookmark → `ImmutableCommitError`;
+  rewriting a mutable lane commit → succeeds; verify the immutable set is evaluated once per tx.

--- a/.scratch/projects/04-gitman-code-review/CODE_REVIEW.md
+++ b/.scratch/projects/04-gitman-code-review/CODE_REVIEW.md
@@ -1,0 +1,416 @@
+# Gitman — Deep Code Review
+
+**Date:** 2026-06-18
+**Scope:** Full `src/gitman/` (17 modules, ~1,800 LOC) + tests + `docs/GITMAN_CONCEPT.md` (the authority).
+**Method:** Read every source/test file and the concept doc; ran `ruff check` (clean) and `pytest -q`
+(36 passed) inside devenv to ground the review against the real in-process pyjutsu engine.
+**Verdict:** High-quality, shippable code. Findings are mostly a gap between the concept's strong
+claims and what the code actually *enforces* and *reports*, plus a handful of concrete bugs.
+
+> **Update (2026-06-18): Batch 1 fixes applied.** M1, M2, M5, L1, L3, L5, L7, L8 are implemented as
+> recommended; **H2 shipped scoped-down** (an honest `status` *note*, not a hard off-canonical flag —
+> see the ⚠ annotation under H2 for why the full version was deferred). 44 tests pass, lint clean. See
+> `REVIEW_REFACTORING_IDEAS.md` for per-finding status and the remaining Batch 2/3 plan.
+
+---
+
+## 1. What the library is
+
+**Gitman is a version-control *policy layer* for coding agents.** Instead of letting an agent run
+`git add` / `commit` / `rebase` / `push` / `tag` (or `jj` plumbing) ad hoc, the agent issues a small
+set of **intents** and gets back a compact, structured report plus a meaningful exit code.
+
+The intent surface (`cli.py`) is eleven verbs:
+
+| Intent | What it does |
+|---|---|
+| `status` | Canonical/off-canonical report: trunk + all lanes |
+| `start <name> [--workspace]` | Create a lane (new change on trunk + bookmark); `--workspace` isolates it |
+| `save [-m]` | Describe the current lane's change |
+| `sync [--all]` | Fetch trunk + rebase the current lane (or all) onto it |
+| `publish` | Push the current lane (verify hook first); branch = lane name |
+| `land [<lane>…]` | Fold lane(s) into trunk, advance trunk, retire the lane(s) |
+| `abandon [<lane>]` | Discard a lane (terminal) |
+| `undo [--op] [--list]` | Revert the last intent, or restore to a chosen op |
+| `resolve [--list]` | Surface remaining conflicts / confirm cleared |
+| `version [bump <level>]` | Show or bump the repo's semver |
+| `release [<level>\|--version]` | (bump →) tag `vX.Y.Z` → push tag (verify hook first) |
+
+Plus `init`, `doctor`, `reconcile`. Global flags: `--repo`, `--json`. Exit codes: `0` ok · `1` VC
+decision needed · `2` infra/config · `3` invalid usage.
+
+It is explicitly **not** a new VCS and **not** a general git wrapper for humans. It is the VCS sibling
+of "Testee" (a verification-policy layer) and deliberately mirrors its shape: a Pydantic report model,
+a Typer CLI, and compact agent-facing reports.
+
+## 2. What it does and who it's for
+
+**Who:** coding agents first (humans/CI secondary), running only inside a `devenv.sh` shell so the
+toolchain is pinned and host drift is impossible. The motivating scenario is *parallel agents*: spin up
+N agents on N problems in N isolated workspaces, each a named lane, then merge back via `land`.
+
+**The problem it solves:** agents do version control badly — destructive commands (`reset --hard`,
+blind `push --force`), the staging dance, getting wedged mid-rebase in a modal state they can't reason
+about, losing uncommitted work, messy history, dumping huge porcelain into context, and being unable to
+recover from mistakes. Gitman's thesis is that the gap isn't tooling, it's the lack of a *policy layer* —
+and that **jujutsu is what makes the layer safe** rather than thin guard rails over a sharp tool.
+
+## 3. How it works
+
+### 3.1 Substrate: jj in-process via pyjutsu
+
+The substrate is **jujutsu (jj)**, embedded **in-process via pyjutsu** (PyO3 bindings to jj-lib). There
+is **no `jj` CLI** on PATH and no `-T` template parsing — pyjutsu hands gitman typed models directly
+(`RepoView.log()/bookmarks()/diff_stat()/conflicts()/operations()`). The jj 0.38 pin lives entirely in
+pyjutsu; `doctor` asserts `pyjutsu.JJ_VERSION == pyjutsu.JJ_LIB_TARGET` so a jj-lib drift fails loudly.
+
+jj fixes the agent failure modes at the *data-model* level, and gitman leans on each property:
+
+- **No staging area; the working copy is an auto-snapshotted commit** → work is always saved.
+- **First-class conflicts** (recorded *in commits*, not a blocking modal state) → an agent is never
+  wedged; `sync`/`land` surface conflicts as `has_conflict` and keep going.
+- **Operation log + total undo** → the headline feature *and* the transactional-rollback lever.
+- **Stable change-IDs** → "the thing I'm working on" survives rewrites.
+- **Workspaces** → the native substrate for parallel agents (`start --workspace`).
+- **Colocated git** → real `.git` stays in sync, so push/CI/tags/`gh` all keep working.
+
+The one surviving subprocess is `tags.py` (annotated git tags), because pyjutsu binds no tag write;
+`git` is on PATH in devenv for exactly this.
+
+### 3.2 The lane model
+
+The repo is always a *set of canonical lanes*. A **lane** = a named jj **bookmark** (= git branch) on a
+trunk descendant, kept linear, optionally in its own jj **workspace**. The design stance: the mess to
+eliminate is not *multiple changes* but *unstructured* changes (anonymous, non-linear, divergent, stray).
+Five invariants are meant to hold *by construction*:
+
+- **I1** Trunk resolved once at `init`, frozen in config, never re-detected at runtime.
+- **I2** Every change belongs to exactly one named lane; no anonymous/stray changes.
+- **I3** Branch name = the lane's readable name, unique-checked at creation.
+- **I4** Gitman is the sole writer; mutating ops serialized by a brief repo lock.
+- **I5** Each lane is linear on trunk (rebase-always); trunk advances only via `land`.
+
+### 3.3 Execution model (the elegant part)
+
+Each mutating intent runs through one of two wrappers in `invariants.py`:
+
+- `canonical_tx` — for **single-transaction** intents (`save`, simple `start`/`abandon`).
+- `canonical_guard` — for **multi-op** intents (`sync`, `land`, workspaced `start`, `version`,
+  `release`) that interleave non-tx ops (`git_fetch`/`git_push`/`add_workspace`/`forget_workspace`)
+  with one or more transactions.
+
+Both follow the same recipe:
+
+```
+take shared-root lock (I4)
+  → assert @ is fresh (refuse stale)        (invariants.py:_assert_fresh)
+  → snapshot + assert canonical BEFORE      (precheck_canonical → capture_state → fresh_view)
+  → capture op_before (deterministic parent after the snapshot)
+  → act in a pyjutsu transaction(auto_snapshot=False)
+  → assert canonical AND trunk-unchanged-unless-land AFTER   (_postcondition)
+      ↳ on violation: ws.restore_operation(op_before); raise exit 1
+  → write the whole-intent undo checkpoint (.gitman/last-undo)
+```
+
+`Session` (`session.py`) is the boundary onto pyjutsu and centralizes the single trickiest correctness
+issue in the system — *when to snapshot*: `view()` is a frozen read at the head op (no snapshot);
+`fresh_view()` snapshots the dirty `@` first (unless stale) so the read reflects on-disk edits. Only two
+call sites snapshot for a read (`status`, `start`'s adopt-check), and `fresh_view` deliberately *skips*
+the snapshot when stale so `status` can *report* staleness instead of crashing.
+
+### 3.4 Recovery is single-pathed
+
+External mutation (raw `jj`/`git`, a human) is the one thing gitman can't prevent. So `status`
+classifies the repo as **canonical** or **off-canonical**, and there is exactly one recovery path:
+`gitman reconcile`, which adopts stray changes into auto-named lanes (or `--abandon` discards them).
+No per-deviant-state handling.
+
+## 4. Overall assessment
+
+This is **high-quality, thoughtful code.** Module boundaries are crisp; docstrings explain *why*, not
+*what*; the transactional-rollback design is genuinely elegant; tests exercise the real engine (no mocks);
+subprocess hygiene is clean (list-form args everywhere, validated semver before substitution). The
+`Session` snapshot policy is the right abstraction in the right place.
+
+The findings below are mostly about the **gap between the concept's strong claims and what the code
+actually enforces/reports**, plus a few concrete bugs. None are catastrophic; the code is shippable.
+Ordered by severity. File:line references are to the state of the tree on 2026-06-18.
+
+---
+
+## 5. High-severity findings
+
+### H1 — The invariants are largely *not* checked; "canonical" only means "no strays"
+
+**Where:** `state.py:79-81` (`find_strays`), `state.py:148-152` (off-canonical derivation),
+`invariants.py:157-168` (`_postcondition`).
+
+The concept (§5, §11) claims the lane model holds "by construction" across all five invariants, calling
+out **I5 (each lane linear on trunk)** explicitly. In reality the *entire* canonical check reduces to:
+
+1. `find_strays` — non-empty changes descended from trunk that are in no bookmark's ancestry, and
+2. the postcondition's single extra assertion — *did trunk move outside a `land`*.
+
+```python
+# state.py:24-28
+def _stray_revset(trunk: str) -> str:
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+```
+
+Nothing checks:
+
+- **Linearity (I5):** a merge commit on a lane, or a lane that is not linear-on-trunk, is never detected.
+- **Divergence:** two visible commits sharing a `change_id` (a divergent change) is never detected.
+- **I2/I3 beyond the stray scan:** multiple bookmarks on one change, or one lane spanning another lane's
+  head, is not flagged.
+
+`state.py:6-8` is honest internally ("Off-canonical detection is the *basic* form; the authoritative
+transactional invariants live in invariants.py") — but `invariants.py` does **not** in fact add the
+linearity/divergence checks; it only adds the trunk-moved check. So the concept's marketing ("engineered
+so an agent cannot … leave the repo in a shape no one can reason about") oversells the implementation.
+
+**Why it matters:** this *is* the product. The value proposition is that the repo is always in a small,
+reasoned-about shape. If a raw `jj` merge or a divergent rewrite slips past `find_strays`, gitman reports
+CANONICAL and the agent proceeds on a false premise. **This is the single most important doc↔code gap.**
+
+**Impact:** correctness of the core guarantee. Either tighten the checks (add linearity + divergence to
+`capture_state`/precheck) or soften the concept's claims to match "stray detection only."
+
+### H2 — A non-empty, unbookmarked `@` reports CANONICAL (the `~ @` exclusion)
+
+**Where:** `state.py:24-28` (`_stray_revset`), trailing `~ @`.
+
+The stray revset removes the current working-copy change from stray detection. For the *empty* working
+copy that's correct (a fresh `@` shouldn't be a stray). But if `@` is a **non-empty, unbookmarked change
+off trunk** — e.g. the agent ran `jj new main` raw and edited, or work got orphaned — then:
+
+- `status` reports **CANONICAL** with `current_lane: None`,
+- `find_strays` returns `[]` because the only stray *is* `@`, which is excluded.
+
+The orphaned work is real but invisible to the one report that's supposed to be the honest enumeration
+(§16: "every change is *listable*"). Downstream, `do_save` will refuse with "not on a lane"
+(`lanes.py:32-36`), so the agent isn't *silently* wedged — but `status` lied first, and `reconcile`
+(which also uses `find_strays`) won't adopt it either.
+
+**Impact:** honesty of `status`; a recovery path (`reconcile`) that can't see the thing it exists to fix.
+Fix: when `@` is non-empty and unbookmarked and descends from trunk, classify it as off-canonical (a
+distinct reason string), and have `reconcile` adopt/abandon it.
+
+> ⚠ **Implemented (Batch 1) — scoped down.** Shipped as an honest `status` **note** ("working copy @ has
+> unbookmarked work — `gitman start <name>` to adopt it into a lane"), *not* a hard off-canonical flag.
+> Reason discovered during implementation: the `~ @` exclusion is **load-bearing**. `start`'s
+> adopt-in-progress flow runs under `canonical_tx`, whose precheck refuses when off-canonical — so
+> flagging orphan-`@` off-canonical would make `start` refuse the very work it exists to adopt
+> (`test_start_adopts_inprogress_work`), and would also contradict `reconcile` (which can't see `@`). The
+> full fix (option H2a) needs coordinated changes across `capture_state`, the precheck, and `reconcile`,
+> and is deferred to Batch 2 with Theme A. See `REVIEW_REFACTORING_IDEAS.md` §H2 for the full rationale.
+
+### H3 — `release <level>` tags a lane commit that `land` will later rewrite
+
+**Where:** `release.py:58-78`.
+
+On a bump, `release.py` sets `release_point = "@"` and tags the bump commit **on the current lane**:
+
+```python
+# release.py:58-66 (paraphrased)
+if new != current:
+    with canonical_guard(session, "release") as canon:
+        lane = require_current_lane(session, trunk)
+        bump_change_on_lane(session, lane, new, op_desc="gitman:release")
+    release_point = "@"          # ← the bump commit on the LANE, not trunk
+else:
+    release_point = trunk
+...
+head = session.view().resolve(release_point)
+commit = head.commit_id
+tags.create_annotated_tag(repo_root, tag, f"Release {new}", commit)
+```
+
+But §13 says "Release normally happens from a landed change on trunk." Annotated tags are **git-side and
+do not follow jj rewrites**. So if the agent does `release minor` on a lane and *then* `land`s it,
+`tx.rebase(lane, onto=trunk)` churns the `commit_id`, and the tag now points at an **orphaned pre-rebase
+commit** — a dangling release tag that is not an ancestor of trunk.
+
+**Impact:** silent production of a release tag on a commit that won't survive `land`. (This is the
+"release-with-bump caveat" already captured in project memory.) Options: refuse `release <bump>` when the
+release point is an unlanded lane; or land-then-tag; or tag only `trunk`-reachable commits.
+
+### H4 — Multi-lane `land` is per-lane atomic, not per-intent
+
+**Where:** `core.py:291-340` (the `for lane in targets:` loop), `invariants.py:231` (checkpoint write).
+
+§11 promises: "Every Gitman command either lands in a canonical state or didn't happen." But `do_land`
+loops per lane, each under its **own** `canonical_guard`, and each successful guard writes a fresh undo
+checkpoint (overwriting `.gitman/last-undo`). So `gitman land a b c` where `c` conflicts leaves `a` and
+`b` **landed** and only `c` reverted. The end state is canonical, but the command demonstrably "happened"
+partially.
+
+The code is honest about the *outcome* — `BLOCKED`, plus the note "`gitman undo` reverts the last lane
+landed" (`core.py:338`) — but:
+
+- `undo` rewinds only the *last* lane (the last checkpoint), so undoing a 2-of-3 partial land requires
+  multiple `undo`s the report doesn't spell out, and
+- the strict atomic framing in §11 is contradicted by a reasonable but different design (sequential land).
+
+**Impact:** the "all-or-nothing" guarantee is per-lane, not per-intent, for the one intent most likely to
+be invoked with multiple targets. Reconcile the docs with the design, and make the multi-undo affordance
+explicit in the report.
+
+---
+
+## 6. Medium-severity findings
+
+### M1 — `gitman.__version__` is stale and unused; there is no `--version`
+
+**Where:** `src/gitman/__init__.py:9` (`__version__ = "0.1.0"`) vs `pyproject.toml:3` (`version = "0.2.0"`).
+
+The constant drifted and is **never read** anywhere (doctor reports only pyjutsu's version), and the CLI
+exposes **no `--version` flag**. Either single-source it from package metadata
+(`importlib.metadata.version("gitman")`) and wire a `--version`, or delete the drifting constant.
+
+### M2 — `resolve --list` is a dead flag
+
+**Where:** `core.py:417-435` (`do_resolve`), `cli.py:161-168`.
+
+`do_resolve(session, list_)` never references `list_`; `gitman resolve` and `gitman resolve --list`
+behave identically. Either implement the distinction (plain = summary line, `--list` = per-file
+enumeration) or drop the flag.
+
+### M3 — Git/push failures map to exit 1, but §7 says infra is exit 2
+
+**Where:** `core.py:51-52` (`map_pyjutsu_error`: all `GitError` → exit 1), `core.py:262-263`
+(`do_publish`: every push `PyjutsuError` → exit 1 "push rejected").
+
+§7 lists "auth" under exit 2 (infra/config). A network/auth failure on `git_fetch`/`git_push` is infra,
+not a "VC decision." Collapsing every `GitError` into exit 1 muddies the exit-code contract — which is a
+load-bearing part of the agent interface (agents branch on it). Distinguish "push rejected (non-ff /
+needs decision)" → exit 1 from "transport/auth failed" → exit 2.
+
+### M4 — Trunk-vs-remote tracking is modeled but never populated or rendered
+
+**Where:** `models.py:56-59` (`TrunkRef.behind_remote` / `ahead_remote`, always `0`), `state.py:100-102`
+(never filled), `render.py:62` (never shown).
+
+The concept's flagship `status` sample (§16) shows `trunk: main @ def456 (up to date with origin/main)`,
+but the implemented `status` silently omits the trunk's sync state with origin, and the two `TrunkRef`
+fields are dead. Either populate + render them, or delete the fields and adjust the concept sample.
+
+### M5 — `repo_lock` stale-reclaim has an unguarded TOCTOU
+
+**Where:** `invariants.py:106-116`.
+
+```python
+try:
+    fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+except FileExistsError:
+    holder = _read_lock_pid(lock)
+    if holder is not None and _pid_alive(holder):
+        raise GitmanError(...) from None
+    lock.unlink(missing_ok=True)
+    fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)   # ← not guarded
+```
+
+If two processes race to reclaim the same dead-pid lock, the loser's second `os.open` raises a raw
+`FileExistsError` (traceback to the user) instead of the clean `GitmanError`. Wrap the reclaim `os.open`
+in the same handling, or loop with a bounded retry.
+
+### M6 — Every mutating intent computes the full `RepoState` twice
+
+**Where:** `invariants.py:142-168` (`precheck_canonical` and `_postcondition` each call `capture_state`),
+`state.py:110-138` (`capture_state` iterates every lane, calling `view.diff_stat` per change).
+
+A single `save` pays two full state captures plus N diff-stats, when the precheck only needs "any strays?
+is trunk where config says?" Fine at small scale; the first thing to hurt on a repo with many
+lanes/changes. A lightweight `is_canonical()` (strays + trunk only, no diff numbers) for the prechecks
+would roughly halve the per-intent cost.
+
+---
+
+## 7. Low-severity / nits
+
+- **L1 — `land`'s remote-branch delete runs inside the guard, before the postcondition**
+  (`core.py:311-316`). It's best-effort (swallows `PyjutsuError` into a note) so it won't trigger
+  rollback — but if the postcondition failed afterward, `restore_operation` would rewind local state while
+  the remote branch is already gone. Also, unlike `publish` (`core.py:264`), it doesn't warn the remote
+  deletion is one-way (the concept stresses honesty about irreversible actions). Move it after the
+  postcondition and/or add a one-way note.
+
+- **L2 — `do_sync --all` silently staleness-bombs other workspaces** (`core.py:381,398-399`). It rebases
+  every lane, including lanes checked out in *secondary* workspaces; those `@`s become stale and the next
+  intent there refuses with "run reconcile." Mechanically reasonable, but the sync report says nothing.
+
+- **L3 — `run_verify` has no timeout** (`core.py:91-100`). A hanging verify hook hangs gitman with no
+  escape. Add a configurable timeout.
+
+- **L4 — verify runs before the lock in `publish`** (`core.py:252` vs guard at `258`). A long verify
+  window isn't serialized; the I4 "sole writer under a brief lock" story is slightly leakier than it reads.
+
+- **L5 — `do_save` NOOP path snapshots without the lock** (`core.py:220` calls `fresh_view()`, which
+  snapshots `@`, for a pure echo). A read that mutates the op-log should take the lock or use frozen
+  `view()`.
+
+- **L6 — `pick_remote` picks an arbitrary "first" remote** when `origin` is absent (`core.py:103-109`).
+  Acknowledged as MP2 work, but pushing/fetching/tag-pushing to a non-deterministic remote is a latent
+  surprise.
+
+- **L7 — `land` IntentResult omits `state=`** (`core.py:334-340`) while every other mutating intent
+  attaches it — a minor `--json` inconsistency.
+
+- **L8 — `do_init` always writes a fresh `gitman.toml`** (`init.py:124-125`) even if config currently
+  lives in `[tool.gitman]` in pyproject; since `gitman.toml` wins (`config.py:75-84`), you can end up with
+  two config sources, one shadowed.
+
+- **L9 — `reconcile` adopting a *chain* of strays** creates stacked lanes (one lane's ancestry contains
+  another's head). It clears the stray check (canonical=True) but produces non-linear-on-trunk lanes — the
+  same I5 blind spot as H1.
+
+---
+
+## 8. What's done well (preserve)
+
+- **Centralized snapshot policy** (`session.py:74-87`): `view()` vs `fresh_view()` isolates the #1 footgun
+  of frozen pyjutsu reads into one place; `fresh_view` correctly *skips* the snapshot when stale so
+  `status` reports instead of crashes.
+- **The transactional rollback design** (`invariants.py`): `canonical_tx` vs `canonical_guard` over the
+  op-log, reusing the same lever as `undo`. Capturing `op_before` *after* the precheck snapshot
+  (`invariants.py:200`) for a deterministic parent is a subtle, correct detail.
+- **Lazy imports in `cli.py`** keep startup fast — right for a tool an agent shells out to constantly.
+- **Subprocess hygiene** (`tags.py`, `run_verify`, version hooks): list-form args (no shell), and
+  `{version}` is validated semver before substitution — no injection surface.
+- **`.gitman/` self-ignoring** (`invariants.py:67-76`): gitman's own state never pollutes the working copy
+  regardless of repo `.gitignore`.
+- **Tests run against the real in-process engine**, including a bare-git-remote round trip, stale refusal,
+  trunk-rewrite revert, conflict-as-commit, and per-intent undo round-trips. The right test posture.
+
+---
+
+## 9. Summary table
+
+Status: ✅ done (Batch 1) · ◑ partial · ⏳ open. See `REVIEW_REFACTORING_IDEAS.md` for the batch plan.
+
+| Sev | ID | Status | Finding | Primary location |
+|---|---|---|---|---|
+| High | H1 | ⏳ | Invariants barely checked; "canonical" == "no strays" (no linearity/divergence) | `state.py:24-28,79-81`; `invariants.py:157-168` |
+| High | H2 | ◑ | Non-empty orphan `@` reports CANONICAL (`~ @` in stray revset) — *status note shipped; full off-canonical deferred* | `state.py:24-28` |
+| High | H3 | ⏳ | `release <bump>` tags a lane commit that `land` rewrites → dangling tag | `release.py:58-78` |
+| High | H4 | ◑ | Multi-lane `land` is per-lane atomic, not per-intent; undo rewinds only last — *report wording shipped; H4c batch-checkpoint deferred* | `core.py:291-340` |
+| Med | M1 | ✅ | `__version__` drift (0.1.0 vs 0.2.0) + no `--version`; unused | `__init__.py:9` |
+| Med | M2 | ✅ | Dead `resolve --list` flag | `core.py:417-435` |
+| Med | M3 | ⏳ | Push/git errors → exit 1, but §7 says infra = exit 2 | `core.py:51-52,262-263` |
+| Med | M4 | ⏳ | `TrunkRef` remote fields modeled but never populated/rendered | `models.py:56-59`; `state.py`; `render.py` |
+| Med | M5 | ✅ | `repo_lock` stale-reclaim TOCTOU (unguarded 2nd `os.open`) | `invariants.py:106-116` |
+| Med | M6 | ⏳ | Full `RepoState` captured twice per mutating intent | `invariants.py:142-168`; `state.py:110-138` |
+| Low | L1 | ✅ | `land` remote delete sequencing + missing one-way note | `core.py:311-316` |
+| Low | L2 | ⏳ | `sync --all` silently staleness-bombs other workspaces | `core.py:381,398-399` |
+| Low | L3 | ✅ | `run_verify` has no timeout | `core.py:91-100` |
+| Low | L4 | ⏳ | verify runs before the lock in `publish` | `core.py:252,258` |
+| Low | L5 | ✅ | `do_save` NOOP snapshots without the lock | `core.py:220` |
+| Low | L6 | ⏳ | `pick_remote` arbitrary "first" remote | `core.py:103-109` |
+| Low | L7 | ✅ | `land` result omits `state=` (json inconsistency) | `core.py:334-340` |
+| Low | L8 | ✅ | `init` always writes `gitman.toml` (can shadow pyproject config) | `init.py:124-125` |
+| Low | L9 | ⏳ | `reconcile` chain-of-strays creates stacked lanes | `reconcile.py:36-47` |
+
+**Highest leverage:** close the gap between invariant *claims* and invariant *checks* (H1/H2) — that's
+the product. Then the `release`-on-lane footgun (H3) and the exit-code contract (M3).
+
+See `REVIEW_REFACTORING_IDEAS.md` for concrete options to address each finding.

--- a/.scratch/projects/04-gitman-code-review/REVIEW_REFACTORING_IDEAS.md
+++ b/.scratch/projects/04-gitman-code-review/REVIEW_REFACTORING_IDEAS.md
@@ -1,0 +1,352 @@
+# Gitman — Refactoring Ideas & Options
+
+Companion to `CODE_REVIEW.md`. For each finding it lays out **options with trade-offs**, a
+**recommendation**, and a rough **effort** estimate (S = <1h, M = a few hours, L = a day+).
+
+> **Implementation status (2026-06-18): Batch 1 is DONE.** Shipped: **M1, M2, M5, L1, L3, L5, L7, L8**,
+> and **H2** (with a scoped-down approach — see the note in §H2). Tests in
+> `tests/test_batch1_review_fixes.py` (8 new; 44 total pass, lint clean). Batches 2–3 (H1, H3, H4, M3,
+> M4, M6, L2, L4, L6, L9) remain open. Per-finding "✅ Implemented / ⏳ Open" tags are inline below.
+
+A recurring theme: several findings are really one decision — **how much of the lane model do we enforce
+vs. document?** That decision (Theme A below) drives H1, H2, L9, and parts of M6. Settle it first.
+
+---
+
+## Theme A — Enforcement vs. documentation (drives H1, H2, L9, M6)
+
+Today `canonical` means "no non-empty unbookmarked changes off trunk, excluding `@`." The concept claims
+more (linearity I5, no divergence, every change in exactly one lane). Three coherent stances:
+
+### Option A1 — Tighten the checks to match the claims *(recommended)*
+Extend canonicity to actually test the invariants it advertises:
+
+- **Divergence:** flag any `change_id` with >1 visible commit. pyjutsu exposes commits per change; a
+  revset like `bookmarks() & divergent()` (or grouping `log()` output by `change_id`) gives this cheaply.
+- **Linearity (I5):** for each lane, assert `trunk..lane` is a single linear chain — i.e. no commit in the
+  range has >1 parent within the range (no merges) and the range is a path. Can be checked from the
+  `log()` parent edges already returned.
+- **Orphan `@` (H2):** drop the `~ @` exclusion *conditionally* — exclude `@` only when it is empty.
+
+Add these to `capture_state`'s off-canonical derivation with distinct reason strings, and let `reconcile`
+key off the reason to choose a fix.
+
+- **Pros:** the product delivers its core promise; `status`/`reconcile` become trustworthy.
+- **Cons:** more pyjutsu calls per capture; need to confirm which revset helpers pyjutsu 0.38 exposes
+  (`divergent()`, parent edges) — may need a small pyjutsu addition.
+- **Effort:** M–L (L if pyjutsu needs a new binding).
+
+### Option A2 — Keep checks minimal, soften the concept doc
+Leave detection as "stray + trunk-moved," and rewrite §5/§11 to claim only that. Rely on "gitman is the
+sole writer" (I4) to keep linearity/divergence from ever arising *through gitman*, and treat external
+raw-`jj` damage as out of scope beyond stray detection.
+
+- **Pros:** zero code risk; honest about current behavior; fast.
+- **Cons:** weakens the headline guarantee; H2's orphan-`@` blind spot persists; external merges still
+  silently pass as canonical.
+- **Effort:** S (doc only).
+
+### Option A3 — Hybrid: cheap checks now, full checks later
+Do H2 (the `~ @` fix — small and high-value) and divergence (usually a one-liner) now; defer full
+linearity to a later milestone with a `# TODO(I5)` and a doc footnote.
+
+- **Pros:** closes the most visible holes immediately at low risk.
+- **Cons:** I5 still unenforced in the interim.
+- **Effort:** S–M.
+
+**Recommendation:** **A3 now, A1 as the target.** Ship the orphan-`@` fix + divergence check immediately;
+schedule linearity once the pyjutsu surface is confirmed. Update the concept doc either way so claims and
+code never disagree.
+
+---
+
+## H1 — Invariants barely checked ⏳ Open (Theme A / Batch 2)
+
+Covered by **Theme A**. Concretely, the work is:
+
+1. Add `_divergence_revset` / a change-id grouping pass to `state.py` → off-canonical reason.
+2. Add a linearity check per lane in `capture_state` (reuse the `range_changes` already fetched at
+   `state.py:116`, inspect parent edges) → off-canonical reason.
+3. Thread the new reasons through `render_status` (`render.py:48-57`) and `reconcile` so each has a
+   recovery path.
+4. Add integration tests: external merge commit on a lane → OFF-CANONICAL; divergent change →
+   OFF-CANONICAL; `reconcile` linearizes or reports honestly.
+
+**Effort:** M–L. **Depends on:** confirming pyjutsu exposes parent edges + divergence.
+
+---
+
+## H2 — Non-empty orphan `@` reports CANONICAL ✅ Implemented (scoped down — H2c, not H2a)
+
+> **What shipped (Batch 1):** an honest `status` **note**, *not* a hard off-canonical flag. During
+> implementation H2a turned out to be **unsafe in isolation** (see "Why H2a was rejected" below), so it
+> was scoped to the note (option **H2c**). Full off-canonical classification is deferred to Batch 2,
+> where the canonicity predicate and precheck are reworked together (Theme A).
+>
+> Code: `state.py` adds `_orphan_working_copy(view, wc, trunk)` (non-empty + no bookmark + descends
+> trunk) and, when `current_lane is None`, appends the note *"working copy @ has unbookmarked work —
+> `gitman start <name>` to adopt it into a lane."* The `canonical` flag is unchanged. Tests:
+> `test_orphan_working_copy_surfaces_note` and `test_empty_working_copy_has_no_orphan_note`.
+
+### Why H2a was rejected (the discovery)
+The `~ @` exclusion in `_stray_revset` is **load-bearing**, not an oversight. Two mechanisms depend on a
+non-empty `@` *not* being treated as off-canonical:
+
+1. **`start`'s adopt-in-progress flow** (`core.py:_adoptable_work` / `do_start`). The normal "edit, then
+   `gitman start`" path leaves `@` non-empty and unbookmarked *by design*; `start` folds it into the new
+   lane. But `do_start` (non-workspace) runs under `canonical_tx`, whose **precheck refuses to act when
+   off-canonical**. So flagging orphan-`@` as off-canonical makes `start` refuse the very work it exists
+   to adopt — `test_start_adopts_inprogress_work` would fail.
+2. **`reconcile` can't see `@`.** `reconcile` also keys off `find_strays`, which excludes `@`. If `status`
+   said OFF-CANONICAL for an orphan `@`, `reconcile` would then report "already canonical — no strays" —
+   a direct contradiction in the one recovery path.
+
+So a *correct* H2a is not a one-line revset tweak; it requires coordinating three call sites
+(`capture_state`, the precheck, and `reconcile`) — which is Batch-2-sized and overlaps Theme A.
+
+### Option H2c — honest note, leave `canonical` alone *(shipped)*
+- **Pros:** fixes the actual review complaint ("`status` lied") without destabilizing adopt/precheck;
+  truly low-risk; no false-alarm on the normal edit-then-start flow (once `start` runs, `@` has a
+  bookmark → note clears).
+- **Cons:** `@` is still technically `canonical: true` in the JSON; full enforcement deferred.
+- **Effort:** S. **Done.**
+
+### Option H2a — Conditional `@` exclusion + precheck/reconcile coordination ⏳ deferred to Batch 2
+Exclude `@` from strays only when empty, **and** teach the precheck to tolerate an adoptable orphan `@`
+(so `start` still works) **and** extend `reconcile` to adopt/abandon a non-empty `@`. Reason string:
+`"working copy @ has unbookmarked work — gitman start <name> to adopt it, or gitman reconcile"`.
+
+- **Pros:** the strong, fully-honest behavior the review asked for.
+- **Cons:** touches three call sites; must not regress the adopt flow; pairs with Theme A's rework.
+- **Effort:** M (was mis-estimated as S before the discovery above).
+
+### Option H2b — Auto-adopt in `start` already covers it
+Argue `do_start`'s adopt path already folds in-progress `@` work, so no `status` change is needed.
+
+- **Cons:** doesn't help `status`/`reconcile` honesty; the agent has to *know* to run `start`. Rejected.
+
+**Outcome:** **H2c shipped** as the low-risk Batch 1 fix; **H2a deferred** to Batch 2 alongside Theme A.
+
+---
+
+## H3 — `release <bump>` tags a lane commit `land` will rewrite ⏳ Open (Batch 3)
+
+### Option H3a — Refuse bump-release off trunk *(recommended, safest)*
+In `do_release` (`release.py:32-66`), if `new != current` (a bump) and the current lane is not yet landed
+(i.e. the release point would be a lane commit, not trunk-reachable), refuse with exit 1 and the
+instruction: "bump on a lane, `gitman land`, then `gitman release` from trunk." This matches §13 ("Release
+normally happens from a landed change on trunk").
+
+- **Pros:** eliminates the dangling-tag footgun; smallest behavior change; clearest mental model.
+- **Cons:** removes the one-shot "bump+tag" convenience on a lane.
+- **Effort:** S.
+
+### Option H3b — Land-then-tag inside `release`
+Make bump-release do: bump → land the lane → tag the resulting trunk commit. One atomic-ish flow.
+
+- **Pros:** keeps the convenience; tag always lands on trunk.
+- **Cons:** `release` silently performing a `land` is a big, surprising side effect; multi-op and
+  conflict-prone (what if land conflicts mid-release?); harder to undo cleanly.
+- **Effort:** M–L.
+
+### Option H3c — Only ever tag trunk-reachable commits + warn
+Allow the bump on the lane but tag only if the bump commit is an ancestor of trunk; otherwise create the
+tag but emit a loud one-way warning that `land` will orphan it.
+
+- **Pros:** minimal restriction.
+- **Cons:** still produces dangling tags; a warning an agent may ignore. Weakest.
+- **Effort:** S.
+
+**Recommendation:** **H3a.** Update `test_release_with_bump_tags_and_bumps` to reflect the new contract
+(bump on lane is allowed; *tagging* off an unlanded lane is refused), or restructure the test to land
+first.
+
+---
+
+## H4 — Multi-lane `land` per-lane vs per-intent atomicity ⏳ Mostly open (Batch 2)
+
+> **Partial (Batch 1, incidental):** the **report-wording half of H4a shipped** as a side effect of the
+> `land` rework for L1/L7 — both the `BLOCKED` and `LANDED` results now note *"`gitman undo` reverts one
+> lane at a time — run it N× to undo all"* when >1 lane landed (`core.py`). **Still open:** the §11
+> concept-doc softening (not yet edited), and the **H4c batch-checkpoint** behavior (one `undo` rewinds
+> the whole multi-land), which is the recommended target.
+
+### Option H4a — Document the sequential semantics + improve the report *(recommended)*
+Keep the sequential design (it's the right one for conflict surfacing — §20 explicitly lists "land
+ordering: sequential rebase with conflict surfacing per lane"). Just align the docs and the report:
+
+- Soften §11's "either … or didn't happen" to "each command leaves the repo canonical; multi-target
+  `land` is sequential and stops at the first conflict, having landed the prior targets."
+- In the `BLOCKED` result (`core.py:324-333`), when >1 lane landed before the block, list them and say
+  "to undo all, run `gitman undo` once per landed lane (N times)."
+
+- **Pros:** no behavior change; honest; cheap.
+- **Effort:** S.
+
+### Option H4b — True all-or-nothing multi-land
+Wrap all targets in a single `canonical_guard` + single transaction; one undo checkpoint for the whole
+batch; any conflict reverts everything.
+
+- **Pros:** matches the strict §11 framing literally.
+- **Cons:** loses partial progress on a multi-land (all-or-nothing means one bad lane discards good
+  landings); larger transaction; arguably *worse* UX for the parallel-agent merge-back scenario.
+- **Effort:** M.
+
+### Option H4c — Batch checkpoint, keep per-lane execution
+Execute sequentially but record a *single* undo checkpoint at the very first `op_before`, so one
+`gitman undo` rewinds the entire multi-land regardless of how many lanes landed.
+
+- **Pros:** "one undo undoes the whole `land` command" — intuitive; keeps partial-progress visibility.
+- **Cons:** slightly more bookkeeping (don't overwrite the checkpoint per lane; write once).
+- **Effort:** S–M.
+
+**Recommendation:** **H4c + the H4a report wording.** One-undo-per-command is the least surprising
+contract and is cheap to implement: capture the batch `op_before` before the loop, and write the
+checkpoint once after the loop (or in the `finally`/block-exit) instead of per-guard.
+
+---
+
+## M1 — Version drift + no `--version` ✅ Implemented
+
+### Recommendation *(S)* — done
+- ✅ `__init__.py` now derives `__version__` from `importlib.metadata.version("gitman")`, with a
+  `PackageNotFoundError` fallback of `"0+unknown"` for a raw (uninstalled) checkout.
+- ✅ Added a `--version` eager option to the Typer callback (`cli.py:_version_callback`) that prints
+  `gitman <version>` and exits. Verified end-to-end: `gitman --version` → `gitman 0.2.0`.
+- ⏳ Not done (optional): surfacing it in `doctor` alongside the pyjutsu line — low value, skipped.
+
+**Tests:** `test_version_is_single_sourced`, `test_cli_version_flag`.
+
+---
+
+## M2 — Dead `resolve --list` flag ✅ Implemented (M2a)
+
+### Option M2a — Implement the distinction *(shipped)*
+✅ `do_resolve` (`core.py`) now branches on `list_`: plain `resolve` → a one-line summary (e.g.
+`"2 conflicted files at @; 1 conflicted lane(s): feat  (\`gitman resolve --list\` for files)"`), and
+`--list` → the full per-file enumeration. Mirrors `undo`'s `--list` shape.
+
+**Tests:** `test_resolve_plain_is_a_summary`, `test_resolve_list_enumerates_files`.
+
+### Option M2b — Drop the flag *(not chosen)*
+Would have removed `list_` entirely. Rejected in favour of the more useful M2a.
+
+---
+
+## M3 — Exit-code contract for git/push failures ⏳ Open (Batch 3)
+
+### Recommendation *(M)*
+Split transport/auth from rejection:
+
+- In `map_pyjutsu_error` (`core.py:33-57`), if pyjutsu distinguishes a non-fast-forward / rejected push
+  from a transport/auth error, map the former → exit 1, the latter → exit 2. If pyjutsu only exposes a
+  single `GitError`, inspect the message (best-effort) or add a pyjutsu error subtype.
+- In `do_publish` (`core.py:260-263`), only call it "push rejected" (exit 1) for the non-ff case;
+  transport/auth → exit 2 "could not reach remote."
+
+**Trade-off:** depends on pyjutsu's error granularity; may need an upstream pyjutsu change (track in the
+pyjutsu rough-edges notes). If blocked upstream, document the current exit-1-for-all behavior as interim.
+
+---
+
+## M4 — Unpopulated `TrunkRef` remote fields ⏳ Open (Batch 3)
+
+### Option M4a — Populate + render *(recommended)*
+In `capture_state`, if a remote-tracking bookmark for trunk exists, compute `ahead_remote`/`behind_remote`
+(`len(view.log("trunk..trunk@origin"))` and the reverse). Render in `render_status`'s trunk line
+(`render.py:62`) as the §16 sample shows: `trunk: main @ def456 (up to date with origin/main | 2 behind)`.
+
+- **Pros:** delivers the concept's status sample; useful staleness signal before `sync`.
+- **Cons:** two more revset reads per `status` (cheap); need the remote-tracking name convention from
+  pyjutsu.
+- **Effort:** M.
+
+### Option M4b — Delete the fields
+Remove `behind_remote`/`ahead_remote` from `TrunkRef` and adjust the §16 sample.
+
+- **Effort:** S. Pick M4a — the info is genuinely useful to an agent deciding whether to `sync`.
+
+---
+
+## M5 — `repo_lock` stale-reclaim TOCTOU ✅ Implemented
+
+> **Shipped (Batch 1)** essentially as written below: `repo_lock` (`invariants.py`) now loops the
+> O_EXCL create (bounded to 2 attempts), re-checking the holder after a failed reclaim and raising a
+> clean `GitmanError` instead of a raw `FileExistsError`. The docstring documents the residual narrow
+> window (a reclaimer could unlink a lock another process just acquired) — strictly rarer than the old
+> unconditional second `os.open`; the common single-reclaimer case is correct. (Not unit-tested: the
+> race is non-deterministic, as noted in the trade-off.)
+
+### Recommendation *(S)* — done
+Wrap the reclaim path in a bounded retry:
+
+```python
+for attempt in range(2):
+    try:
+        fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        break
+    except FileExistsError:
+        holder = _read_lock_pid(lock)
+        if holder is not None and _pid_alive(holder):
+            raise GitmanError(f"... pid {holder}", exit_code=2) from None
+        lock.unlink(missing_ok=True)   # reclaim, then loop retries the O_EXCL open
+else:
+    raise GitmanError("could not acquire repo lock (contended).", exit_code=2)
+```
+
+**Trade-off:** marginally more code; eliminates the raw-traceback race. Hard to unit-test
+deterministically; a comment documenting the race is worthwhile.
+
+---
+
+## M6 — Full `RepoState` captured twice per intent ⏳ Open (Batch 2)
+
+### Option M6a — Lightweight `is_canonical()` for prechecks *(recommended)*
+Add a cheap check that computes only strays (+ the new linearity/divergence flags from Theme A) and the
+trunk commit — **no** per-lane diff_stat loop. Use it in `precheck_canonical` and `_postcondition`;
+reserve full `capture_state` for `status` and for the `IntentResult.state` payload (one capture at the
+end, not two).
+
+- **Pros:** ~halves per-intent cost; keeps the rich state only where it's rendered.
+- **Cons:** two code paths to keep in sync re: what "canonical" means — mitigate by having the full
+  `capture_state` *call* the cheap predicate rather than duplicating logic.
+- **Effort:** M (do it together with Theme A so the canonicity logic lives in one place).
+
+### Option M6b — Cache one capture per Session
+Memoize `capture_state` on the `Session` and invalidate after each tx. Less clean (the pre/post states
+must differ), so prefer M6a.
+
+---
+
+## Low-severity quick wins
+
+| ID | Status | Fix | Effort |
+|---|---|---|---|
+| L1 | ✅ done | Moved `land`'s remote-branch delete after `_postcondition`; note now says it's one-way | S |
+| L2 | ⏳ open | In `sync --all`, list lanes whose workspaces are now stale + nudge `reconcile` there | S |
+| L3 | ✅ done | Added `timeout=` to `run_verify`; new `[publish] verify_timeout` config key (wired into publish + release) | S |
+| L4 | ⏳ open | Move the verify call inside the lock window in `publish` (or document why it's outside) | S |
+| L5 | ✅ done | `do_save` NOOP now uses frozen `view()` (description is commit metadata; no snapshot/lock) | S |
+| L6 | ⏳ open | Make `pick_remote` deterministic (sorted) or require explicit config when origin absent; revisit at MP2 | S |
+| L7 | ✅ done | Attached `state=` to `land`'s `IntentResult` (both LANDED and BLOCKED) for `--json` parity | S |
+| L8 | ✅ done | `do_init` now warns when a non-empty `[tool.gitman]` in pyproject is shadowed by the new `gitman.toml` | S |
+| L9 | ⏳ open | Folded into Theme A (linearity) — adopting a stray chain should produce one linear lane or report | M |
+
+Batch 1 shipped L1, L3, L5, L7, L8. Open: L2, L4, L6 (Batch 3) and L9 (Theme A / Batch 2).
+
+---
+
+## Suggested sequencing
+
+1. **Decide Theme A** (A3 recommended). This unblocks H1, H2(full), L9, and the shape of M6.
+2. **✅ Batch 1 — small, high-value, low-risk — DONE (2026-06-18):** M1, M2, M5, L1, L3, L5, L7, L8,
+   and H2 (shipped as the orphan-`@` *note*, H2c, not the full off-canonical flag — see §H2). The H4a
+   report wording also landed incidentally via the `land` rework.
+3. **Batch 2 — the core guarantee (1–2 days):** H1 (divergence + linearity), H2a (full off-canonical
+   `@` + precheck/reconcile coordination), M6a (shared canonicity predicate), H4c (one-undo-per-command)
+   + the §11 concept-doc reconciliation, L9.
+4. **Batch 3 — contracts & polish (½–1 day):** H3a (refuse bump-tag off trunk), M3 (exit-code split,
+   possibly gated on a pyjutsu error subtype), M4a (trunk-vs-remote in `status`), L2, L4, L6.
+
+After each batch: `ruff check src tests && pytest -q` inside devenv. **Batch 1 result: 44 passed, lint
+clean** (36 original regression net + 8 new in `tests/test_batch1_review_fixes.py`).

--- a/.scratch/projects/05-bootstrap-issues/gitman-pyjutsu-bootstrap-issues.md
+++ b/.scratch/projects/05-bootstrap-issues/gitman-pyjutsu-bootstrap-issues.md
@@ -1,0 +1,200 @@
+# Gitman / pyjutsu bootstrap issues (found wiring citegeist)
+
+> Context: bootstrapping gitman in the **citegeist** repo — an *existing* git repo
+> (one "Initial commit", plus uncommitted work) inside a devenv that provides
+> **pyjutsu 0.7.0 (jj-lib 0.38.0)** but **no `jj` CLI binary**. Goal was simply
+> "commit step 1 via gitman". It took ~6 dead-ends; each is a concrete, fixable gap.
+>
+> Environment facts that matter:
+> - gitman's repoman manager module contributes pyjutsu + Rust/maturin but **not** a
+>   `jj` binary.
+> - `nixpkgs` (devenv rolling) ships **jujutsu 0.42.0**; pyjutsu's `JJ_LIB_TARGET` is
+>   **0.38.0**. So the only available external `jj` is 4 minors ahead of the linked lib.
+
+---
+
+## Issue 1 — pyjutsu `Workspace.init(colocate=True)` can't adopt an existing `.git`
+
+**Severity:** high (blocks the documented bootstrap on any existing git repo).
+
+`pyjutsu.Workspace.init(path, colocate=True)` binds jj-lib's `Workspace::init_colocated_git`
+directly (`Pyjutsu/src/workspace.rs:698-699`). When the directory already contains a
+`.git`, it fails:
+
+```
+_pyjutsu.WorkspaceError: Failed to initialize git repository
+```
+
+The real `jj git init --colocate` *adopts* an existing colocated git (creates `.jj`
+backed by the existing `.git`, importing refs). pyjutsu only supports the "create a
+fresh git repo" path. The Python docstring even says *"Raises WorkspaceError if `path`
+already holds a repo"* — so this is known, but it means **pyjutsu alone cannot bootstrap
+gitman into an existing repo.**
+
+**Suggested fix (pyjutsu):** bind the adopt-existing path too. jj-lib / the jj CLI's
+`git init --colocate` detects an existing `.git` and runs an import rather than a fresh
+init. Expose e.g. `Workspace.init(path, colocate=True, adopt_existing=True)` (or detect
+an existing `.git` and branch internally). Without this, gitman *requires* an external
+`jj` binary just to start — which is the whole problem below.
+
+---
+
+## Issue 2 — version-skew: pyjutsu 0.38 reads a jj-0.42-written workspace path as `'../../'`
+
+**Severity:** high (silent, produces a confusing wrong state).
+
+Because pyjutsu can't adopt (Issue 1), the fallback was the gitman-doctor-prescribed
+`jj git init --colocate` using the only available binary (**jj 0.42**). It "succeeded",
+but then **pyjutsu 0.38 misreads the metadata jj 0.42 wrote**:
+
+```python
+ws = pyjutsu.Workspace.load(repo)
+for w in ws.workspaces():
+    print(w.name, repr(w.path))
+# default '../../'          <-- relative, wrong
+```
+
+So the default workspace's `path` came back as the relative string `'../../'` instead of
+the absolute repo root. (Verified: when pyjutsu 0.38 *both writes and reads* — i.e. a
+clean `Workspace.init` with no external jj involved — the same call returns the correct
+absolute path `/home/andrew/Documents/Projects/citegeist`.)
+
+**Root cause:** format/relativization skew between the jj 0.42 binary's stored workspace
+path and what jj-lib 0.38 (pyjutsu) expects to read.
+
+**Suggested fixes:**
+- **pyjutsu:** make `WorkspaceInfo.path` always absolute — resolve any stored relative
+  path against the repo/workspace root before returning. A relative `path` leaking out of
+  the typed API is a footgun regardless of where it came from.
+- **Toolchain:** gitman's repoman manager module should pin a `jj` binary matching
+  `pyjutsu.JJ_LIB_TARGET` (0.38.0), or — better — remove the need for an external `jj`
+  entirely by fixing Issue 1. Mixing jj 0.42 with jj-lib 0.38 is the trigger here.
+
+---
+
+## Issue 3 — gitman `_shared_root` trusts `w.path` is absolute
+
+**Severity:** medium (defensive gap; turns Issue 2 into a hard failure).
+
+`gitman/src/gitman/session.py` `_shared_root`:
+
+```python
+for w in ws.workspaces():
+    if w.name == "default" and w.path:
+        return Path(w.path)          # <-- trusts absolute
+```
+
+With Issue 2's `'../../'`, this returns `PosixPath('../..')`, and every downstream
+`repo_root / ".git"` / `repo_root / ".jj"` check resolves against the wrong place.
+
+**Suggested fix (gitman):** resolve defensively against the known root:
+`return (ws.root / w.path).resolve()` (or `Path(w.path).resolve()` anchored at
+`ws.root`). gitman would then have survived Issue 2 entirely.
+
+---
+
+## Issue 4 — `gitman doctor` and `gitman init` disagree on "is this colocated?"
+
+**Severity:** medium (very confusing UX).
+
+In the same directory, at the same moment:
+
+```
+gitman init --trunk main   ->  "not a colocated jj repo — run `jj git init --colocate`."  (exit 2)
+gitman doctor              ->  "ok colocated  .git + .jj present"  ... "HEALTHY"           (exit 0)
+```
+
+Both call a byte-identical `_is_colocated(repo_root)` (`doctor.py:41`, `state.py:31`) —
+but with **different `repo_root`s**. `do_init` uses `session.repo_root`
+(`= _shared_root(ws)`, the broken `'../..'` from Issues 2/3). `doctor` evidently resolves
+the root another way (filesystem / cwd) and so passes. A user sees "doctor says HEALTHY
+and colocated" but "init says not colocated" and has no way to reconcile it.
+
+**Suggested fix (gitman):** one root-resolution path for all commands. If `_shared_root`
+is the canonical answer, doctor should use it too (and would then have surfaced the real
+problem); if the filesystem answer is canonical, init should use it. Don't let two
+notions of "the repo root" diverge.
+
+---
+
+## Issue 5 — pyjutsu `git_export` doesn't sync git `HEAD` (colocated git left broken)
+
+**Severity:** medium (colocated git tooling is unusable until HEAD is fixed).
+
+After seeding a commit via pyjutsu and calling `ws.git_export()`:
+
+```
+$ git show-ref
+8b09963... refs/heads/main          # <-- correct, the seed commit
+$ cat .git/HEAD
+ref: refs/jj/root                   # <-- HEAD parked at jj's sentinel
+$ git log            ->  fatal: your current branch 'refs/jj/root' does not have any commits yet
+$ git status         ->  On branch refs/jj/root / No commits yet
+$ git log main       ->  8b09963 Initial commit: ...   # only works with an explicit ref
+```
+
+`git_export` writes `refs/heads/<bookmark>` but never updates `.git/HEAD`. The real `jj`
+CLI keeps git `HEAD` detached at `@`'s parent on every operation, so colocated `git
+log`/`git status` stay sane. With pyjutsu, bare git is broken even though the branch refs
+are correct.
+
+**Suggested fix (pyjutsu):** on `git_export` (or as an explicit `sync_git_head()`),
+update `.git/HEAD` to `@`'s parent commit (detached), matching jj-CLI colocation
+semantics.
+
+---
+
+## Issue 6 — no gitman-native way to make the *first* commit of a repo
+
+**Severity:** medium (design gap; every fresh adoption hits it).
+
+Once colocated + `gitman init`'d, trunk `main` sits on `@`, and `@` holds all the
+not-yet-described file changes. From there:
+
+- `gitman save -m ...` → **"not on a lane — run `gitman start <name>` first."** (no
+  direct-to-trunk commits, by design).
+- `gitman start <name>` → `_adoptable_work` (`core.py`) returns **False** because `@`
+  *has a bookmark* (trunk is on it), so it takes the `else` branch: `tx.new(trunk)` after
+  the precheck snapshot **folds all files into the trunk commit** and creates an *empty*
+  lane. The real content ends up undescribed on trunk and the lane/`save`/`land` describe
+  an empty change. Wrong outcome.
+
+There's no clean front-door path to seed "the initial commit that already exists on
+disk." We worked around it by seeding directly via pyjutsu (snapshot → `tx.describe("@")`
+→ `tx.new("@")` so trunk = the described seed and `@` = a fresh empty child), then
+`git_export`. That's a bootstrap *outside* the lane model.
+
+**Suggested fixes (gitman), any of:**
+- A `gitman init --seed -m "..."` (or a `gitman seed`) that makes the first described
+  commit on trunk and leaves a clean empty `@`.
+- Teach `start`/adoption to handle "trunk bookmark is on `@` and `@` has changes": move
+  trunk to an empty base and adopt the changes as the lane, instead of folding into trunk.
+- At minimum, document the bootstrap recipe in the gitman skill ("adopting an existing
+  repo / first commit").
+
+---
+
+## What actually worked (end-to-end recipe, for reference)
+
+For an existing git repo, in a devenv with pyjutsu 0.38 + jj 0.38 binary available:
+
+1. `rm -rf .git .jj` (only because we chose a clean re-init; not required if Issue 1 is fixed).
+2. Ensure jj identity exists (we wrote `~/.config/jj/config.toml` `[user] name/email`);
+   gitman/pyjutsu author commits from jj settings — there is no gitman-level identity.
+3. `pyjutsu.Workspace.init(repo, colocate=True)` on the clean dir → correct absolute
+   workspace path (no Issue 2).
+4. `gitman init --trunk main` → HEALTHY, trunk frozen.
+5. Seed the first commit via pyjutsu (no gitman path exists — Issue 6):
+   `with ws.transaction(...) as tx: tx.describe("@", msg); tx.new("@")`.
+6. `ws.git_export()` → `refs/heads/main` correct (but fix HEAD per Issue 5).
+7. `gitman status` → CANONICAL. From here, normal `gitman start/save/land` works.
+
+## Priority recommendation
+
+1. **pyjutsu Issue 1** (adopt existing `.git`) — removes the need for an external `jj`
+   binary, which is what dragged in the version skew (Issues 2). Highest leverage.
+2. **pyjutsu Issue 2 + gitman Issue 3** (absolute workspace paths / defensive resolve) —
+   cheap, prevents a silent wrong-state.
+3. **gitman Issue 6** (first-commit bootstrap) — every repo adoption needs it.
+4. **gitman Issue 4** (single root resolution) and **pyjutsu Issue 5** (HEAD sync) —
+   correctness/UX polish.

--- a/.scratch/projects/06-stray-tags-and-divergent-reconcile/issue-overview.md
+++ b/.scratch/projects/06-stray-tags-and-divergent-reconcile/issue-overview.md
@@ -1,0 +1,189 @@
+# 06 — Stray detection vs git tags + `reconcile` vs divergent changes
+
+> **Found:** 2026-06-22, recovering a colocated `.jj` in this repo after it was re-adopted from the
+> (correct) colocated git via `pyjutsu.Workspace.init(".", colocate=True)`. The git side was right —
+> `HEAD = origin/main`, working tree clean — yet `gitman status` reported OFF-CANONICAL and
+> **`gitman reconcile` could not recover it**. Two gitman-side defects combined to make a healthy repo
+> both *look* broken and be *unrecoverable through the front door*. This is the gitman half of the fix;
+> the pyjutsu half (what the adopt imports) lives in `Pyjutsu/.scratch/projects/10-adopt-tag-visibility-and-keep-refs`.
+
+## TL;DR — required fixes
+
+| # | Fix | File | Severity |
+|---|-----|------|----------|
+| G1 | Stray detection must **exclude git-tagged commits** — a release tag is not "work edited outside Gitman" | `src/gitman/state.py` `_stray_revset` | medium |
+| G2 | `reconcile` must handle **divergent** strays — operate by **commit-id**, not the shared change-id | `src/gitman/reconcile.py` `do_reconcile` | high |
+
+G2 is the more serious of the two: when a stray's change-id is divergent, **both** `reconcile`
+(adopt) **and** `reconcile --abandon` hard-fail, so the documented "single recovery path from
+off-canonical" (concept §11, §20) is a dead end. G1 is what *creates* the spurious off-canonical
+state in the first place for any repo that carries a tag on an off-main commit.
+
+---
+
+## The scenario (concrete)
+
+Repo had tags `v0.1.0` (on-main), `v0.2.0` → **`c2a8443`** ("Bump version to 0.2.0", **off-main** — the
+0.2.0 release commit was rebased out of `main`'s ancestry by a later rewrite), `v0.2.1` (on-main). A
+fresh adopt imports all refs incl. tags (jj-standard `git import`), so `c2a8443` is a visible head.
+
+```
+$ gitman status
+Gitman status — OFF-CANONICAL
+Reason: change(s) poosovxywrxs… belong to no lane (edited outside Gitman?).
+
+$ gitman reconcile           # adopt the stray into a lane
+bad revision/revset: Change ID `poosovxywrxs…` is divergent
+$ gitman reconcile --abandon # …or discard it
+bad revision/revset: Change ID `poosovxywrxs…` is divergent
+```
+
+Trunk was correct, working tree clean, `gitman doctor` HEALTHY — but the repo was wedged
+off-canonical with no gitman path out.
+
+---
+
+## G1 — stray detection treats a tagged off-main commit as "work edited outside Gitman"
+
+### Root cause
+
+`src/gitman/state.py`:
+
+```python
+def _stray_revset(trunk: str) -> str:
+    # Changes descended from trunk, not in any bookmark's ancestry (local OR remote …),
+    # excluding the current (often empty) working-copy change.
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+
+def find_strays(view, trunk):
+    return [_change(c) for c in view.log(_stray_revset(trunk)) if not c.is_empty]
+```
+
+The revset subtracts commits in the ancestry of **bookmarks** and **remote_bookmarks**, plus `@`. It
+does **not** subtract **tags**. So any non-empty commit that is reachable only via a `refs/tags/*`
+entry and isn't on trunk's line (e.g. a release tag left on a since-rebased commit) matches the
+revset → `find_strays` returns it → `capture_state` reports OFF-CANONICAL with
+*"belong to no lane (edited outside Gitman?)."*
+
+A git tag is an intentional, immutable marker — emphatically **not** "work edited outside Gitman." It
+should never be a canonicity signal.
+
+### Fix
+
+Subtract tagged commits' ancestry from the stray revset:
+
+```python
+def _stray_revset(trunk: str) -> str:
+    # Tags mark intentional history (releases), never stray work — exclude their ancestry too.
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks() | tags()) ~ @"
+```
+
+(Confirm `tags()` is the correct revset function exposed by the pyjutsu/jj-lib revset surface; jj's
+revset language provides `tags()`. If unavailable through pyjutsu, resolve tag tips explicitly and
+union them in.)
+
+### Test plan
+
+- Build a colocated repo; create a commit, tag it, then rewrite trunk so the tag is off-main; assert
+  `find_strays` returns `[]` and `gitman status` is CANONICAL.
+- Regression: a genuinely stray non-empty, untagged, unbookmarked child of trunk is **still** flagged.
+
+---
+
+## G2 — `reconcile` cannot recover a divergent stray (the dead-end)
+
+### Root cause
+
+`src/gitman/reconcile.py` `do_reconcile` drives jj **by change-id** for both branches:
+
+```python
+for change in strays:
+    if abandon_:
+        tx.abandon(change.change_id)                      # ← change-id
+    else:
+        name = f"adopted-{change.change_id[:8]}"
+        tx.create_bookmark(name, change.change_id)        # ← change-id
+```
+
+When the stray belongs to a **divergent change** (one change-id → ≥2 visible commits), jj refuses to
+resolve the bare change-id (`"Change ID … is divergent"`), so the transaction throws and reconcile
+fails — for **both** adopt and `--abandon`. The repo is off-canonical *by definition* when reconcile
+runs, and reconcile is the only sanctioned recovery, so a divergent stray makes the repo
+**unrecoverable through gitman**.
+
+Here the divergence was real: change-id `poosovxy` mapped to `c2a8443` (off-main, tagged `v0.2.0`)
+**and** `c90ef6c` (on-main "Pyjutsu bootstrap fixes") — a historical rewrite jj records as one change
+with two commits.
+
+### Why commit-id fixes it
+
+`find_strays` already returns a `Change` carrying **both** ids (`models.py`: `change_id`, `commit_id`).
+A commit-id is unambiguous even under divergence. The manual recovery that worked was precisely this:
+
+```python
+tx.abandon("c2a844370f13…")   # commit-id → succeeds where the change-id form fails
+```
+
+### Fix
+
+Operate on `change.commit_id` in `do_reconcile` (both branches):
+
+```python
+for change in strays:
+    if abandon_:
+        tx.abandon(change.commit_id)
+    else:
+        name = f"adopted-{change.change_id[:8]}"          # name can still use change_id (stable label)
+        if name in existing:
+            name = f"adopted-{change.change_id}"
+        tx.create_bookmark(name, change.commit_id)         # target the specific commit
+```
+
+Notes / things to verify:
+- `find_strays` enumerates each stray **commit** separately (it logs commits, not changes), so a
+  divergent change already appears as multiple `Change` rows — handling each by `commit_id` adopts/
+  abandons each divergent side independently, which is the desired behaviour.
+- Keep the lane **name** derived from `change_id` (stable, human-meaningful); only the **revset target**
+  must become `commit_id`.
+- Confirm `tx.abandon` / `tx.create_bookmark` accept a commit-id revset (they do — verified during
+  recovery).
+
+### Test plan
+
+- Construct a divergent change (two visible commits sharing a change-id — e.g. import a tag on a
+  rewritten commit), make one side an off-main stray, and assert `reconcile` and `reconcile --abandon`
+  both succeed and reach CANONICAL.
+- Regression: existing non-divergent reconcile tests still pass.
+
+---
+
+## Interaction & ordering
+
+G1 and G2 are independent and both worth doing:
+
+- **G1 alone** stops tagged off-main commits from ever being flagged → the *specific* scenario here
+  no longer goes off-canonical. But other sources of divergent strays could still wedge reconcile.
+- **G2 alone** makes reconcile able to clear divergent strays → the repo is always recoverable, but a
+  tagged release commit would still spuriously show as a stray needing reconciliation.
+
+Do **both**: G1 removes the false positive; G2 guarantees recoverability for any genuine divergent
+stray. Ship G2 first if prioritising (it removes the dead-end), G1 second (it removes the noise).
+
+---
+
+## Related (separate) gitman follow-ups, not in scope here
+
+- **`start` after `land` diverges from the pushed trunk** (Issue-6 family): editing then `gitman start`
+  in the post-land state rebuilt a commit off the *pre-land* parent, producing a sibling of the landed
+  commit rather than a child. Tracked in repoman `06-bootstrapping issues` (Follow-up B).
+- **`land`/`save`/`start` colocated-git export** — already fixed (gitman `18c7b19`): the canonical
+  wrappers now `git_export` after every mutating intent.
+
+## References
+
+- `src/gitman/state.py` `_stray_revset` (24-28), `find_strays` (79-81), `_change` (37-).
+- `src/gitman/reconcile.py` `do_reconcile` (19-59).
+- `src/gitman/models.py` `Change` (24-28: `change_id`, `commit_id`).
+- pyjutsu counterpart: `Pyjutsu/.scratch/projects/10-adopt-tag-visibility-and-keep-refs/` (what the
+  adopt imports; tag visibility; `refs/jj/keep` hygiene).
+- Recovery narrative: repoman `.scratch/projects/06-bootstrapping issues/…` (Follow-up C).

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/BUILD_PLAN.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/BUILD_PLAN.md
@@ -1,0 +1,207 @@
+# BUILD PLAN — implementing `gitman adopt` (corrected jj-0.42 design)
+
+> Execution plan for the build, downstream of [`ISSUE.md`](ISSUE.md) + [`PLAN.md`](PLAN.md)
+> **as corrected on 2026-06-26** (the validation phase is **done** — see PLAN §1 "Validation
+> findings" and `probes/*.py`). This file is the actionable checklist; PLAN.md is the
+> design rationale. Where they ever disagree, PLAN.md (corrected) wins.
+
+---
+
+## 0. State of play (read before touching anything)
+
+- **The premise was re-validated and the docs were rewritten.** jj-lib **0.42** behavior (not the
+  ISSUE's original 0.38-era inference): `git_fetch` **auto-fast-forwards local trunk**, **prunes
+  deleted lanes**, **orphans `@` (stale)**, and represents a **diverged trunk as a *conflicted*
+  bookmark**. The "trunk stuck behind" symptom is caused by gitman's own `canonical_guard`
+  postcondition **reverting** the fetch's trunk advance ("trunk moved outside a land"), not by jj
+  failing to advance trunk.
+- **WIP already on disk** — lane **`forge-adopt`** (jj bookmark; `gitman status` will show it). It
+  holds a partial PR-1:
+  - `src/gitman/core.py` `do_sync` — **skip-vanished-lanes** fix (re-read `lane_names` after fetch,
+    skip pruned lanes with a note). ✅ keep. **Still needs:** switch the fetch to **lanes-only**
+    (`git_fetch(remote, bookmarks=sorted(targets))`).
+  - `src/gitman/state.py` — `_trunk_remote_relation` helper + populates `TrunkRef.behind_remote/
+    ahead_remote` + a "behind origin" note. ⚠️ **Keep as best-effort, but add conflicted-trunk
+    tolerance** (the headline fix — see PR-1 below). The current code still crashes in the diverged
+    case because `capture_state` resolves the trunk name before the helper runs.
+  - `src/gitman/render.py` — `_remote_relation` suffix on the trunk line. ✅ keep.
+  - `src/gitman/models.py` — `TrunkRef.behind_remote/ahead_remote` already existed; unchanged.
+- **Nothing committed / saved / pushed.** Don't push. Commit with `gitman save` at green
+  checkpoints; land only when the maintainer asks.
+
+### Non-negotiable rules
+- **Everything inside devenv:** `devenv shell -- bash -c 'gitman:lint && gitman:test'` (or
+  `devenv test`). Never bare `uv`/`python`/`pytest`.
+- **Dogfood VC through `gitman`** (never raw `jj`/`git`; `git` is only `tags.py`). Work on the
+  `forge-adopt` lane.
+- jj is embedded via **pyjutsu** (`../Pyjutsu`): reads `Session.view()`/`fresh_view()`, mutations
+  `ws.transaction(...)`. No `jj` CLI, no `-T` templates.
+- No AI-authorship trailers in commits/PRs/docs.
+
+### Verified pyjutsu surface this build leans on
+- `ws.git_fetch(remote, bookmarks=[...])` — bookmark-scoped fetch (the lanes-only lever).
+- `view.bookmarks()` → `Bookmark(name, remote, target_ids: list[CommitId])` with `.conflicted`
+  (`len(target_ids) > 1`). **This is the clean conflicted-trunk detector** — no error-string match.
+- `view.resolve("<name>@<remote>")`, `view.log("a..b")`, `view.resolve(name)` (raises on a
+  conflicted name).
+- `tx.set_bookmark`, `tx.rebase(commit, onto=[...], mode="branch")` → `Commit(.has_conflict,
+  .is_empty)`, `tx.abandon`, `tx.delete_bookmark`.
+- `ws.update_stale()`, `ws.is_stale()`.
+
+---
+
+## 1. Pre-build validations (throwaway probes — do FIRST, ~30 min)
+
+Two remaining unknowns gate the code shape. Probe in the existing two-repo harness pattern
+(`tests/test_m3_integration.py::_with_remote`) or extend `probes/*.py`:
+
+1. **Lanes-only fetch leaves trunk frozen AND still prunes a deleted lane.** Advance origin trunk
+   *and* delete a published lane's branch; call `git_fetch(remote, bookmarks=["<lane>"])`. Assert:
+   local trunk unchanged; `<lane>` pruned (or, if a filtered fetch does *not* prune a deleted
+   in-filter bookmark, fall back to the post-fetch `lane_names` skip which already covers it).
+   → Decides the exact `do_sync` fetch call.
+2. **`tx.set_bookmark(trunk, "<trunk>@<remote>")` resolves a *conflicted* trunk bookmark.** Build
+   the diverged state (un-pushed local land + origin moved → `view.bookmarks()` shows the local
+   trunk `.conflicted`), then in a tx `set_bookmark(trunk, f"{trunk}@{remote}")`; assert afterward
+   `view.resolve(trunk)` succeeds and equals origin. → Gates the `adopt --force` path.
+3. *(cheap)* **`update_stale()` inside a guard body** leaves a canonical `@` and doesn't trip the
+   postcondition. Confirm during PR-2, not blocking.
+
+Record answers inline in the PR (a comment or the PR-2 test). Delete the throwaway probes once the
+real tests subsume them.
+
+---
+
+## 2. PR-1 — `sync` lanes-only + conflicted-trunk tolerance + sharp-edge-#1
+
+**Goal:** `gitman sync` never wedges or silently reverts trunk; `gitman status` never crashes on a
+diverged trunk and reports it actionably. No `adopt` yet.
+
+### 2a. `src/gitman/core.py` — `do_sync`
+- Change the fetch to **lanes-only**: `session.ws.git_fetch(pick_remote(session.ws),
+  bookmarks=sorted(targets))` (only when `targets` non-empty and a remote exists). Trunk is never in
+  the filter → no auto-FF → the postcondition can't revert. Keep the "fetched remote." message.
+- Keep the **skip-vanished** block already present (re-read `surviving = lane_names`; rebase
+  `targets ∩ surviving`; note each vanished lane → `gitman adopt`).
+- **Optional signpost:** after the fetch, if `<trunk>@<remote>` resolves and is ahead of local trunk
+  (`len(view.log(f"{trunk}..{trunk}@{remote}")) > 0`), append note `"origin/<trunk> moved — run
+  \`gitman adopt\`."` (Guard the resolve in try/except RevsetError.)
+
+### 2b. `src/gitman/state.py` — conflicted-trunk tolerance (the PR-1 headline)
+- Add `def _trunk_conflicted(view, trunk) -> bool`: `any(b.name == trunk and b.remote is None and
+  b.conflicted for b in view.bookmarks())`.
+- In `capture_state`, **before** `view.resolve(trunk_name)`: if `_trunk_conflicted(view,
+  trunk_name)`, return a minimal **off-canonical** `RepoState` that reports the divergence and does
+  **not** try to resolve the trunk name or enumerate lanes (both raise against a conflicted trunk):
+  - `trunk = TrunkRef(name=trunk_name, change_id=None, commit_id=None)`
+  - `off_canonical = f"trunk '{trunk_name}' diverged from {remote} (un-pushed local lands + origin
+    moved)."`, `canonical=False`
+  - `notes += ["run \`gitman adopt\` (or \`gitman adopt --force\` to take origin) to reconcile."]`
+  - `lanes=[]`, `current_lane=None` (we can't compute them; that's honest, not lossy).
+- Keep `_trunk_remote_relation` + `behind_remote/ahead_remote` as **best-effort** for the
+  *non-conflicted* path (already wired). They're a cheap readout, not load-bearing.
+- Demote the existing "N behind origin" note to fire only when `behind_remote > 0` on a resolvable
+  trunk (it already does). The diverged path above is the real discoverability win.
+
+### 2c. `src/gitman/render.py` — `render_status`
+- Keep the `_remote_relation` suffix. Add a `DIVERGED` rendering: when `state.off_canonical`
+  mentions "diverged", the existing OFF-CANONICAL branch already covers it — verify the message is
+  legible (`Reason: trunk 'main' diverged …` + the adopt recommendation). Tweak only if ugly.
+
+### 2d. Tests
+- `tests/test_sync_resilience.py`
+  - `test_sync_skips_server_deleted_lane_branch` — publish lane, delete its branch in the bare
+    remote, `do_sync(all_=True)` → `SYNCED`, skip note, **no RevsetError, no "trunk moved" revert**,
+    trunk unchanged. *(acceptance: sync no longer wedges.)*
+  - `test_sync_does_not_advance_or_revert_trunk_when_origin_moved` — origin trunk advances; `do_sync`
+    (lanes-only) leaves local trunk put, no revert, succeeds.
+- `tests/test_remote_trunk_status.py`
+  - `test_status_diverged_trunk_reports_not_crashes` — build the conflicted-trunk state; `capture_state`
+    returns `canonical is False` with a "diverged" reason + adopt recommendation (no GitmanError).
+  - `test_status_trunk_behind_best_effort` — origin ahead, lanes-only fetch done → `behind_remote >=
+    1` best-effort (or 0 if not fetched), no crash.
+  - `test_status_no_remote_leaves_relation_zero` — no remote → fields 0, no crash.
+
+**Green gate:** `devenv shell -- bash -c 'gitman:lint && gitman:test'`. Then `gitman save -m
+"PR-1: sync lanes-only + conflicted-trunk tolerance + skip vanished lanes"`.
+
+---
+
+## 3. PR-2 — `gitman adopt` core
+
+Follow PLAN §1 (corrected sequence) + §2. Key points:
+
+### 3a. `src/gitman/invariants.py` — the one-line exemption
+```python
+trunk_moved = (after.trunk.commit_id != trunk_before) and intent not in ("land", "adopt")
+```
+Nothing else in the guard changes.
+
+### 3b. `src/gitman/core.py` — `do_adopt(session, *, force, dry_run)`
+Sequence (inside `canonical_guard(session, "adopt")`):
+1. `remote = pick_remote(ws)` (exit 2 if no remotes). Capture `local_trunk_before` +
+   `lanes_before = set(lane_names(...))` **before** the fetch.
+2. `ws.git_fetch(remote)` (full fetch — adopt *wants* the trunk FF). Resolve `origin_trunk =
+   view.resolve(f"{trunk}@{remote}")` (exit 1 if absent).
+3. **Classify:** `conflicted = _trunk_conflicted(view, trunk)`.
+   - conflicted + not `force` → `BLOCKED` exit 1 (push lands or `--force`).
+   - else if `local_trunk_before == origin_trunk.commit_id` and `lanes_before == set(lane_names)` →
+     `ALREADY_CURRENT` exit 0.
+4. **Mutate** (one `ws.transaction("gitman:adopt", auto_snapshot=False)`):
+   - if `conflicted`: `tx.set_bookmark(trunk, f"{trunk}@{remote}")` (validation #2).
+   - for each surviving lane: `_reconcile_lane_against_adopted_trunk(session, tx, trunk, lane)` —
+     rebase onto trunk; if post-rebase range all `is_empty` → retire (abandon + delete_bookmark);
+     if `has_conflict` → leave, mark CONFLICT (non-blocking); else survivor (keep rebase).
+5. `if ws.is_stale(): ws.update_stale()` (finding 3).
+6. **Residue:** for `lane in lanes_before - set(lane_names(...))` (pruned by the fetch) →
+   `_cleanup_workspace`, report `retired (forge-merged): <lane>`.
+7. `--dry-run`: do steps 1–3 + classification, open **no transaction**, report the plan,
+   `outcome="PLAN"`, exit 0, no undo line.
+- `IntentResult(intent="adopt", ...)` outcomes: `ADOPTED` / `ALREADY_CURRENT` / `BLOCKED` /
+  `CONFLICT` / `PLAN`. Per-lane rows + `Undo: gitman undo`. Undo note: forge merge + deleted remote
+  branches are not restored by undo.
+
+### 3c. `src/gitman/cli.py` — wire the verb (PLAN §2 snippet): `--force`, `--dry-run`.
+
+### 3d. `render.py` — verify the generic `messages`/`notes`/`undo_command` path renders `adopt`
+(as `sync`/`land` do); add a branch only if needed.
+
+### 3e. Tests `tests/test_adopt_integration.py` (PLAN §5, corrected):
+1. **Squash-merge headline** (lane `m0`, 2 commits → squash on origin as new SHA, branch deleted) →
+   `adopt` → local trunk == origin, `m0` retired, `CANONICAL · 0 lanes`, `doctor` HEALTHY.
+2. **Merge-commit** (lane SHAs preserved as ancestors) → retired via ancestry/empty path.
+3. **Rebase-merge** (new SHAs, same content, branch kept) → retired via empty-after-rebase.
+4. **Un-merged survivor** alongside a merged lane → merged retired, survivor rebased + kept.
+5. **Diverged trunk** (conflicted bookmark) → `BLOCKED` without `--force`; `--force` hard-sets to
+   origin, undoable; `status` reports diverged (PR-1).
+6. **`--dry-run`** mutates nothing (op log unchanged) but reports the right plan.
+7. **`gitman undo`** after adopt restores trunk + lanes.
+8. **`ALREADY_CURRENT`** no-op when origin == local trunk.
+
+---
+
+## 4. PR-3 — docs / concept / skill
+- `docs/GITMAN_CONCEPT.md`: amend **I5** ("trunk advances via `land` **or `adopt`**"); add `adopt`
+  to the intents table; add a "Forge-PR adoption" subsection (`publish → PR → merge → adopt`).
+- `.claude/skills/gitman/SKILL.md`: add the forge loop (after `gh pr merge`, run `gitman adopt`,
+  never the raw reconcile dance); reinforce **keep `gitman.toml`/VC wiring on trunk, never only in a
+  lane** (sharp edge #2); fold the §4 dance in as the *deprecated fallback*.
+- Note in the skill that `gitman sync` fetches lanes-only and signposts `gitman adopt` when origin
+  trunk moved.
+
+---
+
+## 5. Definition of done (ISSUE §7 / PLAN §9)
+- [ ] One command: "PR merged, trunk behind" → `CANONICAL · 0 lanes`, local `trunk == origin`, **no
+      raw git**, fully `gitman undo`-able.
+- [ ] Correct across **squash / merge-commit / rebase** (content detection, not SHA).
+- [ ] Un-merged lane survives + rebased onto adopted trunk (not abandoned).
+- [ ] Refuses safely on a diverged/conflicted trunk (without `--force`) and on dirty/stale tree.
+- [ ] `gitman sync` no longer wedges **or reverts trunk** on a server-deleted lane branch / moved
+      origin (lanes-only fetch).
+- [ ] `gitman status` reports a diverged trunk instead of crashing.
+- [ ] `gitman doctor` HEALTHY afterward; regression test reproduces the squash-merge scenario.
+- [ ] Each PR `gitman:lint && gitman:test` green before the next.
+
+## 6. Sequencing
+PR-1 (§2) → save → PR-2 (§3) → save → PR-3 (§4) → save. Land only when the maintainer asks.

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/ISSUE.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/ISSUE.md
@@ -16,9 +16,10 @@ local trunk bookmark to a **forge-merged `origin/<trunk>`**.
 So the common workflow — `gitman publish` a lane → open a GitHub PR → click **Merge** → the
 forge advances `origin/main` with a **re-hashed** commit (squash/merge/rebase all mint a new
 SHA) — leaves gitman with **no command** to pull the local trunk forward. The local trunk stays
-behind `origin/main` forever, `gitman sync` won't fix it (it rebases onto the *unchanged* local
-trunk), and `gitman land` would mint a **divergent** local SHA from the forge's merge commit —
-poisoning the merge-base of every future PR.
+behind `origin/main`, `gitman sync` won't fix it (its fetch *does* fast-forward local trunk, but
+the canonical guard reverts the move as "trunk moved outside a land" — see §3), and `gitman land`
+would mint a **divergent** local SHA from the forge's merge commit — poisoning the merge-base of
+every future PR.
 
 The only working recovery today is a manual **de-colocate + reset + re-init** dance (§4). It is
 heavyweight, undocumented in the tool, and has two sharp edges. This issue proposes making
@@ -49,13 +50,29 @@ uses forge PRs + the merge button (the normal way to get review + CI gating + an
 
 All references are `src/gitman/core.py` @ 0.2.2.
 
-- **`do_sync` rebases onto the *local* trunk bookmark, not the fetched remote.**
-  It fetches (`session.ws.git_fetch(pick_remote(session.ws))`, which only updates the
-  `origin/<trunk>` remote-tracking ref) and then `tx.rebase(lane, onto=trunk, mode="branch")`,
-  where `trunk` is the **local** bookmark (`require_trunk`). Nothing fast-forwards the local
-  `trunk` bookmark to the fetched `origin/<trunk>`. So after a forge merge, `gitman sync` reports
-  "rebased <lane> onto main" while local `main` stays put. (See the `do_sync` body and its
-  `git_fetch` → `tx.rebase(..., onto=trunk)` sequence.)
+> **Correction — validated against jj-lib 0.42 (2026-06-26).** The original hypothesis ("`git_fetch`
+> only updates the `origin/<trunk>` tracking ref; nothing fast-forwards local trunk") is **wrong for
+> jj 0.42**, and the real cause sits one layer up, in gitman's own guard. Four throwaway probes (in
+> this project's `probes/`) established the actual behavior; the corrected bullet below replaces the original.
+> The *symptom* in §1–§2 is real and correctly observed — only the mechanism was mis-inferred,
+> because gitman reverts the trunk advance before it's observable from the outside.
+
+- **The fetch *does* advance local trunk — then gitman's own canonical guard reverts it.**
+  Validated jj 0.42 facts: `git_fetch` **auto-fast-forwards** the tracked local `<trunk>` bookmark to
+  a moved `origin/<trunk>` (jj bookmark-tracking semantics — local and remote bookmarks are *not*
+  independent the way git branches are), and it **prunes** a lane whose remote branch was deleted
+  server-side (dropping the un-diverged local bookmark too). So in the squash repro, the fetch alone
+  moves local `main` to the forge-merged SHA. But `do_sync` runs that fetch **inside
+  `canonical_guard`**, whose postcondition (`invariants.py`:
+  `trunk_moved = after.trunk.commit_id != trunk_before and intent != "land"`) sees trunk moved
+  outside a `land`, calls `restore_operation(op_before)`, and **rolls the fetch back** — snapping
+  local `main` behind again and raising `reverted: trunk moved outside a land`. (If the remote lane
+  branch was also deleted, `sync` dies one step earlier at `tx.rebase(<lane>)` with "Revision
+  `<lane>` doesn't exist" — sharp edge #1 below — same net result: revert, trunk behind.) From the
+  outside, "jj never advanced trunk" and "jj advanced trunk, gitman reverted it" are
+  indistinguishable — hence the original mis-diagnosis. **Verified by driving the real `do_sync`
+  through the squash repro: it raised `reverted: trunk moved outside a land` and restored trunk to
+  its pre-fetch position.**
 
 - **`do_land` advances trunk *locally*, by pointer.**
   `tx.set_bookmark(trunk, lane)` moves the local trunk bookmark to the lane head — the lane's
@@ -63,17 +80,26 @@ All references are `src/gitman/core.py` @ 0.2.2.
   then push the fast-forwarded trunk) this is correct and there is no gotcha. The gotcha is
   exclusively a **local-land model vs. forge-merge model** mismatch.
 
-- **No remote-trunk adoption primitive exists.**
-  `pick_remote` + `git_fetch` give the building blocks, but no command sets the local `trunk`
-  bookmark from `origin/<trunk>`. (`do_reconcile` is for OFF-CANONICAL stray-change adoption —
-  a different concern; it does not touch the remote.)
+- **No intent is *permitted* to let a fetched trunk advance stand.**
+  The advance primitive isn't missing — `git_fetch` performs it (and `tx.set_bookmark(trunk,
+  "<trunk>@<remote>")` can force it in the diverged case). What's missing is a *sanctioned door*:
+  every existing mutating intent runs under `canonical_guard`, which reverts any non-`land` trunk
+  move (I1/I5). So no command can fetch-and-keep the forge-merged trunk, un-stale the `@` the fetch
+  orphans, and retire the lanes the fetch prunes. (`do_reconcile` is for OFF-CANONICAL stray-change
+  adoption — a different concern; it does not touch the remote.) `gitman adopt` is that door: the
+  second intent the postcondition exempts from the trunk-frozen rule.
 
 ### Two sharp edges that make the manual recovery worse
 
-1. **`gh pr merge --delete-branch` breaks `gitman sync`.** Deleting the remote lane branch leaves
-   the local lane's upstream ref dangling; `gitman sync` then dies with
-   "bad revision/revset: Revision `<lane>` doesn't exist", and re-`publish` is rejected as "stale
-   info". `git fetch --prune` does **not** clear it.
+1. **`gh pr merge --delete-branch` breaks `gitman sync`.** Deleting the remote lane branch makes the
+   next `gitman sync` die with "bad revision/revset: Revision `<lane>` doesn't exist", and re-`publish`
+   is rejected as "stale info". *Validated mechanism (jj 0.42):* jj's `git_fetch` **does** prune the
+   lane — it drops the `<lane>@origin` row *and* the un-diverged local `<lane>` bookmark — so the
+   subsequent `tx.rebase(<lane>, …)` resolves a name that no longer exists and raises. (The "`git
+   fetch --prune` does not clear it" note from the §4 dance was a **raw-git** observation on the
+   colocated `.git`; jj's own fetch prunes, raw `git fetch` of the bare ref does not — two different
+   fetch tools, conflated mid-firefight.) Fix: after the fetch, re-read surviving lanes and skip the
+   vanished one instead of rebasing it.
 2. **`gitman abandon` resets the working copy to trunk** (`do_abandon` abandons every `trunk..lane`
    change and moves the bookmark back to trunk's commit). If any repo wiring (e.g. `gitman.toml`)
    was committed *inside the lane* rather than on trunk, abandoning the lane deletes it from disk →
@@ -129,9 +155,12 @@ gitman sync --adopt-remote          # or a dedicated `gitman adopt` / `gitman re
 
 Behavior:
 1. `git_fetch(pick_remote)` to update `origin/<trunk>`.
-2. **Fast-forward (or hard-set) the local `trunk` bookmark to `origin/<trunk>`** — the missing
-   primitive. If local trunk has commits not on `origin/<trunk>` (true local lands not yet pushed),
-   refuse unless `--force`/`--ours` is given (don't silently discard local trunk work).
+2. **Let the local `trunk` bookmark reach `origin/<trunk>`.** Per the §3 correction, jj's fetch
+   *already* fast-forwards local trunk in the clean case — `adopt`'s job is to run that fetch under a
+   guard that **permits** the move (not to perform a set-bookmark it mostly doesn't need). Only when
+   local trunk has diverged (un-pushed lands → jj leaves a *conflicted* bookmark, no auto-FF) does
+   `adopt` hard-set it via `tx.set_bookmark(trunk, "<trunk>@<remote>")`, and only under
+   `--force`/`--ours` (don't silently discard local trunk work).
 3. For each surviving lane, `rebase(lane, onto=trunk)` onto the *new* trunk.
 4. **Retire lanes already merged on the forge.** A squash/rebase merge re-hashes, so change-ids
    and SHAs won't match — detect "already merged" by **content**: a lane whose `trunk..lane` diff

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/ISSUE.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/ISSUE.md
@@ -1,0 +1,196 @@
+# ISSUE — gitman has no way to adopt a forge-merged trunk (publish → PR → merge gap)
+
+> **Status:** open / triaged, not started. Captured 2026-06-26 from a vendomat session
+> where landing M0 via a GitHub PR required a heavyweight manual reconcile.
+> **gitman version at capture:** 0.2.2.
+> **Scope:** a change to **gitman itself** (this repo), not its consumers.
+
+---
+
+## 1. TL;DR
+
+gitman's integration model is **local**: `gitman land` advances the *local* trunk bookmark to a
+lane head, and `gitman sync` rebases lanes onto the *local* trunk. Neither ever advances the
+local trunk bookmark to a **forge-merged `origin/<trunk>`**.
+
+So the common workflow — `gitman publish` a lane → open a GitHub PR → click **Merge** → the
+forge advances `origin/main` with a **re-hashed** commit (squash/merge/rebase all mint a new
+SHA) — leaves gitman with **no command** to pull the local trunk forward. The local trunk stays
+behind `origin/main` forever, `gitman sync` won't fix it (it rebases onto the *unchanged* local
+trunk), and `gitman land` would mint a **divergent** local SHA from the forge's merge commit —
+poisoning the merge-base of every future PR.
+
+The only working recovery today is a manual **de-colocate + reset + re-init** dance (§4). It is
+heavyweight, undocumented in the tool, and has two sharp edges. This issue proposes making
+forge-merge adoption a first-class gitman operation.
+
+---
+
+## 2. How we hit it
+
+In the vendomat repo (gitman-colocated), landing milestone M0:
+
+1. `gitman start m0-bootstrap` → edit → `gitman save` → `gitman publish` (pushes branch
+   `m0-bootstrap`).
+2. `gh pr create` → review → `gh pr merge --squash`.
+   - The lane head was `4d5aeec`; GitHub's squash produced a **new** commit `8d4c991` on
+     `origin/main`. Different SHA — the re-hash is the crux.
+3. Now: local `main` is still at the pre-merge trunk; `origin/main` is at `8d4c991`. There is no
+   `gitman <verb>` that says "the forge merged my lane; move my trunk to `origin/main` and retire
+   the lane." `gitman sync` fetches but rebases onto local trunk; `gitman land` is wrong (would
+   diverge from `8d4c991`).
+
+This is not a vendomat-specific problem — it is structural for **any** gitman repo whose team
+uses forge PRs + the merge button (the normal way to get review + CI gating + an audit trail).
+
+---
+
+## 3. Root cause (grounded in the code)
+
+All references are `src/gitman/core.py` @ 0.2.2.
+
+- **`do_sync` rebases onto the *local* trunk bookmark, not the fetched remote.**
+  It fetches (`session.ws.git_fetch(pick_remote(session.ws))`, which only updates the
+  `origin/<trunk>` remote-tracking ref) and then `tx.rebase(lane, onto=trunk, mode="branch")`,
+  where `trunk` is the **local** bookmark (`require_trunk`). Nothing fast-forwards the local
+  `trunk` bookmark to the fetched `origin/<trunk>`. So after a forge merge, `gitman sync` reports
+  "rebased <lane> onto main" while local `main` stays put. (See the `do_sync` body and its
+  `git_fetch` → `tx.rebase(..., onto=trunk)` sequence.)
+
+- **`do_land` advances trunk *locally*, by pointer.**
+  `tx.set_bookmark(trunk, lane)` moves the local trunk bookmark to the lane head — the lane's
+  *own* commits, never the forge's re-hashed merge commit. In a pure-gitman flow (land locally,
+  then push the fast-forwarded trunk) this is correct and there is no gotcha. The gotcha is
+  exclusively a **local-land model vs. forge-merge model** mismatch.
+
+- **No remote-trunk adoption primitive exists.**
+  `pick_remote` + `git_fetch` give the building blocks, but no command sets the local `trunk`
+  bookmark from `origin/<trunk>`. (`do_reconcile` is for OFF-CANONICAL stray-change adoption —
+  a different concern; it does not touch the remote.)
+
+### Two sharp edges that make the manual recovery worse
+
+1. **`gh pr merge --delete-branch` breaks `gitman sync`.** Deleting the remote lane branch leaves
+   the local lane's upstream ref dangling; `gitman sync` then dies with
+   "bad revision/revset: Revision `<lane>` doesn't exist", and re-`publish` is rejected as "stale
+   info". `git fetch --prune` does **not** clear it.
+2. **`gitman abandon` resets the working copy to trunk** (`do_abandon` abandons every `trunk..lane`
+   change and moves the bookmark back to trunk's commit). If any repo wiring (e.g. `gitman.toml`)
+   was committed *inside the lane* rather than on trunk, abandoning the lane deletes it from disk →
+   gitman then reports "repo not initialized". (`gitman undo` reverts the abandon.)
+
+---
+
+## 4. The current manual workaround (the "reconcile dance")
+
+Documented here because it is the *only* thing that works today; it is what we ran for vendomat M0.
+It de-colocates to plain git, hard-resets local trunk to the forge SHA, then re-colocates.
+
+```bash
+# (PR is merged on the forge)
+git push origin --delete <lane>          # 1. delete the merged remote lane branch
+git branch -D <lane>                      #    and the local lane branch, if present
+git fetch origin --prune                  # 2. advance origin/<trunk> remote-tracking ref
+rm -rf .jj .gitman                        # 3. de-colocate → plain git (.git + work tree untouched)
+git symbolic-ref HEAD refs/heads/<trunk>  # 4. re-attach HEAD to the trunk branch...
+git reset --hard origin/<trunk>           #    ...and move local trunk to the forge-merged SHA
+# re-colocate at the merged SHA (run from a shell where `gitman` is available):
+gitman init --colocate --trunk <trunk>    # 5. (says "already initialized" if gitman.toml persists —
+                                          #     harmless; .jj is still recreated at the merged SHA)
+gitman abandon <lane>                     # 6. only if a stale local lane got re-imported as an empty lane
+gitman doctor                             # 7. expect HEALTHY; status CANONICAL · 0 lanes; local==origin
+```
+
+**Why it's unacceptable long-term:** it drops out of gitman entirely, uses raw destructive git
+(`rm -rf`, `reset --hard`) that the gitman discipline otherwise forbids, and is easy to get wrong
+(the two sharp edges above). It must become a supported gitman command.
+
+**Keep wiring on trunk.** `gitman.toml` and other VC wiring should live on **trunk**, never only in
+a lane, so step 6's abandon can never delete them.
+
+---
+
+## 5. Possible fixes
+
+### Option A — Adopt gitman's native local-land flow (no code change)
+Stop using the forge **merge button**. After review, `gitman land` locally, then fast-forward-push
+trunk; the forge auto-marks the PR merged when its commits appear on the base. No re-hash, no
+gotcha.
+- **Pros:** zero work; the model is internally consistent.
+- **Cons:** loses merge-button ergonomics — required-status-checks / branch-protection gating,
+  squash policies, and the forge's merge audit trail. Many teams won't accept this.
+
+### Option B — Make forge-merge adoption first-class in gitman (recommended)
+Add a command that does, in-tool, what the §4 dance does by hand. Sketch:
+
+```
+gitman sync --adopt-remote          # or a dedicated `gitman adopt` / `gitman reconcile --remote`
+```
+
+Behavior:
+1. `git_fetch(pick_remote)` to update `origin/<trunk>`.
+2. **Fast-forward (or hard-set) the local `trunk` bookmark to `origin/<trunk>`** — the missing
+   primitive. If local trunk has commits not on `origin/<trunk>` (true local lands not yet pushed),
+   refuse unless `--force`/`--ours` is given (don't silently discard local trunk work).
+3. For each surviving lane, `rebase(lane, onto=trunk)` onto the *new* trunk.
+4. **Retire lanes already merged on the forge.** A squash/rebase merge re-hashes, so change-ids
+   and SHAs won't match — detect "already merged" by **content**: a lane whose `trunk..lane` diff
+   is now empty against the adopted trunk (cherry-mark / patch-id / empty-diff) is merged → abandon
+   it automatically (or list for confirmation).
+5. Stay CANONICAL throughout (run under `canonical_guard`); emit an `IntentResult` + `gitman undo`
+   support like the other intents.
+
+Design questions to resolve when building:
+- **Command surface:** a `--adopt-remote` flag on `sync`, vs. a new top-level `adopt`/`land
+  --remote`. A distinct verb is clearer and keeps `sync`'s "rebase onto local trunk" contract
+  intact.
+- **Detecting forge-merged lanes** across squash/rebase re-hash: patch-id equality vs. jj's
+  `cherry`/empty-after-rebase signal. Must handle squash (N commits → 1), merge-commit, and
+  rebase-merge.
+- **Branch hygiene:** prune the deleted remote lane branch + its dangling local upstream ref
+  *without* tripping sharp edge #1 (the "stale info" / "revision doesn't exist" failures). This is
+  likely the same fix as making `sync` resilient to a server-deleted lane branch.
+- **Safety:** never `reset --hard` away un-pushed local trunk commits or uncommitted work; refuse
+  + explain instead.
+
+### Option C — Keep the manual dance, just document it (stopgap)
+Ship §4 as an official runbook (e.g. in the gitman skill / docs) but no code. Unblocks today; does
+not remove the foot-guns. Acceptable only as a bridge to Option B.
+
+---
+
+## 6. Recommendation
+
+**Build Option B.** Forge PRs (review + CI gating + audit trail) are a first-class workflow, and
+the local-only model silently breaks them. A `gitman adopt`/`sync --adopt-remote` command — fetch,
+fast-forward local trunk to `origin/<trunk>`, rebase survivors, content-detect + retire
+forge-merged lanes — turns a 7-step raw-git dance into one safe, undoable intent. Sharp edge #1
+(server-deleted lane branch breaking `sync`) should be fixed in the same change set, since
+adoption must prune those branches anyway.
+
+Interim: Option C runbook so nobody re-derives the dance under pressure.
+
+---
+
+## 7. Acceptance criteria (for the Option B build)
+
+- A single gitman command takes a repo from "PR merged on the forge, local trunk behind" to
+  CANONICAL · 0 lanes with local `trunk` == `origin/<trunk>`, **no raw git**, fully `gitman undo`-able.
+- Correct across **squash**, **merge-commit**, and **rebase** merges (re-hash handled by
+  content-based merged-lane detection, not SHA/change-id equality).
+- A lane **not** yet merged on the forge survives and is rebased onto the adopted trunk (not
+  abandoned).
+- Refuses safely (clear message, no data loss) when local trunk has un-pushed commits or the work
+  tree is dirty.
+- `gitman sync` no longer wedges when the remote lane branch was deleted server-side (sharp edge #1).
+- `gitman doctor` HEALTHY afterward; regression test reproducing the squash-merge scenario.
+
+---
+
+## 8. References
+
+- `src/gitman/core.py` — `do_sync` (fetch + `rebase onto=trunk`), `do_land` (`set_bookmark(trunk,
+  lane)`), `do_abandon` (resets WC to trunk — sharp edge #2), `pick_remote`, `git_fetch`.
+- `.claude/skills/gitman/SKILL.md` — the lane loop + the (local) `publish → land` model.
+- Concrete repro from this session: vendomat PR #3, lane head `4d5aeec` → squash-merged as
+  `origin/main` `8d4c991` (SHA re-hash), reconciled via the §4 dance.

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/KICKOFF.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/KICKOFF.md
@@ -1,0 +1,62 @@
+# KICKOFF PROMPT — build `gitman adopt`
+
+> Paste everything below the line into a fresh gitman session to start the work.
+> It is self-contained: it points at the issue + plan, states the resolved design
+> decisions, and gives an explicit first-step / validation order so the new session
+> doesn't re-derive what's already settled.
+
+---
+
+We're implementing **`gitman adopt`** — a first-class command to adopt a forge-merged
+trunk (the `publish → PR → click-Merge → local trunk stranded behind origin/main` gap).
+
+**Read first, in order:**
+1. `.scratch/projects/07-forge-pr-trunk-reconcile/ISSUE.md` — the problem, root cause in
+   code, the two "sharp edges", and acceptance criteria (§7).
+2. `.scratch/projects/07-forge-pr-trunk-reconcile/PLAN.md` — the full implementation plan
+   I'm asking you to execute. Follow it; deviate only with a stated reason.
+
+**Project rules (non-negotiable):**
+- Everything runs inside devenv: `devenv shell -- bash -c 'gitman:lint && gitman:test'`
+  (or `devenv test`). Never bare `uv`/`python`/`pytest`.
+- Dogfood version control through `gitman` — never raw `jj`/`git` (that breaks canonicity).
+  `git` is only used by `tags.py`.
+- jj-lib is embedded via pyjutsu (`../Pyjutsu`); there is no `jj` CLI and no `-T` templates.
+  Reads go through `Session.view()`/`fresh_view()`; mutations through `ws.transaction(...)`.
+- No AI-authorship trailers in commits/PRs/docs. Only commit/push when I ask; branch first.
+
+**Design decisions already made (do NOT re-litigate):**
+- Command surface = a **new top-level `gitman adopt`** verb (not `sync --adopt-remote`,
+  not `land --remote`). Flags: `--force` (allow non-FF / discard un-pushed local trunk),
+  `--dry-run` (report plan, no mutation).
+- Forge-merged lanes **auto-retire** and are reported per-lane, with `gitman undo` support.
+- Detection of "already forge-merged" is **content-based** via emptiness-after-rebase
+  (pyjutsu has no patch-id) — see PLAN §1; must work for squash / merge-commit / rebase.
+- `adopt` becomes the **second trunk-advancing intent** (I5 widens to `land` or `adopt`);
+  the only invariants change is the one-line `_postcondition` exemption in PLAN §2.
+
+**Build order (PLAN §7) — three slices, each lint+test green before the next:**
+1. **PR-1**: status honesty (`origin/<trunk>` ahead/behind in `capture_state`/status) +
+   make `do_sync` resilient to a server-deleted remote lane branch (sharp edge #1).
+2. **PR-2**: the `do_adopt` core + `_postcondition` one-liner + content-merged detection +
+   CLI wiring + `--force`/`--dry-run`.
+3. **PR-3**: docs/concept/skill updates; deprecate the §4 manual "reconcile dance".
+
+**Validate these unknowns FIRST (PLAN §8), before writing the main logic — they change the
+shape of `do_adopt`:**
+- Does `session.view()` reflect an in-flight `tx.rebase` so the post-rebase emptiness check
+  works inside one transaction? If not, use two tx blocks under the same `canonical_guard`.
+- Does pyjutsu `git_fetch` prune a dangling `<lane>@origin` row after the remote branch is
+  deleted server-side?
+- Is `tx.rebase(lane, onto=trunk, mode="branch")` a clean no-op when the lane is already an
+  ancestor of trunk (merge-commit case)?
+Write a tiny throwaway test (or use the `tests/test_colocated_git_sync.py` two-repo harness)
+to answer each, then proceed.
+
+**Definition of done:** all PLAN §9 acceptance criteria pass, including a regression test that
+reproduces the squash-merge scenario (lane `m0`, 2 commits → squash-merged on origin as a new
+SHA → `gitman adopt` → CANONICAL · 0 lanes, local `trunk == origin/trunk`, `gitman doctor`
+HEALTHY), and `gitman sync` no longer wedges on a server-deleted lane branch.
+
+Start with PR-1. Show me your plan for it (files + test names) before you write code, then
+proceed once I confirm.

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/KICKOFF_v2.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/KICKOFF_v2.md
@@ -1,0 +1,78 @@
+# KICKOFF v2 — build `gitman adopt` (post-validation, corrected design)
+
+> Paste everything below the line into a fresh gitman session to start the **implementation**.
+> Supersedes the original `KICKOFF.md` (which assumed the pre-validation premise). The validation
+> phase is **done**; the design docs are **corrected**; this kicks off the code.
+
+---
+
+We're implementing **`gitman adopt`** — a first-class command to adopt a forge-merged trunk
+(`publish → PR → click-Merge → local trunk stranded behind origin/main`). The design was
+**validated against jj-lib 0.42 and the ISSUE/PLAN were rewritten**; build against the corrected
+docs, not your priors.
+
+**Read first, in order (all in `.scratch/projects/07-forge-pr-trunk-reconcile/`):**
+1. `BUILD_PLAN.md` — the actionable execution checklist (state of play, pre-build probes, PR-1/2/3
+   file-by-file, tests, done criteria). **This is your primary guide.**
+2. `PLAN.md` — the corrected design rationale. Note **§1 "Validation findings"** and the
+   per-section corrections; where PLAN and your intuition differ, PLAN wins.
+3. `ISSUE.md` — the problem + the **§3 "Correction" callout** (why the original root-cause was
+   wrong) + the two sharp edges.
+
+**What's already true (don't re-derive):**
+- jj-lib **0.42** behavior, validated by `probes/*.py`: `git_fetch` **auto-fast-forwards
+  local trunk**, **prunes deleted lanes**, leaves `@` **stale**, and shows a **diverged trunk as a
+  *conflicted* bookmark** (`Bookmark.conflicted`, i.e. `len(target_ids) > 1`).
+- The "trunk stuck behind" symptom is caused by **gitman's `canonical_guard` postcondition
+  reverting the fetch's trunk advance** ("trunk moved outside a land"), *not* by jj failing to
+  advance trunk. `adopt` is the second intent the postcondition **exempts** (the one-line change
+  `intent not in ("land", "adopt")`); `sync` is fixed by fetching **lanes-only** so it never moves
+  trunk.
+- **WIP is on lane `forge-adopt`** (run `gitman status` to see it): a partial PR-1 — `do_sync`
+  skip-vanished-lanes (keep; still needs the lanes-only fetch) and best-effort
+  `TrunkRef.behind_remote/ahead_remote` in `state.py`/`render.py` (keep; still needs
+  conflicted-trunk tolerance). Details in BUILD_PLAN §0. Continue on this lane.
+
+**Design decisions already settled (do NOT re-litigate):**
+- New top-level **`gitman adopt`** verb (not `sync --adopt-remote`). Flags `--force` (resolve a
+  diverged/conflicted trunk toward origin, discarding un-pushed local lands) and `--dry-run`.
+- Forge-merged lanes **auto-retire**, reported per-lane, `gitman undo`-able.
+- Merged-lane detection is **content-based** (emptiness-after-rebase) for lanes the fetch didn't
+  already prune; deleted-branch lanes are retired by the fetch and handled as residue.
+- `adopt` is the **second trunk-advancing intent** (I5 widens to `land` **or** `adopt`).
+
+**Project rules (non-negotiable):**
+- Everything inside devenv: `devenv shell -- bash -c 'gitman:lint && gitman:test'` (or `devenv
+  test`). Never bare `uv`/`python`/`pytest`.
+- Dogfood VC through `gitman` — never raw `jj`/`git` (that breaks canonicity; `git` is only
+  `tags.py`). Work on the `forge-adopt` lane. `gitman save` at green checkpoints. **Don't push or
+  land** without an explicit ask.
+- jj is embedded via pyjutsu (`../Pyjutsu`); no `jj` CLI, no `-T` templates. Reads via
+  `Session.view()`/`fresh_view()`; mutations via `ws.transaction(...)`.
+- No AI-authorship trailers in commits/PRs/docs.
+
+**Build order — three slices, each `gitman:lint && gitman:test` green before the next:**
+1. **PR-1** (BUILD_PLAN §2): `do_sync` lanes-only fetch + skip vanished lanes; `capture_state`/
+   `status` tolerant of a conflicted/divergent trunk (report it, don't crash); best-effort
+   behind/ahead. Tests in `test_sync_resilience.py` + `test_remote_trunk_status.py`.
+2. **PR-2** (BUILD_PLAN §3): `do_adopt` + the `_postcondition` one-liner + content-merged detection
+   + un-stale `@` + `--force`/`--dry-run` + CLI wiring. Tests in `test_adopt_integration.py`
+   (squash headline is the acceptance repro).
+3. **PR-3** (BUILD_PLAN §4): concept/skill/docs; deprecate the manual reconcile dance.
+
+**Do these two remaining validations FIRST** (throwaway probes, BUILD_PLAN §1 — they fix the exact
+call shapes):
+1. A **lanes-only** `git_fetch(remote, bookmarks=[lane])` leaves local trunk frozen and still
+   prunes a server-deleted lane (else rely on the post-fetch `lane_names` skip).
+2. `tx.set_bookmark(trunk, "<trunk>@<remote>")` **resolves a conflicted** trunk bookmark (gates the
+   `adopt --force` path).
+Use the two-repo harness (`tests/test_m3_integration.py::_with_remote`) or extend
+`probes/*.py`. Report answers, then proceed.
+
+**Definition of done:** BUILD_PLAN §5 acceptance criteria pass — including a regression test
+reproducing the squash-merge scenario (lane `m0`, 2 commits → squash-merged on origin as a new SHA
+→ `gitman adopt` → `CANONICAL · 0 lanes`, local `trunk == origin`, `gitman doctor` HEALTHY), and
+`gitman sync` neither wedges nor reverts trunk on a server-deleted lane branch.
+
+Start with the PR-1 probes (BUILD_PLAN §1), then show me your PR-1 plan (files + test names)
+confirming it matches BUILD_PLAN §2 before writing code; proceed once I confirm.

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/PLAN.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/PLAN.md
@@ -1,0 +1,280 @@
+# PLAN — Option B: `gitman adopt` (forge-merged trunk adoption)
+
+> Implementation plan for [`ISSUE.md`](ISSUE.md). Grounded in the gitman source @ 0.2.2
+> and the verified pyjutsu API surface (jj-lib 0.42 pin in pyjutsu). Two design forks
+> resolved with the maintainer: **(1)** a distinct `gitman adopt` verb (not a `sync` flag);
+> **(2)** merged lanes auto-retire and are reported per-lane (with undo).
+
+---
+
+## 0. Framing: what `adopt` *is*
+
+The mental model that makes the invariants fall out correctly:
+
+> **`adopt` is a `land` that the forge already performed.** `land` advances the local trunk
+> to a lane head you built locally; `adopt` advances the local trunk to a trunk head **the
+> forge built** (`origin/<trunk>`), then reconciles lanes against it exactly as `land`
+> leaves the repo canonical.
+
+Consequences:
+1. `adopt` is the **second sanctioned trunk-advancing intent** — I5 ("trunk advances only
+   via `land`") widens to **`land` or `adopt`**.
+2. It reuses the existing `canonical_guard` machinery verbatim, with one targeted exemption
+   in the postcondition (the same exemption `land` already has).
+3. Its report shape, undo line, and exit-code semantics mirror `land`/`sync`.
+
+---
+
+## 1. The algorithm (grounded in real APIs)
+
+`do_adopt(session, *, force: bool, dry_run: bool)` in `core.py`.
+
+### Verified pyjutsu primitives it stands on
+- `ws.git_fetch(remote)` → updates the `<trunk>@origin` remote-tracking bookmark row.
+- `view.resolve("<trunk>@origin")` → fetched remote head `Commit` (revset form `name@remote`
+  is confirmed working).
+- `tx.set_bookmark(trunk, "<trunk>@origin")` → **the missing primitive**: move local trunk
+  to the forge head. (create-or-move; NOT fast-forward-only — FF-safety is enforced by our
+  refusal logic, not the primitive.)
+- `tx.rebase(lane, onto=trunk, mode="branch")` → returns the rebased `Commit`; exposes
+  `.has_conflict` and `.is_empty`.
+- `view.log("<trunk>..<lane>")` → range; emptiness / ancestry checks.
+- `tx.abandon(change_id)` / `tx.delete_bookmark(name)` → retire merged lanes (same calls
+  `do_abandon` uses).
+
+### Sequence (inside `canonical_guard(session, "adopt")`)
+
+```
+trunk = require_trunk(config)
+remote = pick_remote(ws)          # refuse if not ws.remotes()
+
+# --- 1. FETCH (own op) ---
+ws.git_fetch(remote)              # updates <trunk>@origin; prunes server-deleted lane refs
+view = session.view()
+try:
+    origin_trunk = view.resolve(f"{trunk}@{remote}")
+except RevsetError:
+    raise GitmanError(f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?", exit_code=1)
+
+local_trunk = view.resolve(trunk)
+
+# --- 2. CLASSIFY the trunk relationship ---
+if origin_trunk.commit_id == local_trunk.commit_id:
+    -> ALREADY_CURRENT (no trunk move; still rebase/retire any drifted lanes below)
+ahead  = view.log(f"{origin_trunk.commit_id}..{trunk}")   # local commits NOT on origin
+behind = view.log(f"{trunk}..{origin_trunk.commit_id}")   # forge commits NOT local
+if ahead and not force:
+    raise GitmanError(
+        f"local {trunk} has {len(ahead)} commit(s) not on {remote} — un-pushed local lands. "
+        f"Re-run with --force to hard-set trunk to {remote} (discards them), or push them first.",
+        exit_code=1)
+
+# --- 3. ADVANCE trunk + reconcile lanes (one tx) ---
+lanes = sorted(lane_names(session, trunk))     # survivors + to-retire decided by content
+with ws.transaction("gitman:adopt", auto_snapshot=False) as tx:
+    tx.set_bookmark(trunk, f"{trunk}@{remote}")     # FF (or hard-set under --force)
+    for lane in lanes:
+        retired, conflicted = _reconcile_lane_against_adopted_trunk(session, tx, trunk, lane)
+        ...accumulate report rows...
+# guard postcondition asserts canonical; undo checkpoint; git_export
+```
+
+### Content-merged detection — `_reconcile_lane_against_adopted_trunk`
+
+The crux the issue demands: must work across **squash / merge-commit / rebase** re-hash.
+pyjutsu exposes **no patch-id**, but it gives the right primitive: **emptiness after rebase
+onto the new trunk.** Three cases, one unified test:
+
+1. **Merge-commit** (lane commits kept by SHA, now ancestors of `origin/<trunk>`):
+   after the trunk move, `len(view.log(f"{trunk}..{lane}")) == 0` → lane is already an
+   ancestor → **retire** (just `delete_bookmark`; nothing to abandon).
+
+2. **Squash / rebase-merge** (lane content present under new SHAs):
+   ```
+   rebased = tx.rebase(lane, onto=trunk, mode="branch")
+   if rebased.has_conflict:  -> conflicted; leave for `gitman resolve` (do NOT abandon)
+   range_after = view.log(f"{trunk}..{lane}")   # re-read after the rebase op
+   if all(c.is_empty for c in range_after):  -> merged -> retire (abandon each, delete bookmark)
+   else:                                     -> survivor -> keep the rebase
+   ```
+   Why this works: rebasing a lane onto a trunk that already contains its cumulative content
+   makes every lane commit empty against its new parent tree — true for squash (N→1),
+   rebase-merge (N→N re-hashed), independent of SHA/change-id. A genuinely un-merged lane
+   leaves ≥1 non-empty commit → survives, already rebased onto the new trunk (exactly what we
+   want for survivors).
+
+   ⚠️ **Caveat:** pyjutsu's `rebase` does **not** auto-abandon emptied commits. We must
+   explicitly `is_empty`-test the post-rebase range and `tx.abandon(c.change_id)` the merged
+   ones — cannot rely on rebase dropping them.
+
+3. **Retire** = the `do_abandon` body: `for c in log(f"{trunk}..{lane}"): tx.abandon(c.change_id)`
+   then `tx.delete_bookmark(lane)`, plus `_cleanup_workspace(session, lane)` (reuse the
+   existing helper) and a best-effort `git_push(remote, lane, delete=True)` for any still-live
+   remote branch (mirrors `do_land`).
+
+**Reading inside an open transaction:** `do_land`/`do_sync` already read via `session.view()`
+around tx ops. For the post-rebase emptiness check, read the `Commit` returned by `tx.rebase`
+and, for multi-commit ranges, re-resolve through a fresh `session.view()`. **If intra-tx range
+reads prove unreliable, fall back to two tx blocks under the same guard:** rebase all lanes in
+tx #1, commit, then classify + retire in tx #2 (the guard explicitly supports multiple tx
+blocks). **Validate this empirically early — it's the #1 implementation risk.**
+
+---
+
+## 2. File-by-file changes
+
+### `src/gitman/core.py` — new `do_adopt`
+- New function as above. Reuses `pick_remote`, `lane_names`, `_cleanup_workspace`,
+  `require_trunk`.
+- Returns `IntentResult(intent="adopt", ...)`. Outcomes:
+  - `ADOPTED` — trunk advanced and/or lanes reconciled.
+  - `ALREADY_CURRENT` — `origin/<trunk> == local trunk`, exit 0.
+  - `BLOCKED` — un-pushed local trunk without `--force` (exit 1).
+  - `CONFLICT` — a survivor lane conflicts on rebase; non-blocking like `sync` (exit 1).
+  - `PLAN` — `--dry-run` (exit 0).
+- Per-lane report rows: `retired (forge-merged): <lane>` / `rebased onto trunk: <lane>` /
+  `conflict (resolve, then sync): <lane>`. Ends with `Undo: gitman undo`.
+- `--dry-run`: run fetch + classification but **open no transaction**; report the plan
+  (trunk FF target; which lanes would retire / rebase / conflict); `outcome="PLAN"`, exit 0,
+  no undo line.
+
+### `src/gitman/invariants.py` — allow trunk move under `adopt`
+The single targeted change, in `_postcondition`:
+```python
+trunk_moved = (after.trunk.commit_id != trunk_before) and intent not in ("land", "adopt")
+```
+Everything else (lock, precheck, undo checkpoint, restore-on-violation, git-export) is reused
+unchanged. `adopt` runs under `canonical_guard` (multi-op: a non-tx `git_fetch` + one/two tx
+blocks) — exactly the shape the guard was built for.
+
+### `src/gitman/cli.py` — wire the verb
+```python
+@app.command()
+def adopt(
+    force: Annotated[bool, typer.Option("--force", help="Hard-set trunk to origin even if local trunk has un-pushed commits (discards them).")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Report the adoption plan without mutating.")] = False,
+) -> None:
+    """Adopt a forge-merged trunk: fetch, advance local trunk to origin/<trunk>, rebase survivors, retire merged lanes."""
+    from gitman.core import do_adopt
+    _finish_intent(do_adopt(_session(), force=force, dry_run=dry_run))
+```
+
+### `src/gitman/state.py` + `models.py` — status honesty (`origin/<trunk>` divergence)
+The concept doc already imagines `trunk: main @ def456 (up to date with origin/main)`, but
+`capture_state` never reads the remote. Add (when `remotes()` non-empty): resolve
+`<trunk>@<remote>` if present, compute ahead/behind, set a new `TrunkRef` field
+(e.g. `remote_relation: "current" | "behind N" | "ahead N" | "diverged"`). When behind,
+append a note: `"local <trunk> is N behind origin — run \`gitman adopt\`."` This makes the gap
+**discoverable** instead of silent — directly addresses §3's "`sync` reports success while
+local main stays put."
+
+### Sharp edge #1 fix — server-deleted lane branch (shared by `do_sync` and `adopt`)
+Root cause: after `gh pr merge --delete-branch`, a fetch deletes the tracked remote ref and
+(because the local bookmark tracks it) can drop/dangle the **local** lane bookmark, so
+`tx.rebase(lane, …)` raises `RevsetError: Revision <lane> doesn't exist`. Fix once, use in both:
+- Re-read `existing = lane_names(session, trunk)` **after** fetch; iterate only over lanes that
+  still resolve.
+- In `do_sync`'s rebase loop, guard each `tx.rebase(lane, …)` so a vanished lane is **skipped
+  with a note** (`"lane '<lane>' no longer exists (remote branch deleted) — nothing to sync"`)
+  instead of dying.
+- Confirm whether pyjutsu `git_fetch` prunes the dangling `<lane>@origin` row (jj fetch
+  normally does); if not, the retirement path's defensive `git_push(delete=True)` + the local
+  skip cover it.
+
+### `src/gitman/render.py`
+Add an `adopt` branch to `render_intent` only if it special-cases per-intent; otherwise the
+generic `messages`/`notes`/`undo_command` path already covers it (verify — `sync`/`land` use
+the generic path).
+
+---
+
+## 3. Safety / refusal matrix ("refuses safely, no data loss")
+
+| Condition | Behavior |
+|---|---|
+| No remotes configured | `exit 2`: "no git remote — nothing to adopt." |
+| `<trunk>@origin` absent after fetch | `exit 1`: trunk not pushed / wrong remote. |
+| `origin/<trunk> == local trunk` | `ALREADY_CURRENT`, exit 0 (still rebase drifted lanes). |
+| Local trunk **ahead** of origin (un-pushed lands), no `--force` | `exit 1`, refuse, explain (push or `--force`). **Never silently discard.** |
+| `--force` with local-ahead | hard-set trunk to `origin/<trunk>`; note N local commits dropped (undoable). |
+| Off-canonical (strays) / stale `@` | `precheck_canonical` + `_assert_fresh` already refuse → exit 1 → `gitman reconcile`. **Free.** |
+| Survivor lane conflicts on rebase | non-blocking (like `sync`): keep the conflicted rebase, note `gitman resolve`, exit 1, **do not abandon**. |
+
+---
+
+## 4. Undo & canonicity
+Fully reused from `canonical_guard`: `op_before` captured after the precheck snapshot; the
+fetch op + adopt tx(s) sit above it; any postcondition violation calls
+`restore_operation(op_before)`; on success `write_undo_checkpoint(..., "adopt")` is recorded,
+so `gitman undo` reverts the **entire** adoption (trunk move + lane retirements + fetch) in one
+step. `git_export` mirrors the new trunk ref to colocated git. Report note: *"trunk and lanes
+reverted locally; the forge merge and any deleted remote branches are not restored by undo."*
+
+---
+
+## 5. Tests (`tests/test_adopt_integration.py`, in-process over pyjutsu)
+Build on the existing `test_colocated_git_sync.py` / `test_m3_integration.py` harness
+(two colocated repos as "local" + "origin"). Cases:
+
+1. **Squash-merge (headline repro).** Lane `m0` (2 commits) → push → on "origin" squash into
+   one new-SHA commit on trunk → `do_adopt` → assert local trunk `commit_id == origin/trunk`,
+   `m0` retired, `CANONICAL · 0 lanes`, `doctor` HEALTHY. **(§8 reference scenario — acceptance.)**
+2. **Merge-commit** (lane SHAs preserved as ancestors) → `m0` retired via ancestry path.
+3. **Rebase-merge** (lane commits replayed, new SHAs, identical content) → retired via
+   empty-after-rebase.
+4. **Un-merged survivor** alongside a merged lane: merged retired, survivor rebased onto new
+   trunk and **kept** (not abandoned).
+5. **Local trunk ahead** → refuses without `--force`; `--force` hard-sets and is undoable.
+6. **Sharp edge #1**: publish lane, delete its remote branch server-side, fetch → `gitman sync`
+   no longer raises "revision doesn't exist" (skips with note); `gitman adopt` retires it.
+7. **`--dry-run`** mutates nothing (op log unchanged) but reports the correct plan.
+8. **`gitman undo`** after adopt restores trunk + lanes.
+9. **`ALREADY_CURRENT`** no-op when trunk == origin.
+
+Run: `devenv shell -- bash -c 'gitman:lint && gitman:test'`.
+
+---
+
+## 6. Docs / concept / skill
+- **`docs/GITMAN_CONCEPT.md`**: amend **I5** ("trunk advances only via `land` **or `adopt`**");
+  add `adopt` to the intents table; add a "Forge-PR adoption" subsection describing the
+  `publish → PR → merge → adopt` loop as the sanctioned forge path (complementing local `land`).
+- **`.claude/skills/gitman/SKILL.md`**: add the forge loop — after `gh pr merge`, run
+  `gitman adopt` (never the raw reconcile dance). Reinforce: **keep `gitman.toml` / VC wiring on
+  trunk, never only in a lane** (so retirement can't delete it — sharp edge #2).
+- **Option C interim runbook**: fold the §4 dance into the skill as the *deprecated fallback*.
+
+---
+
+## 7. Sequencing (suggested PRs)
+1. **PR-1 — status honesty + sharp-edge-#1 fix.** `origin/<trunk>` divergence in
+   `capture_state`/status + `do_sync` resilient to server-deleted lane branches. Independently
+   valuable, low risk, unblocks discovery. (Tests 6 + status assertions.)
+2. **PR-2 — `gitman adopt` core.** `do_adopt`, the `_postcondition` one-liner, content-merged
+   detection, CLI wiring, `--force` / `--dry-run`. (Tests 1–5, 7–9.)
+3. **PR-3 — docs/concept/skill** updates + deprecate the manual dance.
+
+---
+
+## 8. Open risks / validate during build
+- **Intra-transaction range reads.** Confirm `session.view()` reflects in-flight tx rebases for
+  the post-rebase emptiness check; if not, split into rebase-tx then classify-tx under the same
+  `canonical_guard`. **Validate first.**
+- **Does pyjutsu `git_fetch` prune dangling `<lane>@origin` rows?** If yes, sharp-edge-#1 is
+  mostly free; if no, local-skip + defensive delete-push covers it. Verify in the harness.
+- **`mode="branch"` when the lane root is already an ancestor of trunk** (merge-commit case) —
+  confirm a clean no-op vs error; the ancestry pre-check (`trunk..lane` empty → skip rebase)
+  avoids relying on it.
+- **`--force` hard-set vs FF.** `set_bookmark` is create-or-move (not FF-only), so the
+  `ahead`-check is the sole FF-safety gate. Keep it.
+
+---
+
+## 9. Acceptance criteria (from ISSUE §7)
+- [ ] One command: "PR merged, trunk behind" → CANONICAL · 0 lanes, local `trunk == origin`,
+      **no raw git**, fully `gitman undo`-able.
+- [ ] Correct across **squash / merge-commit / rebase** (content-based detection, not SHA).
+- [ ] Un-merged lane survives and is rebased onto the adopted trunk (not abandoned).
+- [ ] Refuses safely on un-pushed local-trunk commits or dirty/stale tree.
+- [ ] `gitman sync` no longer wedges on a server-deleted remote lane branch.
+- [ ] `gitman doctor` HEALTHY afterward; regression test reproduces the squash-merge scenario.

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/PLAN.md
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/PLAN.md
@@ -29,57 +29,111 @@ Consequences:
 
 `do_adopt(session, *, force: bool, dry_run: bool)` in `core.py`.
 
+> **Validation findings — jj-lib 0.42, 2026-06-26 (`probes/*.py`).** Four throwaway probes
+> measured what jj actually does, overturning the ISSUE's original §3 inference. These shape the
+> algorithm below; build against them, not against the pre-validation sketch:
+>
+> 1. **Fetch auto-fast-forwards local trunk.** `git_fetch` moves the tracked local `<trunk>`
+>    bookmark to a moved `origin/<trunk>` whenever it's a fast-forward (the clean squash / merge /
+>    rebase case — local trunk is still an ancestor of the forge head). So in the clean case `adopt`
+>    does **not** need an explicit `set_bookmark`; the fetch already advances trunk.
+> 2. **Fetch prunes deleted lanes.** A lane whose remote branch was deleted server-side loses both
+>    its `<lane>@origin` row *and* its un-diverged local bookmark. So forge-merged-and-deleted lanes
+>    are *already retired by the fetch* — `adopt` cleans up the residue (workspaces, a stale `@`),
+>    it doesn't have to abandon them by hand.
+> 3. **Fetch orphans `@` (stale).** When `@` sat on a pruned lane, the fetch leaves `@` **stale** on
+>    an empty orphan. `adopt` must **un-stale** it (`ws.update_stale()` / re-point onto the new
+>    trunk) as an explicit step — this is new vs. the original plan.
+> 4. **Diverged trunk → *conflicted* bookmark, not "behind N".** If local trunk has un-pushed lands
+>    *and* origin moved, jj can't FF, so it records a **conflicted** `<trunk>` bookmark:
+>    `resolve("<trunk>")` raises *"Name `<trunk>` is conflicted"*. This both (a) makes the diverged
+>    case the *only* one needing the explicit `set_bookmark(trunk, "<trunk>@<remote>")` hard-set
+>    (gated by `--force`), and (b) currently **crashes** `capture_state`/`status` — so a
+>    conflicted-trunk tolerance is a prerequisite (see §2).
+>
+> Net: the postcondition exemption for `adopt` (§2) is the real unlock — it lets the fetch's advance
+> *stand* instead of being reverted as "trunk moved outside a land." Everything else is residue
+> cleanup + the diverged hard-set.
+
 ### Verified pyjutsu primitives it stands on
-- `ws.git_fetch(remote)` → updates the `<trunk>@origin` remote-tracking bookmark row.
+- `ws.git_fetch(remote)` → updates `<trunk>@origin`, **auto-FFs the local `<trunk>` bookmark**
+  (clean case), and **prunes** lanes whose remote branch was deleted. The advance is mostly done
+  here, not by an explicit set-bookmark (finding 1/2).
+- `ws.git_fetch(remote, bookmarks=[<lane>, …])` → **lane-scoped fetch**: `git_fetch` takes a
+  bookmark filter, so `do_sync` can fetch *only* lane branches and never touch trunk — the clean way
+  to keep `sync` from tripping the trunk-frozen postcondition (see §2 / §3-of-ISSUE).
 - `view.resolve("<trunk>@origin")` → fetched remote head `Commit` (revset form `name@remote`
-  is confirmed working).
-- `tx.set_bookmark(trunk, "<trunk>@origin")` → **the missing primitive**: move local trunk
-  to the forge head. (create-or-move; NOT fast-forward-only — FF-safety is enforced by our
-  refusal logic, not the primitive.)
+  confirmed working).
+- `ws.update_stale()` → refresh a `@` the fetch left stale (finding 3).
+- `tx.set_bookmark(trunk, "<trunk>@origin")` → hard-set local trunk to the forge head; **needed
+  only in the diverged/conflicted case** under `--force` (finding 4). Create-or-move, NOT FF-only —
+  FF-safety is enforced by our refusal logic.
 - `tx.rebase(lane, onto=trunk, mode="branch")` → returns the rebased `Commit`; exposes
   `.has_conflict` and `.is_empty`.
 - `view.log("<trunk>..<lane>")` → range; emptiness / ancestry checks.
-- `tx.abandon(change_id)` / `tx.delete_bookmark(name)` → retire merged lanes (same calls
-  `do_abandon` uses).
+- `tx.abandon(change_id)` / `tx.delete_bookmark(name)` → retire merged lanes the fetch did *not*
+  already prune (same calls `do_abandon` uses).
 
-### Sequence (inside `canonical_guard(session, "adopt")`)
+### Sequence (inside `canonical_guard(session, "adopt")` — the intent the postcondition *exempts* from the trunk-frozen rule)
+
+The fetch does most of the advancing (findings 1–2); `adopt`'s job is to let it stand, un-stale the
+`@` it orphans (finding 3), and hard-set only when the trunk diverged into a conflicted bookmark
+(finding 4).
 
 ```
-trunk = require_trunk(config)
-remote = pick_remote(ws)          # refuse if not ws.remotes()
+trunk  = require_trunk(config)
+remote = pick_remote(ws)                       # exit 2 if not ws.remotes()
 
-# --- 1. FETCH (own op) ---
-ws.git_fetch(remote)              # updates <trunk>@origin; prunes server-deleted lane refs
+# Capture the PRE-fetch facts — the fetch will move trunk and prune lanes under us.
+local_trunk_before = session.view().resolve(trunk).commit_id
+lanes_before       = set(lane_names(session, trunk))
+
+# --- 1. FETCH (own op): FFs local trunk (clean), prunes merged+deleted lanes, may stale @ ---
+ws.git_fetch(remote)
 view = session.view()
 try:
     origin_trunk = view.resolve(f"{trunk}@{remote}")
 except RevsetError:
     raise GitmanError(f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?", exit_code=1)
 
-local_trunk = view.resolve(trunk)
-
 # --- 2. CLASSIFY the trunk relationship ---
-if origin_trunk.commit_id == local_trunk.commit_id:
-    -> ALREADY_CURRENT (no trunk move; still rebase/retire any drifted lanes below)
-ahead  = view.log(f"{origin_trunk.commit_id}..{trunk}")   # local commits NOT on origin
-behind = view.log(f"{trunk}..{origin_trunk.commit_id}")   # forge commits NOT local
-if ahead and not force:
-    raise GitmanError(
-        f"local {trunk} has {len(ahead)} commit(s) not on {remote} — un-pushed local lands. "
-        f"Re-run with --force to hard-set trunk to {remote} (discards them), or push them first.",
-        exit_code=1)
+trunk_conflicted = _is_conflicted(view, trunk)         # resolve(trunk) raised "Name <trunk> is conflicted"
+if trunk_conflicted:
+    # Diverged: local had un-pushed lands AND origin moved → jj left a *conflicted* bookmark
+    # (finding 4), so the fetch could not FF. This is the ONLY case needing an explicit hard-set.
+    if not force:
+        raise GitmanError(
+            f"local {trunk} diverged from {remote} (un-pushed local lands + forge moved). "
+            f"Push your lands first, or re-run with --force to hard-set {trunk} to {remote} "
+            f"(discards the un-pushed lands; undoable).", exit_code=1)
+elif local_trunk_before == origin_trunk.commit_id and lanes_before == set(lane_names(session, trunk)):
+    -> ALREADY_CURRENT  (pre-fetch trunk already == origin and nothing pruned) — exit 0, no-op
 
-# --- 3. ADVANCE trunk + reconcile lanes (one tx) ---
-lanes = sorted(lane_names(session, trunk))     # survivors + to-retire decided by content
+# --- 3. (hard-set if diverged) + reconcile surviving lanes + un-stale @ (one tx + cleanup) ---
 with ws.transaction("gitman:adopt", auto_snapshot=False) as tx:
-    tx.set_bookmark(trunk, f"{trunk}@{remote}")     # FF (or hard-set under --force)
-    for lane in lanes:
-        retired, conflicted = _reconcile_lane_against_adopted_trunk(session, tx, trunk, lane)
-        ...accumulate report rows...
-# guard postcondition asserts canonical; undo checkpoint; git_export
+    if trunk_conflicted:                       # resolve the conflict toward the forge head
+        tx.set_bookmark(trunk, f"{trunk}@{remote}")
+    for lane in sorted(lane_names(session, trunk)):   # only lanes the fetch did NOT already prune
+        _reconcile_lane_against_adopted_trunk(session, tx, trunk, lane)   # rebase, or retire-if-empty
+if ws.is_stale():                              # the fetch orphaned @ off a pruned lane (finding 3)
+    ws.update_stale()
+# Residue: lanes in (lanes_before − now) were retired *by the fetch* — forget their workspaces and
+# report each as "retired (forge-merged): <lane>". Then the adopt-exempt postcondition asserts
+# canonical; undo checkpoint; git_export.
 ```
 
+> **Note on `ALREADY_CURRENT` / `ahead`/`behind`.** The original plan computed `ahead`/`behind`
+> revsets to detect un-pushed local lands. That's now redundant and unreliable: jj signals
+> divergence structurally via the **conflicted bookmark** (finding 4), which a revset can't even
+> evaluate (`resolve` raises). Detect divergence via `_is_conflicted`, not via counting `ahead`.
+
 ### Content-merged detection — `_reconcile_lane_against_adopted_trunk`
+
+> **Scope note (findings 1–2).** Lanes whose remote branch was **deleted** at merge time (the common
+> `gh pr merge --delete-branch`) are *already pruned by the fetch* and never reach this function —
+> they're handled as residue in §1 step 3. This detection covers the **surviving** lanes: a
+> squash/rebase-merge that kept the branch, a merge-commit whose lane is still local, or any lane the
+> user never published. The emptiness-after-rebase test still earns its keep for those.
 
 The crux the issue demands: must work across **squash / merge-commit / rebase** re-hash.
 pyjutsu exposes **no patch-id**, but it gives the right primitive: **emptiness after rebase
@@ -159,27 +213,41 @@ def adopt(
     _finish_intent(do_adopt(_session(), force=force, dry_run=dry_run))
 ```
 
-### `src/gitman/state.py` + `models.py` — status honesty (`origin/<trunk>` divergence)
-The concept doc already imagines `trunk: main @ def456 (up to date with origin/main)`, but
-`capture_state` never reads the remote. Add (when `remotes()` non-empty): resolve
-`<trunk>@<remote>` if present, compute ahead/behind, set a new `TrunkRef` field
-(e.g. `remote_relation: "current" | "behind N" | "ahead N" | "diverged"`). When behind,
-append a note: `"local <trunk> is N behind origin — run \`gitman adopt\`."` This makes the gap
-**discoverable** instead of silent — directly addresses §3's "`sync` reports success while
-local main stays put."
+### `src/gitman/state.py` + `models.py` — status honesty (conflicted/divergent trunk)
+**Revised by finding 4.** The original idea — read `<trunk>@<remote>`, compute ahead/behind, and
+note "N behind origin" — is **low-value on jj 0.42**: `status` does no network fetch, so it only
+knows the *last* fetch's `<trunk>@<remote>`; and after a fetch the clean case reads `behind == 0`
+(trunk auto-FF'd) while the diverged case **crashes `capture_state`** because `view.resolve(trunk)`
+raises *"Name `<trunk>` is conflicted"*. So the genuinely valuable honesty fix is:
+- **Make `capture_state` tolerant of a conflicted trunk bookmark.** Wrap the `resolve(trunk)` so a
+  conflicted-name `RevsetError` is classified as off-canonical / "trunk diverged", not "trunk not
+  found — run doctor". Report `trunk: <name> @ DIVERGED  — local trunk diverged from <remote>; run
+  \`gitman adopt\` (--force to take origin).` Exit 1 (a VC decision), like other off-canonical states.
+- Keep the existing `TrunkRef.behind_remote`/`ahead_remote` fields as **best-effort**: populate them
+  only when trunk resolves *and* `<trunk>@<remote>` is present and non-conflicted; otherwise 0. They
+  remain a cheap, honest readout (e.g. after a lane-only `sync` that fetched origin without FFing
+  trunk) without being load-bearing.
 
-### Sharp edge #1 fix — server-deleted lane branch (shared by `do_sync` and `adopt`)
-Root cause: after `gh pr merge --delete-branch`, a fetch deletes the tracked remote ref and
-(because the local bookmark tracks it) can drop/dangle the **local** lane bookmark, so
-`tx.rebase(lane, …)` raises `RevsetError: Revision <lane> doesn't exist`. Fix once, use in both:
-- Re-read `existing = lane_names(session, trunk)` **after** fetch; iterate only over lanes that
-  still resolve.
-- In `do_sync`'s rebase loop, guard each `tx.rebase(lane, …)` so a vanished lane is **skipped
-  with a note** (`"lane '<lane>' no longer exists (remote branch deleted) — nothing to sync"`)
-  instead of dying.
-- Confirm whether pyjutsu `git_fetch` prunes the dangling `<lane>@origin` row (jj fetch
-  normally does); if not, the retirement path's defensive `git_push(delete=True)` + the local
-  skip cover it.
+This is the PR-1 "status honesty" deliverable — reframed from a numeric ahead/behind (which barely
+fires) to **not crashing on, and clearly reporting, a diverged trunk** (the state `adopt --force`
+resolves).
+
+### `src/gitman/core.py` — `do_sync`: fetch lanes-only + skip vanished lanes (sharp edge #1)
+Two coupled fixes so `sync` stops both wedging *and* silently reverting:
+- **Fetch only the lane branches, never trunk.** `do_sync` today calls `git_fetch(remote)`, which
+  auto-FFs local trunk → the postcondition reverts it as "trunk moved outside a land" (the real §3
+  cause). Switch to `git_fetch(remote, bookmarks=sorted(targets))` so the fetch can't move trunk and
+  `sync` keeps its narrow contract ("rebase lanes onto *local* trunk"). Trunk advancement is
+  `adopt`'s job, by design (separate verb). *Build check:* confirm a lane-scoped fetch leaves trunk
+  untouched in the squash harness (it should — trunk isn't in the bookmark filter).
+- **Skip vanished lanes.** After the fetch, re-read `surviving = lane_names(session, trunk)` and
+  rebase only `targets ∩ surviving`; a lane the fetch pruned (remote branch deleted) is **skipped
+  with a note** (`"lane '<lane>' no longer exists (remote branch deleted) — nothing to sync; \`gitman
+  adopt\` to retire it."`) instead of raising `RevsetError`. *(Already implemented in the PR-1 WIP.)*
+- **Optional signpost:** if a lane-only fetch reveals `<trunk>@<remote>` is ahead of local trunk,
+  add a note "origin/<trunk> moved — run `gitman adopt`." Cheap discoverability without moving trunk.
+
+`adopt` reuses the same "re-read survivors after fetch" discipline (lanes_before − now = retired).
 
 ### `src/gitman/render.py`
 Add an `adopt` branch to `render_intent` only if it special-cases per-intent; otherwise the
@@ -194,10 +262,10 @@ the generic path).
 |---|---|
 | No remotes configured | `exit 2`: "no git remote — nothing to adopt." |
 | `<trunk>@origin` absent after fetch | `exit 1`: trunk not pushed / wrong remote. |
-| `origin/<trunk> == local trunk` | `ALREADY_CURRENT`, exit 0 (still rebase drifted lanes). |
-| Local trunk **ahead** of origin (un-pushed lands), no `--force` | `exit 1`, refuse, explain (push or `--force`). **Never silently discard.** |
-| `--force` with local-ahead | hard-set trunk to `origin/<trunk>`; note N local commits dropped (undoable). |
-| Off-canonical (strays) / stale `@` | `precheck_canonical` + `_assert_fresh` already refuse → exit 1 → `gitman reconcile`. **Free.** |
+| pre-fetch `local trunk == origin/<trunk>` & nothing pruned | `ALREADY_CURRENT`, exit 0 (still rebase drifted lanes). |
+| **Diverged** — un-pushed local lands + origin moved → jj leaves a **conflicted** `<trunk>` bookmark, no `--force` | `exit 1`, refuse, explain (push lands or `--force`). **Never silently discard.** Detected via `_is_conflicted`, not an `ahead` count (finding 4). |
+| `--force` with a diverged/conflicted trunk | `tx.set_bookmark(trunk, "<trunk>@<remote>")` resolves the conflict toward the forge head; note the un-pushed lands dropped (undoable). |
+| Off-canonical (strays) / stale `@` *before* adopt | `precheck_canonical` + `_assert_fresh` refuse at guard entry → exit 1 → `gitman reconcile`. **Free.** (The stale `@` the fetch creates *during* adopt is expected and `update_stale`'d — finding 3.) |
 | Survivor lane conflicts on rebase | non-blocking (like `sync`): keep the conflicted rebase, note `gitman resolve`, exit 1, **do not abandon**. |
 
 ---
@@ -224,9 +292,12 @@ Build on the existing `test_colocated_git_sync.py` / `test_m3_integration.py` ha
    empty-after-rebase.
 4. **Un-merged survivor** alongside a merged lane: merged retired, survivor rebased onto new
    trunk and **kept** (not abandoned).
-5. **Local trunk ahead** → refuses without `--force`; `--force` hard-sets and is undoable.
-6. **Sharp edge #1**: publish lane, delete its remote branch server-side, fetch → `gitman sync`
-   no longer raises "revision doesn't exist" (skips with note); `gitman adopt` retires it.
+5. **Diverged trunk** (un-pushed local land + origin moved → conflicted `<trunk>` bookmark) →
+   `adopt` refuses without `--force`; `status` reports "trunk diverged" instead of crashing;
+   `--force` hard-sets to origin and is undoable.
+6. **Sharp edge #1**: publish lane, delete its remote branch server-side → `gitman sync`
+   (lanes-only fetch) no longer raises "revision doesn't exist" (skips with note) and does **not**
+   revert trunk; `gitman adopt` retires the lane.
 7. **`--dry-run`** mutates nothing (op log unchanged) but reports the correct plan.
 8. **`gitman undo`** after adopt restores trunk + lanes.
 9. **`ALREADY_CURRENT`** no-op when trunk == origin.
@@ -247,9 +318,11 @@ Run: `devenv shell -- bash -c 'gitman:lint && gitman:test'`.
 ---
 
 ## 7. Sequencing (suggested PRs)
-1. **PR-1 — status honesty + sharp-edge-#1 fix.** `origin/<trunk>` divergence in
-   `capture_state`/status + `do_sync` resilient to server-deleted lane branches. Independently
-   valuable, low risk, unblocks discovery. (Tests 6 + status assertions.)
+1. **PR-1 — `sync` lanes-only + conflicted-trunk tolerance + sharp-edge-#1.** (a) `do_sync` fetches
+   lane branches only (no trunk auto-FF → no revert) and skips fetch-pruned lanes; (b)
+   `capture_state`/`status` tolerates and reports a diverged/conflicted trunk instead of crashing,
+   keeping `behind/ahead` best-effort. Independently valuable, low risk, unblocks discovery.
+   (Tests 5 status-side + 6.)
 2. **PR-2 — `gitman adopt` core.** `do_adopt`, the `_postcondition` one-liner, content-merged
    detection, CLI wiring, `--force` / `--dry-run`. (Tests 1–5, 7–9.)
 3. **PR-3 — docs/concept/skill** updates + deprecate the manual dance.
@@ -257,16 +330,32 @@ Run: `devenv shell -- bash -c 'gitman:lint && gitman:test'`.
 ---
 
 ## 8. Open risks / validate during build
-- **Intra-transaction range reads.** Confirm `session.view()` reflects in-flight tx rebases for
-  the post-rebase emptiness check; if not, split into rebase-tx then classify-tx under the same
-  `canonical_guard`. **Validate first.**
-- **Does pyjutsu `git_fetch` prune dangling `<lane>@origin` rows?** If yes, sharp-edge-#1 is
-  mostly free; if no, local-skip + defensive delete-push covers it. Verify in the harness.
-- **`mode="branch"` when the lane root is already an ancestor of trunk** (merge-commit case) —
-  confirm a clean no-op vs error; the ancestry pre-check (`trunk..lane` empty → skip rebase)
-  avoids relying on it.
-- **`--force` hard-set vs FF.** `set_bookmark` is create-or-move (not FF-only), so the
-  `ahead`-check is the sole FF-safety gate. Keep it.
+
+**Resolved by the 2026-06-26 probes (`probes/*.py`):**
+- ✅ **`git_fetch` prunes deleted lanes** — drops `<lane>@origin` *and* the un-diverged local
+  `<lane>` bookmark. Sharp-edge-#1 fix = re-read survivors after fetch + skip. (probe 1)
+- ✅ **`git_fetch` auto-FFs local trunk** in the clean case → `adopt` rides the fetch; `sync` must
+  fetch lanes-only to avoid it. (probes 2–3)
+- ✅ **`git_fetch` orphans `@` (stale)** when `@` was on a pruned lane → `adopt` must `update_stale`.
+  (probe 3)
+- ✅ **Diverged trunk = conflicted bookmark**, `resolve(trunk)` raises *"Name … is conflicted"* →
+  detect via `_is_conflicted`; it crashes `capture_state` today (PR-1 must tolerate it). (probe 4)
+- ✅ **Real `do_sync` reverts** in the squash repro (`reverted: trunk moved outside a land`),
+  restoring trunk behind — confirming the guard, not jj, is the §3 cause. (probe `sync_squash`)
+
+**Still to validate while building:**
+- **`tx.set_bookmark(trunk, "<trunk>@<remote>")` on a *conflicted* bookmark** — confirm it resolves
+  the divergence (sets local trunk to the forge head, clearing the conflict) rather than erroring.
+  The `--force` path depends on it; probe before relying on it.
+- **`update_stale()` placement.** Confirm calling it *inside* `canonical_guard` (after the adopt tx)
+  leaves a canonical `@` on the new trunk and doesn't itself trip the postcondition; if it publishes
+  its own op awkwardly, sequence it like the other multi-op guard bodies.
+- **Intra-transaction range reads** for the post-rebase emptiness check on *surviving* lanes —
+  confirm `session.view()` reflects an in-flight `tx.rebase`; if not, split rebase-tx then
+  classify-tx under the same guard (still untested).
+- **`mode="branch"` when the lane is already an ancestor of trunk** (merge-commit survivor) — the
+  ancestry pre-check (`trunk..lane` empty → retire, skip rebase) avoids relying on its no-op
+  behavior; confirm.
 
 ---
 

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_diverged.py
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_diverged.py
@@ -1,0 +1,77 @@
+"""Throwaway probe: the DIVERGED case — local trunk has an un-pushed land AND origin
+advanced independently. Does jj fetch refuse to fast-forward (leaving local trunk
+behind+ahead = a real `behind_remote` signal), and what shape does the bookmark take?
+
+Run: devenv shell -- python .scratch/probe_diverged.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+from pyjutsu.errors import RevsetError
+
+
+def sh(*args, cwd=None):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def show(ws, label):
+    v = ws.head()
+    print(f"\n--- {label} ---")
+    for nm in ("main", "main@origin"):
+        try:
+            c = v.resolve(nm)
+            print(f"  {nm:14} {c.commit_id[:8]} desc={c.description.strip()[:24]!r}")
+        except RevsetError:
+            print(f"  {nm:14} <none>")
+    print("  bookmarks:", [(b.name, b.remote) for b in v.bookmarks()])
+    for rng in ("main..main@origin", "main@origin..main"):
+        try:
+            print(f"  {rng}: {len(v.log(rng))}")
+        except RevsetError as e:
+            print(f"  {rng}: ERR {str(e)[:40]}")
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    remote = tmp / "remote.git"
+    sh("git", "init", "--bare", str(remote))
+    work = tmp / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+
+    # local un-pushed land: advance local main by one commit, do NOT push.
+    with ws.transaction("local land") as tx:
+        tx.new("main")
+        tx.set_bookmark("main", "@")
+        tx.describe("@", "local land (unpushed)")
+    (work / "local.txt").write_text("local\n")
+    ws.snapshot()
+    with ws.transaction("new @") as tx:
+        tx.new("main")  # move @ off main so main is frozen at the land
+
+    # origin advances independently (another actor).
+    other = tmp / "other"
+    sh("git", "clone", str(remote), str(other))
+    (other / "forge.txt").write_text("forge\n")
+    sh("git", "add", ".", cwd=other)
+    sh("git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", "forge land", cwd=other)
+    sh("git", "push", "origin", "HEAD:main", cwd=other)
+
+    op = ws.git_fetch("origin")
+    print("fetch op:", op.id[:12] if op else None, "| stale@?", ws.is_stale())
+    show(ws, "after fetch (diverged: local ahead 1, origin ahead 1)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_fetch_advance.py
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_fetch_advance.py
@@ -1,0 +1,64 @@
+"""Throwaway probe: does jj git_fetch auto-advance the LOCAL trunk bookmark when
+origin/<trunk> moves (another actor merged), or leave local trunk behind?
+
+This decides whether `behind_remote` is detectable and whether `gitman adopt` is needed at all.
+
+Run: devenv shell -- python .scratch/probe_fetch_advance.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+
+def sh(*args, cwd=None):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    remote = tmp / "remote.git"
+    sh("git", "init", "--bare", str(remote))
+    work = tmp / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+
+    local_before = ws.head().resolve("main").commit_id
+
+    # Another actor advances origin/main by 2 commits (a forge merge).
+    other = tmp / "other"
+    sh("git", "clone", str(remote), str(other))
+    for i in range(2):
+        (other / f"forge{i}.txt").write_text("forge\n")
+        sh("git", "add", ".", cwd=other)
+        sh("git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", f"forge {i}", cwd=other)
+    sh("git", "push", "origin", "HEAD:main", cwd=other)
+
+    # Fetch in the work repo.
+    op = ws.git_fetch("origin")
+    print("fetch op:", op.id[:12] if op else None)
+
+    v = ws.head()
+    local_after = v.resolve("main").commit_id
+    remote_after = v.resolve("main@origin").commit_id
+    print("local main before fetch:", local_before[:8])
+    print("local main after  fetch:", local_after[:8])
+    print("main@origin after fetch:", remote_after[:8])
+    print("local advanced on fetch?", local_after != local_before)
+    print("local == origin?       ", local_after == remote_after)
+    print("behind (main..main@origin):", len(v.log("main..main@origin")))
+    print("ahead  (main@origin..main):", len(v.log("main@origin..main")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_fetch_prune.py
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_fetch_prune.py
@@ -1,0 +1,83 @@
+"""Throwaway probe (PR-1 Step-0): what does pyjutsu git_fetch do to a lane whose
+remote branch was deleted server-side?
+
+Builds a two-repo harness (work + bare origin), publishes a lane, deletes its branch
+in the bare remote, fetches, and inspects the local bookmark + resolvability.
+
+Run: devenv shell -- python .scratch/probe_fetch_prune.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+from pyjutsu.errors import RevsetError
+
+
+def sh(*args, cwd=None):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def dump(ws, label):
+    v = ws.head()
+    print(f"\n--- {label} ---")
+    rows = [(b.name, b.remote) for b in v.bookmarks()]
+    print("  bookmarks:", rows)
+    for nm in ("feat", "feat@origin", "main", "main@origin"):
+        try:
+            c = v.resolve(nm)
+            print(f"  resolve({nm!r}) -> {c.commit_id[:8]}")
+        except RevsetError as e:
+            print(f"  resolve({nm!r}) -> RevsetError: {str(e)[:60]}")
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    remote = tmp / "remote.git"
+    sh("git", "init", "--bare", str(remote))
+    work = tmp / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+
+    # publish a lane
+    with ws.transaction("lane") as tx:
+        tx.new("main")
+        tx.create_bookmark("feat", "@")
+    (work / "f.txt").write_text("base\nfeat\n")
+    ws.snapshot()
+    with ws.transaction("describe") as tx:
+        tx.describe("@", "feat work")
+    ws.git_push("origin", "feat", allow_new=True)
+    dump(ws, "after publish feat")
+
+    # delete the branch on the bare remote (simulates `gh pr merge --delete-branch`)
+    sh("git", "update-ref", "-d", "refs/heads/feat", cwd=remote)
+    print("\n[deleted refs/heads/feat in the bare remote]")
+
+    # fetch — does it prune feat@origin? does the local `feat` bookmark survive?
+    op = ws.git_fetch("origin")
+    print(f"\ngit_fetch returned op: {op.id[:12] if op else None}")
+    dump(ws, "after fetch (remote branch gone)")
+
+    # can we still rebase the local lane?
+    try:
+        with ws.transaction("rebase probe") as tx:
+            r = tx.rebase("feat", onto=["main"], mode="branch")
+            print(f"\nrebase(feat) OK -> {r.commit_id[:8]} empty={r.is_empty} conflict={r.has_conflict}")
+    except Exception as e:
+        print(f"\nrebase(feat) raised: {type(e).__name__}: {str(e)[:80]}")
+
+    print(f"\n(tmp dir: {tmp})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_squash_scenario.py
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_squash_scenario.py
@@ -1,0 +1,95 @@
+"""Throwaway probe: the headline squash-merge scenario, end to end, to see what jj
+fetch actually does to the FROZEN local trunk while @ is on a lane.
+
+Mirrors ISSUE §2: start lane m0 (2 commits) -> publish -> squash-merge on origin as a
+new SHA -> fetch -> inspect local main vs main@origin and the lane.
+
+Run: devenv shell -- python .scratch/probe_squash_scenario.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+from pyjutsu.errors import RevsetError
+
+
+def sh(*args, cwd=None):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def show(ws, label):
+    v = ws.head()
+    print(f"\n--- {label} ---")
+    for nm in ("main", "main@origin", "m0", "m0@origin", "@"):
+        try:
+            c = v.resolve(nm)
+            print(f"  {nm:14} {c.commit_id[:8]} empty={c.is_empty} desc={c.description.strip()[:24]!r}")
+        except RevsetError:
+            print(f"  {nm:14} <none>")
+    print("  bookmarks:", [(b.name, b.remote) for b in v.bookmarks()])
+    try:
+        print("  behind (main..main@origin):", len(v.log("main..main@origin")))
+        print("  ahead  (main@origin..main):", len(v.log("main@origin..main")))
+    except RevsetError as e:
+        print("  range err:", str(e)[:50])
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    remote = tmp / "remote.git"
+    sh("git", "init", "--bare", str(remote))
+    work = tmp / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+    main_c0 = ws.head().resolve("main").commit_id
+
+    # lane m0: 2 commits, @ on the lane (NOT on trunk)
+    with ws.transaction("m0") as tx:
+        tx.new("main")
+        tx.create_bookmark("m0", "@")
+    (work / "a.txt").write_text("aaa\n")
+    ws.snapshot()
+    with ws.transaction("desc a") as tx:
+        tx.describe("@", "add a")
+    with ws.transaction("m0 c2") as tx:
+        tx.new("@")
+        tx.set_bookmark("m0", "@")
+    (work / "b.txt").write_text("bbb\n")
+    ws.snapshot()
+    with ws.transaction("desc b") as tx:
+        tx.describe("@", "add b")
+    ws.git_push("origin", "m0", allow_new=True)
+    show(ws, "after publish m0 (@ on m0)")
+
+    # squash-merge on origin: another clone collapses m0's files into ONE new-SHA commit on main,
+    # then deletes the m0 branch (gh pr merge --squash --delete-branch).
+    other = tmp / "other"
+    sh("git", "clone", str(remote), str(other))
+    sh("git", "checkout", "main", cwd=other)
+    (other / "a.txt").write_text("aaa\n")
+    (other / "b.txt").write_text("bbb\n")
+    sh("git", "add", ".", cwd=other)
+    sh("git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", "squash: m0 (#1)", cwd=other)
+    sh("git", "push", "origin", "HEAD:main", cwd=other)
+    sh("git", "push", "origin", "--delete", "m0", cwd=other)
+    print("\n[origin: squash-merged m0 into main as a new SHA; deleted m0 branch]")
+
+    # fetch in the work repo (what `gitman sync`/`adopt` would do first)
+    op = ws.git_fetch("origin")
+    print("\nfetch op:", op.id[:12] if op else None, " | stale@?", ws.is_stale())
+    show(ws, "after fetch (squash-merged, m0 deleted)")
+    print("\nmain_c0 was:", main_c0[:8])
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_sync_squash.py
+++ b/.scratch/projects/07-forge-pr-trunk-reconcile/probes/probe_sync_squash.py
@@ -1,0 +1,92 @@
+"""Throwaway probe: drive the REAL gitman do_sync (with the PR-1 sharp-edge fix already
+applied) through the squash-merge scenario, to see the actual current behavior:
+does it revert because fetch moved trunk? does capture_state survive the stale @?
+
+Run: devenv shell -- python .scratch/probe_sync_squash.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import GitmanError, do_sync
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def sh(*args, cwd=None):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def sess(work):
+    return Session.load(work, CFG)
+
+
+def main():
+    tmp = Path(tempfile.mkdtemp())
+    remote = tmp / "remote.git"
+    sh("git", "init", "--bare", str(remote))
+    work = tmp / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+
+    from gitman.core import do_save, do_start
+
+    do_start(sess(work), "m0", workspace=False)
+    (work / "a.txt").write_text("aaa\n")
+    do_save(sess(work), "add a")
+    from gitman.core import do_publish
+
+    do_publish(sess(work))
+    print("published m0; lane head, @ on m0")
+
+    # squash-merge on origin + delete branch
+    other = tmp / "other"
+    sh("git", "clone", str(remote), str(other))
+    sh("git", "checkout", "main", cwd=other)
+    (other / "a.txt").write_text("aaa\n")
+    sh("git", "add", ".", cwd=other)
+    sh("git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", "squash m0", cwd=other)
+    sh("git", "push", "origin", "HEAD:main", cwd=other)
+    sh("git", "push", "origin", "--delete", "m0", cwd=other)
+    print("origin: squash-merged m0, deleted branch")
+
+    # current gitman sync
+    try:
+        res = do_sync(sess(work), all_=True)
+        print("\ndo_sync OUTCOME:", res.outcome, "exit", res.exit_code)
+        for m in res.messages:
+            print("  msg:", m)
+        for n in res.notes:
+            print("  note:", n)
+    except GitmanError as e:
+        print("\ndo_sync RAISED GitmanError:", e, "| exit", e.exit_code)
+    except Exception as e:
+        print("\ndo_sync RAISED:", type(e).__name__, str(e)[:80])
+
+    # where did things land?
+    try:
+        st = capture_state(sess(work))
+        print("\ncapture_state OK: canonical?", st.canonical, "| lanes:", [l.name for l in st.lanes])
+        print("  trunk:", st.trunk.commit_id[:8], "behind", st.trunk.behind_remote, "ahead", st.trunk.ahead_remote)
+        for n in st.notes:
+            print("  note:", n)
+    except Exception as e:
+        print("\ncapture_state RAISED:", type(e).__name__, str(e)[:80])
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/projects/08-split-lane-capability/ISSUE.md
+++ b/.scratch/projects/08-split-lane-capability/ISSUE.md
@@ -1,0 +1,154 @@
+# 08 — `gitman split`: no way to separate entangled work in one lane
+
+> **Found:** 2026-06-26, while finishing the **flora** `005-config-compiler-profile`
+> session. Two independent efforts had piled into a single uncommitted working-copy
+> change on one lane, and gitman offered **no front-door way to split them**. The
+> only options were "save them bundled together" or "drop to raw `jj`" — and raw
+> `jj` is forbidden (breaks canonicity → forces `reconcile`). This is a concrete,
+> fixable capability gap, not a misuse.
+
+## TL;DR — what we want
+
+| # | Want | Where | Severity |
+|---|------|-------|----------|
+| S1 | A first-class **`gitman split`** command to carve a subset of a lane's change into its own commit/lane | new `src/gitman/cli.py` cmd + `core.do_split` | **high** (only missing core lane op) |
+| S2 | MVP scope = **path-scoped** split (`--paths <globs>`), non-interactive — composable from existing pyjutsu primitives, **no new Rust bindings** | `src/gitman/core.py`, `lanes.py`, `session.py` | high |
+| S3 | (Stretch) hunk/interactive split + a native pyjutsu `split` binding | `Pyjutsu` `transaction.rs` | low |
+
+`split` is the one obvious lane operation gitman doesn't have. `start` opens work,
+`save` describes it, `land`/`abandon` end it, `sync` rebases it — but nothing
+*divides* a change once two concerns have entangled in it.
+
+---
+
+## The scenario (concrete, from this session)
+
+The flora repo had **two efforts sharing one working copy**:
+
+- the in-progress **004 image-dataset-curator** scaffold (`src/flora/curator/`,
+  `.scratch/projects/004-…`), already uncommitted on a lane named **`curator-004`**;
+- the brand-new **005 config spine** I built this session (`src/flora/config/`,
+  `cli.py`, `runtime/`, `tests/`, `examples/`).
+
+Both ended up as **one draft change on the `curator-004` lane**:
+
+```
+$ gitman status
+Gitman status — CANONICAL · 1 lane
+trunk: main @ afa3a49…
+* curator-004          draft      1 change, +7313 −1   · you are here
+```
+
+I wanted the 005 work on its own properly-named lane (`config-spine-005`) and the
+004 scaffold left on `curator-004`, so they could be reviewed / landed / published
+independently (they belong to different sessions). There was **no gitman command to
+do that.** I had to `gitman save` everything bundled under a curator-named lane,
+with a commit message apologising for the mix. That's exactly the kind of
+off-canonical temptation gitman exists to remove.
+
+**Why this will recur:** agents frequently discover a second concern mid-change
+(a drive-by fix, a second feature, a stray refactor), or — as here — inherit a
+working copy that already carries someone else's WIP. "Separate these into two
+lanes" is a routine, expected VC operation everywhere except gitman.
+
+---
+
+## Capability investigation (so the fix is grounded)
+
+### gitman 0.2.2 surface — no split
+
+`gitman --help` commands: `doctor, status, start, save, seed, publish, land,
+abandon, sync, resolve, undo, version, release, init, reconcile`. No `split`, no
+`squash`, no `move`, no `edit`. Command registration lives in `src/gitman/cli.py`
+(e.g. `start` @112, `save` @123), each delegating to a `do_*` in `src/gitman/core.py`.
+
+### pyjutsu transaction surface — enough to compose a path-scoped split
+
+gitman drives **jj-lib embedded via pyjutsu** (there is **no `jj` CLI** and no `-T`
+templates; mutations go through `ws.begin_transaction()` → `PyTransaction`). The
+exposed transaction methods (`Pyjutsu/python/pyjutsu/_pyjutsu.pyi:108-125`):
+
+| Method | Signature | Role in a split |
+|---|---|---|
+| `new` | `new(parents=[…])` | create the second (empty) commit |
+| `restore` | `restore(commit, from_, paths=[…])` | **the key primitive** — revert a path-set in `commit` to another commit's content |
+| `rebase` | `rebase(commit, onto=[…], mode)` | re-stack descendants / lanes |
+| `describe` | `describe(revset, message)` | message each half |
+| `abandon` / `squash` | … | cleanup / inverse |
+| `create_bookmark` / `set_bookmark` / `delete_bookmark` | … | name the carved-out lane |
+| `commit` / `rollback` | … | finish / bail the transaction |
+
+There is **no native `split`** exposed. But `restore(commit, from_, paths)` is
+precisely the building block: jj's own `split` is internally two tree-restores, and
+`Pyjutsu/src/transaction.rs:35` **already imports** `move_commits, restore_tree,
+squash_commits` from `jj_lib::rewrite` — the lower-level support is present; only a
+binding/compose layer is missing.
+
+**Conclusion:** a **path-scoped** `gitman split` is implementable **at the gitman
+layer today** by composing `new` + `restore` + `rebase` + `create_bookmark`, with
+**no Pyjutsu changes**. A hunk-level/interactive split (selecting partial-file
+changes) is the only variant that would need new pyjutsu surface — defer it (S3).
+
+---
+
+## Proposed UX (for discussion)
+
+Split the current lane's change, moving a path-set onto a **new lane** stacked in
+front of the remainder:
+
+```
+# carve the 005 paths onto a new lane; the rest stays on the current lane
+gitman split --paths 'src/flora/config/**' 'src/flora/cli.py' 'tests/**' \
+             --into config-spine-005 -m "config: build the Flora config spine"
+
+# or: split by what's NOT matched, keep current lane name for the remainder
+gitman split --paths 'src/flora/curator/**' --into curator-004 --keep-name config-spine-005
+```
+
+Sketch of behaviour (path-scoped, two-commit linear result on trunk):
+
+1. Resolve the current lane `L` and its single change `C` (error if `L` has >1
+   change or a dirty mismatch — define the precondition explicitly).
+2. In a transaction: create `C_b` = the carved-out paths, `C_a` = the remainder
+   (via `restore` against `C`'s parent in each direction), keep them **linear**
+   (`C_a ← C_b`) so canonicity holds.
+3. Move/`set_bookmark` the new lane name onto the carved commit; leave the other
+   bookmark on the remainder; `describe` each with its `-m`.
+4. Re-point `@` and rebase any descendants; emit a `status`-style report + an
+   `Undo:` line (whole-intent, like every other gitman op).
+
+Open design questions:
+
+- **Direction & stacking:** carved lane *in front of* or *behind* the remainder?
+  Default linear order, and which bookmark stays "current"?
+- **Selector:** `--paths` globs for MVP. Later: `--revset`, or `--interactive`.
+- **Precondition:** only operate on a lane with exactly one undescribed/draft change?
+  How to behave if the change is already `save`d (rewrite vs new child)?
+- **Naming:** `split` vs `carve` vs `divide`; `--into <new-lane>` vs `--name`.
+- **Canonicity/undo:** ensure the whole split is one jj operation so `gitman undo`
+  reverts it atomically; verify `status` stays CANONICAL after.
+
+---
+
+## Acceptance criteria
+
+1. `gitman split --paths <globs> --into <lane>` turns one lane's change into **two
+   linear commits on two named lanes**, with the path-set partitioned exactly.
+2. Runs entirely through pyjutsu transactions — **no raw `jj`/`git`**, and
+   `gitman status` reports **CANONICAL** before and after.
+3. **`gitman undo`** reverts the split as a single intent.
+4. Clear errors for the unsupported preconditions (multi-change lane, empty match,
+   path-set == everything / nothing).
+5. Docs + the agent skill updated to list `split` in the lane loop; a test in
+   `gitman/tests/` covering the entangled-working-copy case from this issue.
+6. **No Pyjutsu changes required** for the path-scoped MVP (S3 hunk-level is a
+   separate follow-up issue if pursued).
+
+---
+
+## Workaround used this session (so nothing was lost)
+
+`gitman save -m "config: build Flora config spine …"` on the existing
+`curator-004` lane, with a body noting it also snapshots the pre-existing 004
+curator scaffold. Reversible via `gitman undo`. The lane is mis-named for half its
+contents — which is the whole motivation for `split`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,5 +63,7 @@ nix/gitman.nix  reusable devenv module (tasks + enterTest)
   surviving raw subprocess is `tags.py` (annotated git tags — pyjutsu binds no tag write).
 - Exit codes: `0` ok · `1` VC decision needed · `2` infra/config · `3` invalid usage.
 - Every mutating report ends with an inline **Undo** line. Reports are compact and honest.
-- `.scratch/` and `archive/` are untracked. Don't commit unless asked. No AI-attribution
-  in commits/PRs/docs.
+- **`.scratch/projects/<NN-name>/`** holds **tracked** design docs — the per-project ISSUE / PLAN /
+  KICKOFF / concept notes that drive each effort. Commit these. The rest of `.scratch/` (loose
+  probes, dogfood scripts, throwaway notes) is **untracked** working scratch — don't commit it.
+  `archive/` is untracked. No AI-attribution in commits/PRs/docs.

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1781538852,
-        "narHash": "sha256-eALw5HvwZMNrP2++x3fv9j8WR/yuBTmcgeqcB0ZY8LU=",
+        "lastModified": 1782153911,
+        "narHash": "sha256-Z7BG4cSJX1ybJeZztEMV8WlE6GrXJsSd34x9eHvpzU8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "78279726f86be1b575cca66d082a0ac032d617d4",
+        "rev": "d894e487bb23ed87e0555d2158710844bde65322",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,28 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -122,11 +139,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1778507786,
-        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "lastModified": 1782132010,
+        "narHash": "sha256-ZnAVHdVrotp80iIMm5CSR1fdxPlw7Uwmwxb+O/wsgZ8=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "rev": "12866ae2dddbc0ab8b329915f8072bb9c75bde89",
         "type": "github"
       },
       "original": {
@@ -152,13 +169,59 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src_2"
+      },
+      "locked": {
+        "lastModified": 1782132010,
+        "narHash": "sha256-ZnAVHdVrotp80iIMm5CSR1fdxPlw7Uwmwxb+O/wsgZ8=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "12866ae2dddbc0ab8b329915f8072bb9c75bde89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyjutsu": {
+      "flake": false,
+      "locked": {
+        "ref": "refs/heads/main",
+        "type": "git",
+        "url": "file:///home/andrew/Documents/Projects/Pyjutsu"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:///home/andrew/Documents/Projects/Pyjutsu"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "mk-shell-bin": "mk-shell-bin",
         "nix2container": "nix2container",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-python": "nixpkgs-python"
+        "nixpkgs-python": "nixpkgs-python",
+        "vendomat": "vendomat"
+      }
+    },
+    "vendomat": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4",
+        "pyjutsu": "pyjutsu"
+      },
+      "locked": {
+        "path": "/home/andrew/Documents/Projects/vendomat",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/andrew/Documents/Projects/vendomat",
+        "type": "path"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -11,18 +11,23 @@
   dotenv.disableHint = true;
 
   # https://devenv.sh/packages/
-  # No `jj` CLI: gitman talks to jj-lib in-process via pyjutsu (built from the sibling
-  # ../Pyjutsu). `git` stays for the one retained subprocess (annotated tags, tags.py).
+  # No `jj` CLI: gitman talks to jj-lib in-process via pyjutsu. `git` stays for the one
+  # retained subprocess (annotated tags, tags.py). No Rust/maturin: pyjutsu now arrives as
+  # a prebuilt wheel from vendomat's store wheelhouse (see vendor.* below), so this repo
+  # never compiles the native extension.
   packages = [
     pkgs.git
     pkgs.uv
-    pkgs.maturin
   ];
 
-  # Rust toolchain to compile pyjutsu's native _pyjutsu extension (jj-lib via PyO3). jj-lib
-  # 0.38 requires Rust >= 1.89 (edition 2024); rolling nixpkgs' stable rustc satisfies this.
-  # The jj 0.38 pin lives in pyjutsu; gitman just builds it.
-  languages.rust.enable = true;
+  # Install pyjutsu from vendomat's prebuilt wheelhouse instead of building ../Pyjutsu's
+  # maturin extension on every `uv sync`. UV_FIND_LINKS + UV_NO_BUILD_PACKAGE are set by the
+  # imported vendomat/modules; no sccache here since gitman compiles no Rust of its own.
+  vendor = {
+    enable = true;
+    libs = [ "pyjutsu" ];
+    sharedCargo = false;
+  };
 
   # https://devenv.sh/languages/
   languages.python = {
@@ -31,10 +36,9 @@
     venv.enable = true;
     uv = {
       enable = true;
-      # Install gitman (editable) + deps into the venv on shell entry. pyjutsu is a uv path
-      # dependency on ../Pyjutsu (see [tool.uv.sources]); uv builds its maturin extension
-      # using the Rust toolchain + maturin above. The console script and ruff/pytest resolve
-      # to the venv.
+      # Install gitman (editable) + deps into the venv on shell entry. pyjutsu resolves to the
+      # prebuilt cp313-abi3 wheel via UV_FIND_LINKS (vendomat) — no maturin/cargo build. The
+      # console script and ruff/pytest resolve to the venv.
       sync.enable = true;
     };
   };

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -10,3 +10,10 @@ inputs:
     url: github:nlewo/nix2container
   mk-shell-bin:
     url: github:rrbutani/nix-mk-shell-bin
+  # vendomat: prebuilt wheels for native libs (pyjutsu) from the Nix store, so `uv sync`
+  # installs pyjutsu instead of compiling its maturin extension every time.
+  vendomat:
+    url: path:/home/andrew/Documents/Projects/vendomat
+
+imports:
+  - vendomat/modules

--- a/docs/GITMAN_CONCEPT.md
+++ b/docs/GITMAN_CONCEPT.md
@@ -106,7 +106,7 @@ repo-global, and auto-following the change across rewrites.
 | I2 | **Every change belongs to exactly one named lane; no anonymous/stray changes.** | Stranded work — every change is *listable*; `status` is a uniform enumeration, not a triage. |
 | I3 | **Branch name = the lane's readable name**, unique-checked at creation, stable via the bookmark. | Branch-name generation / collision / freeze logic. |
 | I4 | **Gitman is the sole writer; mutating ops are serialized by a brief repo lock.** | Concurrent-rewrite divergence (parallel work lives in separate workspaces). |
-| I5 | **Each lane is linear on trunk (rebase-always); trunk advances only via `land`.** | Merge-commit states; "which base?" ambiguity. |
+| I5 | **Each lane is linear on trunk (rebase-always); trunk advances only via `land` or `adopt`.** | Merge-commit states; "which base?" ambiguity. |
 
 The principle: **resolve variability once, at a well-defined moment (init, lane
 creation), not repeatedly at runtime.**
@@ -168,7 +168,7 @@ Base deps kept lean: `pydantic`, `typer`. `jj` and `git` binaries come from deve
 
 ## 7. Intent vocabulary — v1
 
-Eleven intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
+Twelve intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
 model requires; everything else is deferred until friction proves it.
 
 | Intent | Signature | What it does | Underneath |
@@ -179,6 +179,7 @@ model requires; everything else is deferred until friction proves it.
 | `sync` | `gitman sync [--all]` | Fetch trunk + rebase the current lane (or `--all` lanes) onto it. | `jj git fetch` + `jj rebase` |
 | `publish` | `gitman publish` | Push the current lane; branch = lane name. Verify hook first. | `jj git push` (forge extra: + open/update PR) |
 | `land` | `gitman land [<lane>…]` | Fold lane(s) into trunk, advance trunk, retire the lane(s). | rebase + ff trunk + bookmark/workspace cleanup (forge extra: merge PR) |
+| `adopt` | `gitman adopt [--force] [--dry-run]` | Adopt a forge-merged trunk: advance local trunk to `origin/<trunk>`, rebase survivors, retire merged lanes. | `jj git fetch` (auto-FF trunk) + content-based retire + un-stale `@` |
 | `abandon` | `gitman abandon [<lane>]` | Discard a lane (terminal). | `jj abandon` + bookmark delete + workspace cleanup |
 | `undo` | `gitman undo [--op <id>] [--list]` | Revert the last intent, or to a chosen op. | `jj undo` / `jj op restore` |
 | `resolve` | `gitman resolve [--list]` | Surface remaining conflicts / confirm cleared. | `jj resolve --list` |
@@ -224,6 +225,30 @@ $ gitman abandon fix-cart-test                        # gave up on that one
 - **`land`** is the sanctioned trunk-advance (I5): it rebases the lane onto current trunk,
   fast-forwards trunk to include it, then deletes the bookmark and forgets the workspace.
   The forge extra swaps the local fast-forward for a GitHub PR merge.
+
+### Forge-PR adoption (`publish → PR → merge → adopt`)
+
+`land` advances trunk to a lane head you built **locally**. But the common reviewed-and-gated
+flow advances trunk on the **forge**: `gitman publish` a lane → open a PR → click **Merge**.
+The forge mints a **re-hashed** commit on `origin/<trunk>` (squash, merge-commit, and rebase
+merges all produce a new SHA), leaving the local trunk behind `origin/<trunk>`. **`adopt` is a
+`land` the forge already performed** — it's the second sanctioned trunk-advancing intent (I5),
+the only other one the transactional postcondition exempts from the trunk-frozen rule.
+
+`gitman adopt`:
+1. **Fetches** the remote. jj auto-fast-forwards the local `<trunk>` bookmark to the forge head
+   in the clean case, and prunes lanes whose remote branch was deleted (`--delete-branch`).
+2. **Retires merged lanes by content, not SHA** — a lane is "already merged" iff it is empty
+   after rebasing onto the adopted trunk (true across squash N→1, rebase-merge N→N re-hashed,
+   and merge-commit ancestry). Genuine survivors are rebased onto the new trunk and **kept**.
+3. **Refuses safely on divergence.** Un-pushed local lands + a moved origin make jj record a
+   *conflicted* trunk bookmark; `adopt` refuses (push first) unless `--force` hard-sets trunk to
+   the forge head (dropping the un-pushed lands; undoable). `--dry-run` reports the plan only.
+
+Stays CANONICAL throughout and is a single `gitman undo` step. **`sync` never advances trunk**
+(it fetches lanes-only and rebases onto *local* trunk) — trunk advancement is `land`'s or
+`adopt`'s job, by design. Keep `gitman.toml` / VC wiring on **trunk**, never only in a lane, so
+retiring a lane can never delete it.
 
 ## 9. The `RepoState` model (the Pydantic heart)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitman"
-version = "0.2.1"
+version = "0.2.2"
 description = "Agent-first version-control interface: a safe lane workflow over jujutsu + colocated git."
 readme = "README.md"
 requires-python = ">=3.13"
@@ -15,7 +15,7 @@ authors = [
 dependencies = [
   "pydantic>=2.12",
   "typer>=0.12",
-  "pyjutsu",
+  "pyjutsu>=0.8",
 ]
 
 [project.optional-dependencies]
@@ -50,13 +50,10 @@ include = [
   "pyproject.toml",
 ]
 
-[tool.uv]
-
-# pyjutsu is built from the sibling checkout (build-from-sibling distribution). Editable so
-# gitman picks up local pyjutsu changes; uv builds its native extension via maturin + the
-# Rust toolchain from devenv.nix. Long-term this becomes a published wheel.
-[tool.uv.sources]
-pyjutsu = { path = "../Pyjutsu", editable = true }
+# No [tool.uv.sources] for pyjutsu: it resolves from vendomat's prebuilt wheelhouse via
+# UV_FIND_LINKS (set by the imported vendomat devenv module), instead of being built from
+# the sibling ../Pyjutsu checkout. UV_NO_BUILD_PACKAGE=pyjutsu makes a missing wheel fail
+# loudly rather than silently recompiling.
 
 # Seed policy; `gitman init` writes the frozen trunk here (or to gitman.toml). See concept §15.
 [tool.gitman]

--- a/src/gitman/cli.py
+++ b/src/gitman/cli.py
@@ -181,6 +181,20 @@ def sync(
 
 
 @app.command()
+def adopt(
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Hard-set trunk to origin even if local trunk diverged (drops un-pushed lands)."),
+    ] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Report the adoption plan without mutating.")] = False,
+) -> None:
+    """Adopt a forge-merged trunk: advance local trunk to origin/<trunk>, rebase survivors, retire merged lanes."""
+    from gitman.core import do_adopt
+
+    _finish_intent(do_adopt(_session(), force=force, dry_run=dry_run))
+
+
+@app.command()
 def resolve(
     list_: Annotated[bool, typer.Option("--list", help="List remaining conflicts.")] = False,
 ) -> None:

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -463,18 +463,37 @@ def do_sync(session: Session, all_: bool):
     notes: list[str] = []
     conflicted: list[str] = []
     with canonical_guard(session, "sync") as canon:
-        if session.ws.remotes():
-            session.ws.git_fetch(pick_remote(session.ws))  # own op
+        if session.ws.remotes() and targets:
+            # Fetch the lane branches ONLY — never trunk. A full `git_fetch` auto-fast-forwards the
+            # local trunk bookmark to a moved `origin/<trunk>`, which the canonical_guard
+            # postcondition then reverts as "trunk moved outside a land" (the real wedge). Trunk
+            # advancement is `gitman adopt`'s job, by design. Bookmark-scoped fetch keeps sync's
+            # narrow contract ("rebase lanes onto *local* trunk") and still prunes a server-deleted
+            # in-filter lane (validated). (verb: adopt)
+            session.ws.git_fetch(pick_remote(session.ws), bookmarks=sorted(targets))  # own op
             messages.append("fetched remote.")
-        else:
+        elif not session.ws.remotes():
             notes.append("no remote — rebasing onto local trunk only.")
-        with session.ws.transaction("gitman:sync", auto_snapshot=False) as tx:
-            for lane in targets:
-                rebased = tx.rebase(lane, onto=trunk, mode="branch")
-                if rebased.has_conflict:
-                    conflicted.append(lane)  # DO NOT raise — sync is non-blocking
-    if targets:
-        messages.append(f"rebased {', '.join(targets)} onto {trunk}.")
+        # A fetch can prune a lane whose remote branch was deleted server-side (e.g.
+        # `gh pr merge --delete-branch`): jj drops the un-diverged local bookmark too, so a later
+        # `tx.rebase(lane, …)` would raise "Revision <lane> doesn't exist". Re-read the survivors
+        # AFTER the fetch and skip vanished lanes with a note instead of wedging (sharp edge #1).
+        surviving = lane_names(session, trunk)
+        todo = [lane for lane in targets if lane in surviving]
+        for lane in targets:
+            if lane not in surviving:
+                notes.append(
+                    f"lane '{lane}' no longer exists (remote branch deleted) — nothing to sync; "
+                    f"`gitman adopt` to retire it."
+                )
+        if todo:
+            with session.ws.transaction("gitman:sync", auto_snapshot=False) as tx:
+                for lane in todo:
+                    rebased = tx.rebase(lane, onto=trunk, mode="branch")
+                    if rebased.has_conflict:
+                        conflicted.append(lane)  # DO NOT raise — sync is non-blocking
+    if todo:
+        messages.append(f"rebased {', '.join(todo)} onto {trunk}.")
     if conflicted:
         notes.append(f"conflicts in {', '.join(conflicted)} — not blocked; `gitman resolve`, then continue.")
     return IntentResult(
@@ -483,6 +502,246 @@ def do_sync(session: Session, all_: bool):
         messages=messages,
         notes=notes,
         exit_code=1 if conflicted else 0,
+        undo_command="gitman undo",
+        state=canon.state,
+    )
+
+
+# --- forge-PR adoption: `gitman adopt` (the second trunk-advancing intent) ------------
+
+
+def _retire_lane(session: Session, trunk: str, lane: str, published_before: set[str], notes: list[str]) -> None:
+    """Retire a forge-merged surviving lane: abandon its (now-empty) trunk..lane changes, delete the
+    bookmark, forget its workspace, best-effort delete a still-live remote branch. Runs its own tx
+    inside an already-open `canonical_guard`. For the merge-commit case (`trunk..lane` already empty)
+    the abandon loop is a no-op and only the bookmark is dropped (the commits stay as trunk ancestors).
+    """
+    from pyjutsu import PyjutsuError
+
+    with session.ws.transaction("gitman:adopt-retire", auto_snapshot=False) as tx:
+        for c in session.view().log(f"{trunk}..{lane}"):
+            tx.abandon(c.change_id)
+        tx.delete_bookmark(lane)
+    notes += _cleanup_workspace(session, lane)
+    notes.append(f"retired (forge-merged): {lane}")
+    if lane in published_before:
+        try:
+            session.ws.git_push(pick_remote(session.ws), lane, delete=True)
+            notes.append(f"deleted remote branch '{lane}' (one-way; `gitman undo` won't restore it).")
+        except PyjutsuError as exc:
+            notes.append(f"remote branch '{lane}' not deleted (delete it manually): {exc}")
+
+
+def _reconcile_lane_against_adopted_trunk(
+    session: Session,
+    trunk: str,
+    lane: str,
+    published_before: set[str],
+    *,
+    retired: list[str],
+    rebased: list[str],
+    conflicts: list[str],
+    notes: list[str],
+) -> None:
+    """Reconcile one surviving lane against the freshly-adopted trunk (content-based, not SHA).
+
+    Three cases, one emptiness-after-rebase test (works across squash N→1, rebase-merge N→N
+    re-hashed, and merge-commit ancestry — independent of SHA/change-id):
+      * `trunk..lane` already empty  → lane is an ancestor of the new trunk → retire (no rebase).
+      * rebase onto trunk conflicts  → leave the conflicted rebase, mark CONFLICT (non-blocking).
+      * post-rebase range all empty  → merged → retire (abandon the emptied commits + delete bookmark).
+      * otherwise                    → genuine survivor → keep the rebase onto the new trunk.
+    """
+    if not session.view().log(f"{trunk}..{lane}"):  # merge-commit: already an ancestor of trunk
+        _retire_lane(session, trunk, lane, published_before, notes)
+        retired.append(lane)
+        return
+
+    with session.ws.transaction("gitman:adopt-rebase", auto_snapshot=False) as tx:
+        rebased_head = tx.rebase(lane, onto=trunk, mode="branch")
+    if rebased_head.has_conflict:  # survivor that conflicts — non-blocking, do NOT abandon
+        conflicts.append(lane)
+        notes.append(f"conflict (resolve, then sync): {lane}")
+        return
+
+    range_after = session.view().log(f"{trunk}..{lane}")  # re-read after the rebase op committed
+    if range_after and all(c.is_empty for c in range_after):  # squash / rebase-merge → merged
+        _retire_lane(session, trunk, lane, published_before, notes)
+        retired.append(lane)
+    else:
+        rebased.append(lane)
+        notes.append(f"rebased onto trunk: {lane}")
+
+
+def _adopt_dry_run(session: Session, trunk: str, remote: str):
+    """Report the adoption plan without mutating: fetch (then roll the fetch back so the op leaves no
+    net change), classify, restore. Opens no adopt transaction. See plan §2 / BUILD_PLAN §3b.7."""
+    from pyjutsu.errors import RevsetError
+
+    from gitman.invariants import repo_lock
+    from gitman.lanes import lane_names
+    from gitman.models import IntentResult
+    from gitman.state import _trunk_conflicted, capture_state
+
+    messages: list[str] = []
+    with repo_lock(session.repo_root):
+        op_before = session.ws.head_operation()
+        lanes_before = set(lane_names(session, trunk))
+        try:
+            session.ws.git_fetch(remote)
+            view = session.view()
+            try:
+                origin_trunk = view.resolve(f"{trunk}@{remote}")
+            except RevsetError:
+                messages.append(f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?")
+                return IntentResult(intent="adopt", outcome="PLAN", messages=messages, exit_code=1)
+            surviving = set(lane_names(session, trunk))
+            if _trunk_conflicted(view, trunk):
+                messages.append(f"trunk diverged from {remote} — needs `--force` to take {remote}.")
+            else:
+                # `behind` = forge commits not yet local; trunk only advances when origin is ahead
+                # (a fetch never moves trunk backward, so local-ahead means trunk stays put).
+                behind = len(view.log(f"{trunk}..{trunk}@{remote}"))
+                if behind:
+                    head = origin_trunk.commit_id[:12]
+                    messages.append(f"would advance {trunk} → {head} ({behind} forge commit(s)).")
+                elif lanes_before == surviving:
+                    messages.append(f"already current: local {trunk} is up to date with {trunk}@{remote}.")
+                else:
+                    messages.append(f"{trunk} already current — would reconcile lanes only.")
+            for lane in sorted(lanes_before - surviving):
+                messages.append(f"would retire (forge-merged, branch deleted): {lane}")
+            for lane in sorted(surviving):
+                if not view.log(f"{trunk}..{lane}"):
+                    messages.append(f"would retire (already an ancestor of trunk): {lane}")
+                else:
+                    messages.append(f"would rebase onto trunk (retire if emptied): {lane}")
+        finally:
+            session.ws.restore_operation(op_before)  # undo the fetch's FF/prune → no net mutation
+    return IntentResult(
+        intent="adopt",
+        outcome="PLAN",
+        messages=messages,
+        notes=["dry run — nothing changed; re-run without `--dry-run` to apply."],
+        state=capture_state(session),
+    )
+
+
+def do_adopt(session: Session, *, force: bool, dry_run: bool):
+    """Adopt a forge-merged trunk: fetch, let the local trunk advance to `origin/<trunk>`, rebase
+    survivors, retire merged lanes. The second intent the canonical_guard postcondition exempts from
+    the trunk-frozen rule (I5: trunk advances via `land` OR `adopt`). See ISSUE/PLAN/BUILD_PLAN §07.
+    """
+    from pyjutsu.errors import RevsetError
+
+    from gitman.invariants import canonical_guard
+    from gitman.lanes import lane_names
+    from gitman.models import IntentResult
+    from gitman.state import _lane_index, _trunk_conflicted
+
+    trunk = require_trunk(session.config)
+    if not session.ws.remotes():
+        raise GitmanError("no git remote — nothing to adopt.", exit_code=2)
+    remote = pick_remote(session.ws)
+
+    if dry_run:
+        return _adopt_dry_run(session, trunk, remote)
+
+    # Pre-fetch facts — the fetch will move trunk and prune lanes under us.
+    local_trunk_before = session.view().resolve(trunk).commit_id
+    lanes_before = set(lane_names(session, trunk))
+    published_before = _lane_index(session.view())[1]
+
+    retired: list[str] = []
+    rebased: list[str] = []
+    conflicts: list[str] = []
+    notes: list[str] = []
+    try:
+        with canonical_guard(session, "adopt") as canon:
+            session.ws.git_fetch(remote)  # own op: FFs trunk (clean), prunes deleted lanes, may stale @
+            view = session.view()
+            try:
+                origin_trunk = view.resolve(f"{trunk}@{remote}")
+            except RevsetError as exc:
+                raise GitmanError(
+                    f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?", exit_code=1
+                ) from exc
+
+            if _trunk_conflicted(view, trunk):
+                if not force:
+                    raise GitmanError(
+                        f"local {trunk} diverged from {remote} (un-pushed local lands + forge moved). "
+                        f"Push your lands first, or re-run with `--force` to hard-set {trunk} to {remote} "
+                        f"(discards the un-pushed lands; undoable).",
+                        exit_code=1,
+                    )
+                # The un-pushed local lands are the commits reachable from the old local trunk but
+                # not from the forge head; hard-setting trunk past them would strand them as strays
+                # (off-canonical → the postcondition would revert), so abandon them in the same tx.
+                dropped = [
+                    c.change_id
+                    for c in session.view().log(f"{origin_trunk.commit_id}..{local_trunk_before}")
+                ]
+                with session.ws.transaction("gitman:adopt-force", auto_snapshot=False) as tx:
+                    tx.set_bookmark(trunk, f"{trunk}@{remote}")  # resolve the conflict toward the forge head
+                    for cid in dropped:
+                        tx.abandon(cid)
+                notes.append(
+                    f"forced {trunk} to {remote} — {len(dropped)} un-pushed local land(s) dropped (undoable)."
+                )
+
+            surviving = set(lane_names(session, trunk))
+            for lane in sorted(lanes_before - surviving):  # pruned by the fetch (forge-merged + deleted)
+                notes += _cleanup_workspace(session, lane)
+                notes.append(f"retired (forge-merged): {lane}")
+                retired.append(lane)
+            for lane in sorted(surviving):
+                _reconcile_lane_against_adopted_trunk(
+                    session, trunk, lane, published_before,
+                    retired=retired, rebased=rebased, conflicts=conflicts, notes=notes,
+                )
+
+            if session.ws.is_stale():  # the fetch/abandons orphaned @ off a pruned/retired lane
+                session.ws.update_stale()
+                notes.append("refreshed the working copy onto the adopted trunk.")
+    except GitmanError as exc:
+        return IntentResult(
+            intent="adopt",
+            outcome="BLOCKED",
+            messages=[str(exc)],
+            notes=["nothing changed — the repo is back to its pre-adopt state."],
+            exit_code=exc.exit_code,
+        )
+
+    trunk_after = canon.state.trunk.commit_id if canon.state else local_trunk_before
+    changed = bool(retired or rebased or conflicts) or trunk_after != local_trunk_before
+    if conflicts:
+        outcome, exit_code = "CONFLICT", 1
+    elif not changed:
+        outcome, exit_code = "ALREADY_CURRENT", 0
+    else:
+        outcome, exit_code = "ADOPTED", 0
+
+    messages = []
+    if trunk_after != local_trunk_before:
+        messages.append(f"adopted {remote}/{trunk} → {trunk} @ {trunk_after[:12] if trunk_after else '?'}.")
+    elif outcome == "ALREADY_CURRENT":
+        messages.append(f"already current: local {trunk} == {remote}/{trunk}.")
+    if retired:
+        messages.append(f"retired {len(retired)} forge-merged lane(s): {', '.join(retired)}.")
+    if rebased:
+        messages.append(f"rebased {len(rebased)} survivor(s) onto {trunk}: {', '.join(rebased)}.")
+    if conflicts:
+        joined = ", ".join(conflicts)
+        messages.append(f"{len(conflicts)} survivor(s) conflict — `gitman resolve`, then `gitman sync`: {joined}.")
+    notes.append("`gitman undo` reverts trunk + lanes; the forge merge and deleted remote branches are not restored.")
+
+    return IntentResult(
+        intent="adopt",
+        outcome=outcome,
+        messages=messages,
+        notes=notes,
+        exit_code=exit_code,
         undo_command="gitman undo",
         state=canon.state,
     )

--- a/src/gitman/invariants.py
+++ b/src/gitman/invariants.py
@@ -170,7 +170,9 @@ def _postcondition(session: Session, intent: str, trunk_before: str | None, op_b
     from gitman.state import capture_state
 
     after = capture_state(session)
-    trunk_moved = (after.trunk.commit_id != trunk_before) and intent != "land"
+    # `adopt` is the second sanctioned trunk-advancing intent (I5 widens to land OR adopt): it lets
+    # the forge-merged `origin/<trunk>` advance stand instead of reverting it as a stray trunk move.
+    trunk_moved = (after.trunk.commit_id != trunk_before) and intent not in ("land", "adopt")
     if not after.canonical or trunk_moved:
         session.ws.restore_operation(op_before)
         reason = after.off_canonical or (

--- a/src/gitman/render.py
+++ b/src/gitman/render.py
@@ -25,6 +25,18 @@ def _diff_str(ins: int, dels: int) -> str:
     return f"+{ins} −{dels}"
 
 
+def _remote_relation(trunk) -> str:
+    """The `(… origin)` suffix on the trunk line — only when a remote trunk is known."""
+    bits = []
+    if trunk.behind_remote:
+        bits.append(f"{trunk.behind_remote} behind")
+    if trunk.ahead_remote:
+        bits.append(f"{trunk.ahead_remote} ahead")
+    if not bits:
+        return ""
+    return f"  ({', '.join(bits)} origin)"
+
+
 def _lane_line(lane: Lane, current: str | None) -> str:
     here = lane.name == current
     marker = "*" if here else " "
@@ -47,11 +59,17 @@ def _lane_line(lane: Lane, current: str | None) -> str:
 
 def render_status(state: RepoState) -> str:
     if not state.canonical:
+        diverged = bool(state.off_canonical) and "diverged" in state.off_canonical
+        recover = (
+            "Recover: `gitman adopt`  — adopt the forge-merged trunk (`--force` to take origin)."
+            if diverged
+            else "Recover: `gitman reconcile`  — adopt it into a lane, or abandon it."
+        )
         return "\n".join(
             [
-                "Gitman status — OFF-CANONICAL",
+                f"Gitman status — {'DIVERGED' if diverged else 'OFF-CANONICAL'}",
                 f"Reason: {state.off_canonical}",
-                "Recover: `gitman reconcile`  — adopt it into a lane, or abandon it.",
+                recover,
                 "Exit: 1",
             ]
         )
@@ -59,7 +77,7 @@ def render_status(state: RepoState) -> str:
     n = len(state.lanes)
     header = f"Gitman status — CANONICAL · {n} lane{'' if n == 1 else 's'}"
     trunk = state.trunk
-    trunk_line = f"trunk: {trunk.name} @ {trunk.commit_id or '?'}"
+    trunk_line = f"trunk: {trunk.name} @ {trunk.commit_id or '?'}{_remote_relation(trunk)}"
     lines = [header, trunk_line]
     for lane in state.lanes:
         lines.append(_lane_line(lane, state.current_lane))

--- a/src/gitman/state.py
+++ b/src/gitman/state.py
@@ -76,6 +76,37 @@ def _lane_index(view: RepoView) -> tuple[set[str], set[str]]:
     return local, published
 
 
+def _trunk_conflicted(view: RepoView, trunk: str) -> bool:
+    """True if the local `<trunk>` bookmark is *conflicted* (diverged): un-pushed local lands
+    AND origin moved, so jj couldn't fast-forward and recorded multiple targets. `resolve(trunk)`
+    raises against it; `view.bookmarks()` exposes it structurally via `.conflicted`
+    (`len(target_ids) > 1`) — the clean detector, no error-string match. `gitman adopt --force`
+    resolves it toward the forge head."""
+    return any(b.name == trunk and b.remote is None and b.conflicted for b in view.bookmarks())
+
+
+def _trunk_remote_relation(session: Session, view: RepoView, trunk: str) -> tuple[int, int, str | None]:
+    """(behind, ahead, remote) of the local trunk bookmark vs its `<trunk>@<remote>` row.
+
+    `behind` = forge commits on `<trunk>@<remote>` not yet local (the forge-merge gap `gitman adopt`
+    closes); `ahead` = local trunk commits not yet pushed. Returns zeros + the remote name when no
+    remote is configured or the remote trunk hasn't been fetched yet (no network — reads the last
+    fetch's tracking ref).
+    """
+    from gitman.core import pick_remote
+
+    if not session.ws.remotes():
+        return 0, 0, None
+    remote = pick_remote(session.ws)
+    try:
+        view.resolve(f"{trunk}@{remote}")
+    except RevsetError:
+        return 0, 0, remote  # remote trunk not fetched yet
+    behind = len(view.log(f"{trunk}..{trunk}@{remote}"))
+    ahead = len(view.log(f"{trunk}@{remote}..{trunk}"))
+    return behind, ahead, remote
+
+
 def find_strays(view: RepoView, trunk: str) -> list[Change]:
     """Non-empty changes descended from trunk that belong to no lane (basic off-canonical signal)."""
     return [_change(c) for c in view.log(_stray_revset(trunk)) if not c.is_empty]
@@ -104,14 +135,45 @@ def capture_state(session: Session) -> RepoState:
 
     view = session.fresh_view()
 
+    # A *diverged* trunk (un-pushed local lands + origin moved) is a conflicted bookmark: both
+    # `view.resolve(trunk_name)` AND lane enumeration raise against it. Detect it structurally and
+    # report it off-canonical with the adopt recommendation — don't crash (this is the state
+    # `gitman adopt --force` resolves). Handled before any resolve so neither path can throw.
+    if _trunk_conflicted(view, trunk_name):
+        from gitman.core import pick_remote
+
+        remote_name = pick_remote(session.ws) if session.ws.remotes() else "origin"
+        return RepoState(
+            repo_root=repo_root,
+            colocated_git=_is_colocated(repo_root),
+            canonical=False,
+            off_canonical=(
+                f"trunk '{trunk_name}' diverged from {remote_name} (un-pushed local lands + origin moved)."
+            ),
+            trunk=TrunkRef(name=trunk_name, change_id=None, commit_id=None),
+            current_lane=None,
+            lanes=[],
+            conflicts=[],
+            recent_ops=[_op(o) for o in view.operations(10)],
+            notes=[f"run `gitman adopt` (or `gitman adopt --force` to take {remote_name}) to reconcile."],
+        )
+
     try:
         trunk_commit = view.resolve(trunk_name)
     except RevsetError as exc:
         raise GitmanError(
             f"configured trunk '{trunk_name}' not found — run `gitman doctor`.", exit_code=2
         ) from exc
+
+    # Trunk vs its remote-tracking branch (status honesty — surfaces the forge-merge gap that
+    # `gitman adopt` closes). Reads the *last fetch's* `<trunk>@<remote>` row; no network here.
+    behind_remote, ahead_remote, remote_name = _trunk_remote_relation(session, view, trunk_name)
     trunk_ref = TrunkRef(
-        name=trunk_name, change_id=trunk_commit.change_id, commit_id=trunk_commit.commit_id
+        name=trunk_name,
+        change_id=trunk_commit.change_id,
+        commit_id=trunk_commit.commit_id,
+        behind_remote=behind_remote,
+        ahead_remote=ahead_remote,
     )
 
     local_names, published = _lane_index(view)
@@ -169,6 +231,11 @@ def capture_state(session: Session) -> RepoState:
         notes.append("working copy is stale — run `gitman reconcile`.")
     if not session.ws.remotes():
         notes.append("no git remote — publish/release unavailable.")
+    if behind_remote:
+        notes.append(
+            f"local {trunk_name} is {behind_remote} behind {remote_name}/{trunk_name} "
+            f"— run `gitman adopt` to adopt the forge-merged trunk."
+        )
     if current_lane is None and _orphan_working_copy(view, wc, trunk_name):
         notes.append("working copy @ has unbookmarked work — `gitman start <name>` to adopt it into a lane.")
 

--- a/tests/test_adopt_integration.py
+++ b/tests/test_adopt_integration.py
@@ -1,0 +1,318 @@
+"""PR-2: `gitman adopt` — adopt a forge-merged trunk across squash / merge-commit / rebase
+re-hash, retire merged lanes (content-based), rebase survivors, refuse/force on divergence.
+
+In-process over pyjutsu, two colocated repos (work + bare origin). Lanes are built with raw
+`ws` ops for precise commit counts; the forge side is simulated with raw git in throwaway
+clones. The intent under test is the real `do_adopt`.
+See .scratch/projects/07-forge-pr-trunk-reconcile/{ISSUE,PLAN,BUILD_PLAN}.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pyjutsu import Workspace
+from pyjutsu.errors import RevsetError
+
+from gitman.config import GitmanConfig
+from gitman.core import do_adopt, do_undo
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def _resolve(work: Path, name: str) -> str | None:
+    try:
+        return _sess(work).view().resolve(name).commit_id
+    except RevsetError:
+        return None
+
+
+def _git(*args, cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=f@x", "-c", "user.name=forge", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _with_remote(tmp_path: Path) -> tuple[Path, Path, Workspace]:
+    """A colocated work repo on `main`, pushed to a bare `origin`. Returns (work, remote, ws)."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+    return work, remote, ws
+
+
+def _make_lane(ws: Workspace, work: Path, lane: str, files: list[tuple[str, str]], *, publish: bool = True) -> None:
+    """Build a lane bookmark with one commit per (filename, content) pair, head bookmarked."""
+    with ws.transaction(f"start {lane}") as tx:
+        tx.new("main")
+        tx.create_bookmark(lane, "@")
+    for i, (fn, content) in enumerate(files):
+        (work / fn).write_text(content)
+        ws.snapshot()
+        with ws.transaction(f"describe {lane} {i}") as tx:
+            tx.describe("@", f"{lane} commit {i}")
+        if i < len(files) - 1:
+            with ws.transaction(f"new {lane} {i}") as tx:
+                tx.new("@")
+                tx.set_bookmark(lane, "@")
+    # park @ on trunk so the lane bookmark is frozen at its head (mimics not being cd'd on it)
+    with ws.transaction(f"park {lane}") as tx:
+        tx.new("main")
+    if publish:
+        ws.git_push("origin", lane, allow_new=True)
+
+
+def _clone(remote: Path, tmp_path: Path, tag: str) -> Path:
+    other = tmp_path / f"other-{tag}"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True, capture_output=True)
+    _git("checkout", "main", cwd=other)
+    return other
+
+
+def _forge_squash(remote: Path, tmp_path: Path, files: list[tuple[str, str]], *, delete: str | None) -> None:
+    """Squash-merge: one new-SHA commit on origin/main reproducing the cumulative lane content."""
+    other = _clone(remote, tmp_path, "squash")
+    for fn, content in files:
+        (other / fn).write_text(content)
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "squash merge", cwd=other)
+    _git("push", "origin", "HEAD:main", cwd=other)
+    if delete:
+        _git("push", "origin", "--delete", delete, cwd=other)
+
+
+def _forge_merge_commit(remote: Path, tmp_path: Path, lane: str) -> None:
+    """Merge-commit: `git merge --no-ff <lane>` into main — preserves the lane SHAs as ancestors."""
+    other = _clone(remote, tmp_path, "merge")
+    _git("merge", "--no-ff", f"origin/{lane}", "-m", f"merge {lane}", cwd=other)
+    _git("push", "origin", "HEAD:main", cwd=other)
+
+
+def _advance_main(remote: Path, tmp_path: Path) -> None:
+    other = _clone(remote, tmp_path, "advance")
+    (other / "forge.txt").write_text("forge\n")
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "forge moves trunk", cwd=other)
+    _git("push", "origin", "HEAD:main", cwd=other)
+
+
+# --- 1. squash-merge headline (acceptance repro) -------------------------------------
+
+
+def test_adopt_squash_merge_headline(tmp_path: Path):
+    """Lane m0 (2 commits) → squash-merged on origin as a new SHA, branch deleted → `adopt`
+    leaves CANONICAL · 0 lanes, local trunk == origin, doctor HEALTHY."""
+    from gitman.doctor import run_doctor
+
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "m0", [("a.txt", "A\n"), ("b.txt", "B\n")])
+    _forge_squash(remote, tmp_path, [("a.txt", "A\n"), ("b.txt", "B\n")], delete="m0")
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    assert res.exit_code == 0
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.lanes == []
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+    assert "m0" in " ".join(res.messages)  # reported as retired
+    assert run_doctor(work).exit_code == 0  # HEALTHY
+
+
+# --- 2. merge-commit (lane SHAs preserved as ancestors) ------------------------------
+
+
+def test_adopt_merge_commit_retires_via_ancestry(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "m0", [("a.txt", "A\n")])
+    _forge_merge_commit(remote, tmp_path, "m0")  # keeps the branch; lane SHAs become ancestors
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert "m0" not in {lane.name for lane in state.lanes}
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+
+
+# --- 3. rebase-merge (new SHAs, same content, branch kept) ---------------------------
+
+
+def test_adopt_rebase_merge_retires_via_emptiness(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "m0", [("a.txt", "A\n"), ("b.txt", "B\n")])
+    # forge replays the same content under new SHAs and KEEPS the branch
+    _forge_squash(remote, tmp_path, [("a.txt", "A\n"), ("b.txt", "B\n")], delete=None)
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert "m0" not in {lane.name for lane in state.lanes}  # emptied-after-rebase → retired
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+
+
+# --- 4. un-merged survivor alongside a merged lane -----------------------------------
+
+
+def test_adopt_keeps_unmerged_survivor(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "merged", [("a.txt", "A\n")])
+    _make_lane(ws, work, "survivor", [("s.txt", "S\n")])
+    _forge_squash(remote, tmp_path, [("a.txt", "A\n")], delete="merged")  # only `merged` is on the forge
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    names = {lane.name for lane in state.lanes}
+    assert names == {"survivor"}  # merged retired, survivor kept
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+    # survivor was rebased onto the adopted trunk (its base is the new trunk)
+    survivor = next(lane for lane in state.lanes if lane.name == "survivor")
+    assert survivor.behind == 0
+
+
+# --- 5. diverged trunk: BLOCKED without --force, hard-set with --force ----------------
+
+
+def _make_diverged(work: Path, remote: Path, tmp_path: Path, ws: Workspace) -> None:
+    """Un-pushed local land + origin moved independently → fetch leaves a conflicted trunk."""
+    with ws.transaction("local land") as tx:
+        tx.new("main")
+        tx.set_bookmark("main", "@")
+        tx.describe("@", "local land (unpushed)")
+    (work / "local.txt").write_text("local\n")
+    ws.snapshot()
+    with ws.transaction("park") as tx:
+        tx.new("main")
+    _advance_main(remote, tmp_path)
+
+
+def test_adopt_diverged_blocks_without_force(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_diverged(work, remote, tmp_path, ws)
+    trunk_before = _resolve(work, "main")
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "BLOCKED"
+    assert res.exit_code == 1
+    assert any("diverged" in m for m in res.messages)
+    # the fetch was rolled back → repo is canonical again, trunk untouched
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.commit_id == trunk_before
+
+
+def test_adopt_diverged_force_takes_origin(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_diverged(work, remote, tmp_path, ws)
+
+    res = do_adopt(_sess(work), force=True, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+    # undoable
+    do_undo(_sess(work), op=None, list_=False)
+    assert capture_state(_sess(work)).trunk.commit_id != _resolve(work, "main@origin")
+
+
+# --- 6. --dry-run mutates nothing ----------------------------------------------------
+
+
+def test_adopt_dry_run_mutates_nothing(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "m0", [("a.txt", "A\n")])
+    _forge_squash(remote, tmp_path, [("a.txt", "A\n")], delete="m0")
+    trunk_before = _resolve(work, "main")
+    lanes_before = {lane.name for lane in capture_state(_sess(work)).lanes}
+
+    res = do_adopt(_sess(work), force=False, dry_run=True)
+
+    assert res.outcome == "PLAN"
+    assert res.exit_code == 0
+    assert res.undo_command is None
+    assert any("would" in m for m in res.messages)
+    # nothing changed: trunk and lanes are exactly as before
+    state = capture_state(_sess(work))
+    assert state.trunk.commit_id == trunk_before
+    assert {lane.name for lane in state.lanes} == lanes_before
+
+
+# --- 7. undo after adopt restores trunk + lanes --------------------------------------
+
+
+def test_adopt_undo_restores(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "m0", [("a.txt", "A\n")])
+    trunk_before = _resolve(work, "main")
+    _forge_squash(remote, tmp_path, [("a.txt", "A\n")], delete="m0")
+
+    do_adopt(_sess(work), force=False, dry_run=False)
+    assert _resolve(work, "main") != trunk_before  # adopted
+
+    do_undo(_sess(work), op=None, list_=False)
+    state = capture_state(_sess(work))
+    assert state.trunk.commit_id == trunk_before  # trunk reverted
+    assert "m0" in {lane.name for lane in state.lanes}  # lane restored
+
+
+# --- 8. ALREADY_CURRENT no-op --------------------------------------------------------
+
+
+def test_adopt_already_current(tmp_path: Path):
+    work, remote, ws = _with_remote(tmp_path)  # local trunk == origin/main, no lanes
+    trunk_before = _resolve(work, "main")
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "ALREADY_CURRENT"
+    assert res.exit_code == 0
+    assert _resolve(work, "main") == trunk_before
+
+
+# --- 9. no remote → exit 2 -----------------------------------------------------------
+
+
+def test_adopt_no_remote_refuses(tmp_path: Path):
+    from gitman.core import GitmanError
+
+    work = tmp_path / "solo"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+
+    try:
+        do_adopt(_sess(work), force=False, dry_run=False)
+    except GitmanError as exc:
+        assert exc.exit_code == 2
+    else:
+        raise AssertionError("expected GitmanError on no remote")

--- a/tests/test_remote_trunk_status.py
+++ b/tests/test_remote_trunk_status.py
@@ -1,0 +1,121 @@
+"""PR-1: `gitman status` reports a diverged/conflicted trunk instead of crashing, and keeps
+the `behind_remote`/`ahead_remote` readout best-effort (never load-bearing, never raising).
+
+A diverged trunk (un-pushed local lands + origin moved) is a *conflicted* jj bookmark:
+`view.resolve(trunk)` raises "Name `<trunk>` is conflicted". `capture_state` must detect it
+structurally and return an off-canonical RepoState pointing at `gitman adopt`.
+See .scratch/projects/07-forge-pr-trunk-reconcile/{ISSUE,PLAN,BUILD_PLAN}.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import GitmanError
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def _with_remote(tmp_path: Path) -> tuple[Path, Workspace]:
+    """A colocated work repo on `main`, pushed to a bare `origin`. Returns (work, ws)."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+    return work, ws
+
+
+def _forge_advances_main(remote: Path, tmp_path: Path) -> None:
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True, capture_output=True)
+    (other / "forge.txt").write_text("forge\n")
+    subprocess.run(["git", "add", "."], cwd=other, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", "forge land"],
+        cwd=other,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "push", "origin", "HEAD:main"], cwd=other, check=True, capture_output=True)
+
+
+def test_status_diverged_trunk_reports_not_crashes(tmp_path: Path):
+    """Build the diverged state (un-pushed local land + origin moved → conflicted `main`
+    bookmark). `capture_state` reports it off-canonical with an adopt recommendation, no crash."""
+    work, ws = _with_remote(tmp_path)
+    remote = tmp_path / "remote.git"
+
+    # un-pushed local land on main
+    with ws.transaction("local land") as tx:
+        tx.new("main")
+        tx.set_bookmark("main", "@")
+        tx.describe("@", "local land (unpushed)")
+    (work / "local.txt").write_text("local\n")
+    ws.snapshot()
+    with ws.transaction("park @") as tx:
+        tx.new("main")
+
+    # origin advances independently → fetch can't FF → conflicted local `main`
+    _forge_advances_main(remote, tmp_path)
+    ws.git_fetch("origin")
+
+    # the headline: report, don't raise
+    try:
+        state = capture_state(_sess(work))
+    except GitmanError as exc:  # pragma: no cover - the bug we're fixing
+        raise AssertionError(f"capture_state crashed on a diverged trunk: {exc}") from exc
+
+    assert state.canonical is False
+    assert "diverged" in state.off_canonical
+    assert any("adopt" in n for n in state.notes)
+    # trunk commit is unknowable while conflicted — reported as such, not fabricated
+    assert state.trunk.commit_id is None
+    assert state.lanes == []
+
+
+def test_status_trunk_behind_best_effort(tmp_path: Path):
+    """Origin ahead, no local divergence. A lanes-only fetch (what `sync` does) doesn't refresh
+    the trunk tracking ref, so `behind_remote` reads 0 — the point is it's a safe int, never a
+    crash. (A positive value is only reachable via a full trunk fetch, which auto-FFs local trunk.)"""
+    work, ws = _with_remote(tmp_path)
+    remote = tmp_path / "remote.git"
+    _forge_advances_main(remote, tmp_path)
+
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert isinstance(state.trunk.behind_remote, int)
+    assert isinstance(state.trunk.ahead_remote, int)
+    assert state.trunk.behind_remote >= 0
+
+
+def test_status_no_remote_leaves_relation_zero(tmp_path: Path):
+    """No remote configured → behind/ahead are 0, no crash."""
+    work = tmp_path / "solo"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.behind_remote == 0
+    assert state.trunk.ahead_remote == 0

--- a/tests/test_sync_resilience.py
+++ b/tests/test_sync_resilience.py
@@ -1,0 +1,106 @@
+"""PR-1: `gitman sync` is resilient to forge-side churn — it neither wedges on a
+server-deleted lane branch nor silently reverts trunk when origin moved (sharp edge #1).
+
+In-process over pyjutsu, two colocated repos (work + bare origin), driving the real
+`do_sync`. See .scratch/projects/07-forge-pr-trunk-reconcile/{ISSUE,PLAN,BUILD_PLAN}.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import do_publish, do_save, do_start, do_sync
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def _with_remote(tmp_path: Path) -> tuple[Path, Path]:
+    """A colocated work repo on `main`, pushed to a bare `origin`. Returns (work, remote)."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+    return work, remote
+
+
+def _advance_origin_trunk(remote: Path, tmp_path: Path) -> None:
+    """Another actor advances origin/main by one commit (the forge moving trunk)."""
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=other, check=True, capture_output=True)
+    (other / "forge.txt").write_text("forge\n")
+    subprocess.run(["git", "add", "."], cwd=other, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "user.email=f@x", "-c", "user.name=forge", "commit", "-m", "forge moves trunk"],
+        cwd=other,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "push", "origin", "HEAD:main"], cwd=other, check=True, capture_output=True)
+
+
+def _publish_lane(work: Path, lane: str, content: str) -> None:
+    do_start(_sess(work), lane, workspace=False)
+    (work / "f.txt").write_text(content)
+    do_save(_sess(work), f"{lane} work")
+    do_publish(_sess(work))
+
+
+def test_sync_skips_server_deleted_lane_branch(tmp_path: Path):
+    """`gh pr merge --delete-branch` deletes the remote lane branch; the lanes-only fetch
+    prunes the local lane too. `sync` must skip it with a note, not raise RevsetError or revert."""
+    work, remote = _with_remote(tmp_path)
+    _publish_lane(work, "feat", "base\nfeat\n")
+
+    trunk_before = _sess(work).view().resolve("main").commit_id
+
+    # delete the remote lane branch directly in the bare repo
+    subprocess.run(["git", "update-ref", "-d", "refs/heads/feat"], cwd=remote, check=True, capture_output=True)
+
+    res = do_sync(_sess(work), all_=True)
+
+    assert res.outcome == "SYNCED"
+    assert res.exit_code == 0
+    assert any("feat" in n and "no longer exists" in n for n in res.notes)
+    # trunk untouched, repo still readable + canonical (no revert, no crash)
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.commit_id == trunk_before
+
+
+def test_sync_does_not_advance_or_revert_trunk_when_origin_moved(tmp_path: Path):
+    """Origin trunk advances while a lane is live. The lanes-only fetch leaves local trunk
+    frozen (trunk isn't in the bookmark filter) → no postcondition revert; sync succeeds."""
+    work, remote = _with_remote(tmp_path)
+    _publish_lane(work, "feat", "base\nfeat\n")
+    _advance_origin_trunk(remote, tmp_path)
+
+    trunk_before = _sess(work).view().resolve("main").commit_id
+
+    res = do_sync(_sess(work), all_=True)
+
+    assert res.outcome == "SYNCED"
+    assert res.exit_code == 0
+    # local trunk neither advanced (adopt's job) nor reverted (the old wedge)
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.commit_id == trunk_before
+    # the surviving lane is still present (rebased onto local trunk)
+    assert "feat" in {lane.name for lane in state.lanes}


### PR DESCRIPTION
Adds `gitman adopt` — a first-class intent to adopt a forge-merged trunk (`publish → PR → merge → adopt`), closing the gap where clicking **Merge** strands local trunk behind a re-hashed `origin/<trunk>`. `adopt` is "a `land` the forge already performed": the second sanctioned trunk-advancing intent (I5 widens to `land` or `adopt`).

## PR-1 — sync resilience + status honesty
- `do_sync` fetches **lanes-only** (never auto-FFs trunk → the canonical-guard postcondition can no longer revert the fetch's trunk advance), and skips server-deleted lanes with a note.
- `capture_state` tolerates a diverged (conflicted) trunk bookmark instead of crashing; `status` renders it as `DIVERGED` pointing at `gitman adopt`.

## PR-2 — `gitman adopt` core
- Fetch (auto-FF trunk), retire forge-merged lanes by **content** (emptiness-after-rebase: works across squash / merge-commit / rebase re-hash), rebase + keep genuine survivors, un-stale `@`, clean up fetch-pruned residue.
- `--force` hard-sets a diverged trunk to origin and abandons the dropped local lands (undoable). `--dry-run` reports the plan without mutating.
- One-line postcondition exemption; reuses `canonical_guard` machinery and `gitman undo`.

## PR-3 — docs
- Concept I5 + intents table + "Forge-PR adoption" subsection; skill forge loop; deprecates the manual reconcile dance.

75 tests pass (`test_sync_resilience`, `test_remote_trunk_status`, `test_adopt_integration`), ruff clean, `gitman doctor` HEALTHY.