### PR TITLE
fix(adopt): --force advances a diverged-but-not-conflicted trunk

### DIFF
--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -510,6 +510,17 @@ def do_sync(session: Session, all_: bool):
 # --- forge-PR adoption: `gitman adopt` (the second trunk-advancing intent) ------------
 
 
+def _trunk_diverged_no_ff(view, trunk: str, origin_trunk, remote: str) -> bool:
+    """True if a *resolvable* (non-conflicted) local trunk can't fast-forward to the forge head —
+    origin is ahead AND local is ahead (a real divergence). Distinguishes this from the clean
+    ancestor case (behind only → the fetch auto-FFs) and the local-ahead case (ahead only → nothing
+    to adopt; never move trunk backward). Uses the resolved forge-head commit id, not the
+    `<trunk>@<remote>` row, so it's robust. See do_adopt — the diverged-not-conflicted gap."""
+    behind = len(view.log(f"{trunk}..{origin_trunk.commit_id}"))  # forge commits not local
+    ahead = len(view.log(f"{origin_trunk.commit_id}..{trunk}"))  # local commits not on the forge head
+    return behind > 0 and ahead > 0
+
+
 def _retire_lane(session: Session, trunk: str, lane: str, published_before: set[str], notes: list[str]) -> None:
     """Retire a forge-merged surviving lane: abandon its (now-empty) trunk..lane changes, delete the
     bookmark, forget its workspace, best-effort delete a still-live remote branch. Runs its own tx
@@ -596,11 +607,11 @@ def _adopt_dry_run(session: Session, trunk: str, remote: str):
                 messages.append(f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?")
                 return IntentResult(intent="adopt", outcome="PLAN", messages=messages, exit_code=1)
             surviving = set(lane_names(session, trunk))
-            if _trunk_conflicted(view, trunk):
-                messages.append(f"trunk diverged from {remote} — needs `--force` to take {remote}.")
+            if _trunk_conflicted(view, trunk) or _trunk_diverged_no_ff(view, trunk, origin_trunk, remote):
+                messages.append(f"trunk diverged from {remote} — needs `--force` (drops divergent local commits).")
             else:
-                # `behind` = forge commits not yet local; trunk only advances when origin is ahead
-                # (a fetch never moves trunk backward, so local-ahead means trunk stays put).
+                # `behind` = forge commits not yet local; trunk only advances when origin is strictly
+                # ahead (a fetch never moves trunk backward, so local-ahead means trunk stays put).
                 behind = len(view.log(f"{trunk}..{trunk}@{remote}"))
                 if behind:
                     head = origin_trunk.commit_id[:12]
@@ -667,27 +678,35 @@ def do_adopt(session: Session, *, force: bool, dry_run: bool):
                     f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?", exit_code=1
                 ) from exc
 
-            if _trunk_conflicted(view, trunk):
+            # Trunk needs a hard-set when it can't reach the forge head by fast-forward — i.e. local
+            # trunk has commit(s) the forge head lacks. jj surfaces that two ways: a *conflicted*
+            # bookmark (resolve raises), OR a plain diverged bookmark (resolvable, but origin is ahead
+            # AND local is ahead — e.g. local trunk carries a re-hashed duplicate of a commit the forge
+            # already has). The fetch auto-FFs only the clean ancestor case; both diverged shapes need
+            # `--force`. The local-only commits (origin_head..local_before) would strand as strays after
+            # the hard-set, so abandon them in the same tx.
+            diverged = _trunk_conflicted(view, trunk) or _trunk_diverged_no_ff(view, trunk, origin_trunk, remote)
+            if diverged:
                 if not force:
                     raise GitmanError(
-                        f"local {trunk} diverged from {remote} (un-pushed local lands + forge moved). "
-                        f"Push your lands first, or re-run with `--force` to hard-set {trunk} to {remote} "
-                        f"(discards the un-pushed lands; undoable).",
+                        f"local {trunk} diverged from {remote} (local commits the forge head lacks). "
+                        f"Push them first, or re-run with `--force` to hard-set {trunk} to {remote} "
+                        f"(drops the divergent local commits; undoable).",
                         exit_code=1,
                     )
-                # The un-pushed local lands are the commits reachable from the old local trunk but
-                # not from the forge head; hard-setting trunk past them would strand them as strays
-                # (off-canonical → the postcondition would revert), so abandon them in the same tx.
+                # Abandon by COMMIT id, not change id: a re-hashed duplicate makes the local change
+                # *divergent* (one change-id, two commit-ids), so `abandon(change_id)` is ambiguous and
+                # raises. The commit-id names exactly the local-only revision to drop.
                 dropped = [
-                    c.change_id
+                    c.commit_id
                     for c in session.view().log(f"{origin_trunk.commit_id}..{local_trunk_before}")
                 ]
                 with session.ws.transaction("gitman:adopt-force", auto_snapshot=False) as tx:
-                    tx.set_bookmark(trunk, f"{trunk}@{remote}")  # resolve the conflict toward the forge head
-                    for cid in dropped:
-                        tx.abandon(cid)
+                    tx.set_bookmark(trunk, f"{trunk}@{remote}")  # take the forge head (resolves any conflict)
+                    for commit_id in dropped:
+                        tx.abandon(commit_id)
                 notes.append(
-                    f"forced {trunk} to {remote} — {len(dropped)} un-pushed local land(s) dropped (undoable)."
+                    f"forced {trunk} to {remote} — {len(dropped)} divergent local commit(s) dropped (undoable)."
                 )
 
             surviving = set(lane_names(session, trunk))

--- a/tests/test_adopt_integration.py
+++ b/tests/test_adopt_integration.py
@@ -242,6 +242,53 @@ def test_adopt_diverged_force_takes_origin(tmp_path: Path):
     assert capture_state(_sess(work)).trunk.commit_id != _resolve(work, "main@origin")
 
 
+# --- 5b. diverged but NOT conflicted (re-hashed duplicate trunk commit) --------------
+
+
+def test_adopt_reconciles_rewritten_origin_trunk(tmp_path: Path):
+    """Origin rewrote/re-hashed trunk past a local commit (force-push). `adopt` must end with
+    local trunk == origin, canonical, the divergent local commit gone — whether jj auto-takes the
+    rewritten remote (no force needed) or pins the local bookmark (diverged → needs `--force`). The
+    force path here covers the gap where `adopt` only force-advanced a *conflicted* trunk; the
+    diverged-but-not-conflicted shape is also validated live against the gitman repo's own trunk."""
+    work, remote, ws = _with_remote(tmp_path)
+    base = ws.head().resolve("main").commit_id
+
+    # local advances main to C (with c.txt) and pushes it
+    with ws.transaction("commit C") as tx:
+        tx.new("main")
+        tx.set_bookmark("main", "@")
+        tx.describe("@", "commit C")
+    (work / "c.txt").write_text("C\n")
+    ws.snapshot()
+    with ws.transaction("set main C") as tx:
+        tx.set_bookmark("main", "@")
+    ws.git_push("origin", "main")
+    with ws.transaction("park") as tx:
+        tx.new("main")
+    local_c = ws.head().resolve("main").commit_id
+
+    # origin rewrites C → C' (identical tree, new SHA) and adds Z, then force-pushes
+    other = _clone(remote, tmp_path, "rewrite")
+    _git("reset", "--hard", base, cwd=other)
+    (other / "c.txt").write_text("C\n")
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "C rehash", cwd=other)
+    (other / "z.txt").write_text("Z\n")
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "Z", cwd=other)
+    _git("push", "-f", "origin", "main", cwd=other)
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+    if res.outcome == "BLOCKED":  # jj pinned the local bookmark → diverged, needs the hard-set
+        res = do_adopt(_sess(work), force=True, dry_run=False)
+    assert res.outcome == "ADOPTED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert state.trunk.commit_id == _resolve(work, "main@origin")
+    assert state.trunk.commit_id != local_c  # the divergent local commit is gone
+
+
 # --- 6. --dry-run mutates nothing ----------------------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #22. Dogfooding `gitman adopt` on this repo surfaced a gap: `do_adopt` only triggered the `--force` hard-set when the local trunk was a *conflicted* jj bookmark. But a trunk can diverge **without** being conflicted — when local trunk carries a re-hashed duplicate of a commit the forge head already has (origin rewrote/squashed past it). In that state the fetch can't fast-forward, jj records no bookmark conflict, and `adopt` silently no-op'd the trunk advance.

## Changes
- `_trunk_diverged_no_ff(view, trunk, origin_trunk, remote)` — detects a resolvable-but-non-FF trunk (origin ahead **and** local ahead). `--force` now hard-sets the trunk to origin for this case as well as the conflicted one; without `--force` it refuses (never silently drops local commits).
- Abandon the dropped local commits by **commit-id**, not change-id: a re-hashed duplicate makes the local change *divergent* (one change-id, two commit-ids), so `abandon(change_id)` is ambiguous and raises. The commit-id names exactly the local-only revision.
- `--dry-run` reports the diverged-not-conflicted case as needing `--force`.
- Regression test: `test_adopt_reconciles_rewritten_origin_trunk` (force-pushed/rewritten origin trunk → adopt ends with local trunk == origin, divergent local commit gone).

76 tests pass, ruff clean. Validated live: reconciled this repo's own trunk (a re-hashed 0.2.2 version-bump duplicate) to the forge-merged head.