### PR TITLE
Harden gitman adopt + colocated-git resilience (round 09)

### DIFF
--- a/.claude/skills/gitman/SKILL.md
+++ b/.claude/skills/gitman/SKILL.md
@@ -46,6 +46,32 @@ never run the old raw-git reconcile dance (`rm -rf .jj` / `git reset --hard` —
 `adopt` replaces it). **Never** `gitman land` after a forge merge — it would mint a divergent
 local SHA from the forge's merge commit.
 
+A survivor lane whose changes **overlap** the adopted trunk can't auto-rebase: `adopt` reports it
+`CONFLICT`, leaves it **on its prior base with the worktree untouched** (never writes conflict
+markers into your files), and tells you to `gitman sync` it (rebase + resolve) or `gitman abandon`
+it if it was already merged.
+
+### Colocated `gh` quirks (jj keeps git HEAD detached)
+
+In a colocated jj repo git's `HEAD` is detached (parked at `@`'s parent), so some `gh`/`git`
+porcelain that assumes a checked-out branch misbehaves — **the forge action still succeeds**:
+
+- `gh pr merge … --delete-branch` prints `could not determine current branch: not on any branch`.
+  **The merge itself succeeds**; only the *local* branch-delete step fails. Delete the merged
+  **remote** branch explicitly instead:
+  ```
+  gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<lane>
+  ```
+  (or just merge in the web UI). Then `gitman adopt` retires the local lane.
+
+### Pushing trunk to `origin`
+
+There is **no `gitman push` for trunk** — by design, trunk reaches `origin` through the **forge
+loop** (`publish → PR → merge → adopt`), which is the sanctioned path. If you landed locally
+(`gitman land`) and must publish trunk without a PR, push it explicitly with jj's git bridge:
+`python -c 'from pyjutsu import Workspace; Workspace.load(".").git_push("origin","main")'` (never
+raw `git push`, which can ship a stale ref). Prefer the forge loop.
+
 **Keep `gitman.toml` and other VC wiring committed on trunk, never only inside a lane** — so
 retiring/abandoning a lane can never delete it from disk.
 
@@ -56,7 +82,10 @@ retiring/abandoning a lane can never delete it from disk.
 - **`gitman resolve [--list]`** surfaces conflicts. Conflicts are *not* blocking — keep
   working and resolve later (jj records conflicts in commits).
 - **`gitman reconcile`** is the one recovery path when `status` says OFF-CANONICAL: it
-  adopts stray changes into lanes (or `--abandon` discards them).
+  adopts stray changes into lanes (or `--abandon` discards them). It also heals **colocated
+  git-ref drift** — when `gitman doctor` warns `colocated-refs` (a lane's `refs/heads/<name>`
+  lags jj, or an abandoned lane left a leftover ref that makes `git_export` fail), `reconcile`
+  re-syncs the refs to jj and removes the leftovers.
 
 ## Versioning
 

--- a/.scratch/projects/09-adopt-colocation-hardening/KICKOFF.md
+++ b/.scratch/projects/09-adopt-colocation-hardening/KICKOFF.md
@@ -1,0 +1,150 @@
+# KICKOFF — Round 09: harden `gitman adopt` + colocated-git resilience
+
+> Paste everything below the line into a fresh gitman session to start this round.
+> This is the follow-up to **Round 07** (`gitman adopt`, merged as PRs #22 + #23). The adopt
+> feature works, but dogfooding it on gitman's own repo exposed sharp edges that made a real
+> trunk reconcile far more manual than it should be. This round makes `adopt` (and the colocated
+> git export it depends on) **deterministic and self-healing**.
+
+---
+
+We're hardening **`gitman adopt`** and the **colocated-git export** path. The adopt feature shipped
+(forge-PR trunk adoption: `publish → PR → merge → adopt`), but the **first real-world use** — adopting
+gitman's own forge-merged trunk — silently failed to advance trunk, then required hand surgery with
+raw `pyjutsu`/`git` to recover. Root causes are understood; this round fixes them.
+
+**Read first (authority + context):**
+1. `docs/GITMAN_CONCEPT.md` — §"Forge-PR adoption", I5, the intents table. The lane model + invariants.
+2. `src/gitman/core.py` — `do_adopt`, `_trunk_diverged_no_ff`, `_reconcile_lane_against_adopted_trunk`,
+   `_retire_lane`, `_adopt_dry_run`. This is the code under change.
+3. `src/gitman/invariants.py` — `_postcondition` (the `("land","adopt")` exemption),
+   `_export_colocated_git` (best-effort, swallows errors — **central to gap B**), `canonical_guard`.
+4. `src/gitman/state.py` — `_trunk_conflicted`, `capture_state`.
+5. `.scratch/projects/07-forge-pr-trunk-reconcile/{ISSUE,PLAN,BUILD_PLAN}.md` — the adopt design.
+6. Memory `gitman-known-gaps.md` (the "`gitman adopt` shipped … rough edges still open" block) — the
+   ground-truth list this round closes.
+
+**Current state (don't re-derive):** `main` is CANONICAL · 0 lanes at the merged head; adopt feature
++ the diverged-not-conflicted fix are both on `origin/main`. `gitman doctor` is HEALTHY. 76 tests pass.
+
+---
+
+## The gaps to close (priority order)
+
+### A. `adopt` must explicitly advance trunk on a clean fast-forward — don't trust jj's fetch auto-FF (#1, the headline)
+**Symptom:** `gitman adopt` reported `ADOPTED` but **left local trunk behind origin**, with no error;
+the survivor lane was rebased onto the *stale* trunk instead of retired.
+**Mechanism:** `do_adopt` relies on `git_fetch` auto-fast-forwarding the local `<trunk>` bookmark in
+the clean case (Round-07 "finding 1"). That auto-FF **silently does not happen** when the colocated
+git refs are desynced (see gap B) — and possibly in other states. `do_adopt` only ever calls
+`set_bookmark(trunk, …)` in the conflicted/diverged `--force` branch, so when the fetch doesn't move
+trunk, nothing does.
+**Fix:** after the fetch + classification, when origin is **strictly ahead** (local trunk is an
+ancestor of `<trunk>@<remote>`: `behind > 0 and ahead == 0`) and trunk hasn't already advanced,
+**explicitly** `tx.set_bookmark(trunk, f"{trunk}@{remote}")`. Make trunk advancement deterministic and
+independent of jj's fetch behavior. The postcondition already exempts `adopt`, so the explicit move
+stands. Re-check `ALREADY_CURRENT` / outcome logic afterward (trunk-moved detection currently keys off
+`canon.state.trunk.commit_id != local_trunk_before`, which will now fire correctly).
+**Also:** update `_adopt_dry_run` so its "would advance" path matches the explicit-set behavior.
+
+### B. A failed `git_export` on one stale bookmark silently blocks trunk's export → the desync that causes A
+**Symptom:** `_pyjutsu.GitError: failed to export some bookmarks: <lane>@git`; afterward `refs/heads/main`
+lagged jj's `main` bookmark, and jj's `main@git` tracking went stale → fetch stopped auto-FFing (gap A).
+**Mechanism:** when a conflicted/abandoned lane leaves a `refs/heads/<lane>` that diverged from jj's
+last-exported position, jj-lib's batch `git_export` raises for that bookmark **and trunk's ref never
+updates**. `invariants._export_colocated_git` swallows the `PyjutsuError` (best-effort by design), so
+the lagging trunk ref is invisible until something breaks.
+**Fix (pick/validate the cleanest):**
+- Make the export **trunk-safe**: ensure `<trunk>`'s ref exports even if an unrelated lane's ref is
+  stuck — e.g. export trunk explicitly, or `git_import()` to reconcile jj's tracking before/after
+  export, or detect-and-surface the stuck bookmark instead of silently swallowing.
+- When `_export_colocated_git` partially fails, **at minimum surface a note** ("colocated git ref for
+  `<lane>` is stale — `gitman doctor`/reconcile") rather than silent best-effort, so a desynced trunk
+  ref can't hide.
+- Consider a `gitman doctor` check + a reconcile path for "jj bookmark ≠ colocated git ref" desync
+  (recovery in this round's notes: `git update-ref -d refs/heads/<stale>` → `git_import()` →
+  `git_export()`). Decide whether `reconcile` should automate it.
+
+### C. Adopting a survivor lane whose content overlaps the adopted trunk conflicts and **corrupts the worktree**
+**Symptom:** rebasing a lane that carried the *whole already-squash-merged feature* onto the squash
+commit **conflicted**, and jj materialized `.jjconflict-base/side-*` snapshots into the worktree/git
+ref — which wrote conflict markers into `src/gitman/core.py` and **broke the gitman CLI itself**
+(recovered via `restore_operation` from `.gitman/last-undo`).
+**Mechanism:** `_reconcile_lane_against_adopted_trunk` rebases survivors and commits conflicts
+non-blocking (mirroring `sync`). A lane whose changes are a re-hashed superset of trunk's content
+3-way-conflicts instead of emptying, and adopt **commits** that conflicted rebase (outcome `CONFLICT`),
+leaving markers on disk.
+**Fix (design decision in this round):** options, choose + justify —
+- Detect a lane that is **fully redundant** (its `trunk..lane` content already present in trunk, modulo
+  re-hash) and **retire** it instead of producing a conflicted rebase. The emptiness-after-rebase test
+  misses this when the lane also has unrelated deltas.
+- For a survivor whose rebase conflicts on **tracked source that adopt itself depends on**, prefer
+  **revert + BLOCK with guidance** over committing markers into the worktree (a conflicted gitman
+  source file is uniquely dangerous — it bricks the tool). At minimum, guarantee the worktree is
+  recoverable and document the `restore_operation` escape hatch in the report.
+- Reassess whether `adopt` should auto-rebase survivors at all, vs. advance trunk + leave survivors for
+  an explicit `gitman sync`.
+
+### D. `gh pr merge` fails in a colocated jj repo (detached HEAD) — minor, document/automate
+**Symptom:** `gh pr merge` → `could not determine current branch: not on any branch`. The **merge still
+succeeds**; only `--delete-branch`'s local step fails.
+**Fix:** document in `.claude/skills/gitman/SKILL.md` the colocated forge loop: merge succeeds despite
+the warning; delete merged remote branches via `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<br>`.
+Optionally add a tiny `gitman` affordance. Low priority.
+
+### E. (Stretch) No gitman-native trunk push / fully gitman-native forge round-trip
+Trunk reaches `origin` only via the forge loop or a raw `ws.git_push("origin","main")`. Decide whether
+this round adds a sanctioned trunk-push affordance or explicitly documents the forge loop as the only
+path. (Relates to the long-standing "no `gitman push` for trunk" note in `gitman-known-gaps`.)
+
+---
+
+## Validate FIRST (throwaway probes, ~30 min) — these pin the fixes
+
+Build in the two-repo harness pattern (`tests/test_adopt_integration.py::_with_remote`, or extend
+`.scratch/projects/07-forge-pr-trunk-reconcile/probes/`). Delete the probes once real tests subsume them.
+
+1. **Reproduce gap A deterministically.** Create a colocated repo where `refs/heads/main` (git) lags
+   jj's `main` bookmark (e.g. leave a stale lane ref so `git_export` fails). Advance origin trunk. Call
+   `git_fetch(remote)` and assert local trunk does **NOT** auto-FF. Then confirm an explicit
+   `tx.set_bookmark("main","main@origin")` advances it cleanly. → pins gap A's fix.
+2. **Gap B export behavior.** With a stale `refs/heads/<lane>` that diverges from jj, call `git_export()`
+   and confirm it raises and that **trunk's ref does not update**. Then test the chosen remedy
+   (per-bookmark export / `git_import` first / explicit trunk export) advances trunk's ref anyway.
+3. **Gap C worktree safety.** Build a survivor lane whose `trunk..lane` content overlaps the adopted
+   trunk; run the reconcile and confirm whether markers land in tracked files. Validate the chosen
+   guard (retire-redundant, or revert-on-conflict) leaves a clean worktree.
+
+Report probe answers before writing code.
+
+---
+
+## Build order (each slice `devenv shell -- bash -c 'gitman:lint && gitman:test'` green before the next)
+1. **PR-1 — gap A** (explicit clean-FF trunk advance) + `_adopt_dry_run` parity. Regression test:
+   adopt advances trunk even when the fetch doesn't auto-FF (desynced refs). Highest value, smallest change.
+2. **PR-2 — gap B** (export resilience / desync surfacing + optional `doctor`/`reconcile` path).
+3. **PR-3 — gap C** (survivor-conflict worktree safety / redundant-lane retire).
+4. **PR-4 — gap D/E docs + skill** (colocated `gh` workaround; trunk-push decision).
+
+## Project rules (non-negotiable)
+- Everything inside devenv: `devenv shell -- bash -c 'gitman:lint && gitman:test'` (the venv tools are
+  at `$DEVENV_STATE/venv/bin`; the `gitman:lint`/`gitman:test` names are **devenv tasks**, not on PATH —
+  invoke `"$DEVENV_STATE/venv/bin/ruff" check src tests` and `… /pytest -q` directly inside the shell).
+- Dogfood VC through `gitman` — never raw `jj`/`git` (raw git is only for unavoidable colocated-ref
+  recovery, and `tags.py`). Work on a lane; `gitman save` at green checkpoints. **Don't push or land
+  without an explicit ask.**
+- jj is embedded via pyjutsu (`../Pyjutsu`); no `jj` CLI, no `-T` templates. Reads via
+  `Session.view()`/`fresh_view()`; mutations via `ws.transaction(...)`.
+- No AI-authorship trailers in commits/PRs/docs.
+
+## Definition of done
+- [ ] `gitman adopt` **deterministically advances trunk** on a clean FF regardless of fetch auto-FF /
+      colocated-ref state; regression test reproduces the desync and proves the explicit set fixes it.
+- [ ] A stale lane git ref **cannot silently leave trunk's ref lagging**; the desync is surfaced and/or
+      auto-healed (doctor/reconcile), with a test.
+- [ ] Adopting an overlapping/redundant survivor lane **never corrupts the worktree** (no stray conflict
+      markers in tracked source); it either retires cleanly or reverts with guidance.
+- [ ] Forge loop in the skill documents the colocated `gh` quirk + the `gh api` branch-delete.
+- [ ] `gitman doctor` HEALTHY; full suite green; each slice green before the next.
+- [ ] A full **dry-run rehearsal** of the forge loop on a scratch colocated repo (publish → PR → merge →
+      adopt) completes with **zero manual `pyjutsu`/`git` surgery** — the bar this round must clear.

--- a/.scratch/projects/09-adopt-colocation-hardening/PROBE_FINDINGS.md
+++ b/.scratch/projects/09-adopt-colocation-hardening/PROBE_FINDINGS.md
@@ -1,0 +1,72 @@
+# Round 09 — probe findings (validate-first)
+
+Probes: `.scratch/projects/09-adopt-colocation-hardening/probes/{probe_gaps,probe_combined}.py`
+Run in-process over pyjutsu against a colocated work repo + bare origin.
+
+## Gap A — does `git_fetch` auto-FF local trunk?
+
+- **Baseline clean-FF: YES, the fetch auto-FFs** local trunk to `origin/main` (`behind>0, ahead==0`).
+- **Even with a deleted `refs/heads/main` (desynced colocated ref): still auto-FFs.**
+- **Even after a real failed lane export (gap B) left stale state: the next fetch still auto-FFs.**
+
+→ I could **not** reproduce the exact "fetch silently doesn't auto-FF" symptom in isolation; it's
+state-specific. **But the conclusion is unchanged and stronger:** the fix is to make trunk
+advancement *not depend on the fetch at all*. When origin is strictly ahead (`behind>0 && ahead==0`)
+and trunk hasn't already reached origin, **explicitly `set_bookmark(trunk, trunk@remote)`**. When the
+fetch already auto-FF'd, this is a harmless no-op (sets to the same commit). Deterministic either way.
+
+Regression test simulates the symptom by wrapping `git_fetch` so it leaves local trunk behind
+(origin tracking still advances), then asserts adopt advances trunk via the explicit set.
+
+## Gap B — failed lane export
+
+- A **moved jj lane bookmark + externally-diverged `refs/heads/<lane>`** → `git_export()` **RAISES**
+  `failed to export some bookmarks: l0@git`.
+- **KEY: trunk's git ref IS still written** even when the lane fails — `git::export_refs` writes every
+  writable ref, collects failures, *then* pyjutsu raises. So "trunk's ref never updates" is **not**
+  the real mechanism; trunk-safety already holds at the jj-lib layer.
+- The real residue: pyjutsu raises **before committing the op**, so jj's `@git` tracking can lag, and
+  the **stuck `refs/heads/<lane>` lingers** (e.g. an abandoned lane's leftover ref).
+- `_export_colocated_git` swallows this **silently** → the stuck ref is invisible until something breaks.
+- **Heal that works:** `git update-ref -d refs/heads/<stale>` → `git_import()` → `git_export()`.
+  `git_import()` alone is **risky** (it would *resurrect* an abandoned lane from its lingering ref), so
+  auto-import is not safe; deleting the leftover ref first is the correct recovery.
+
+→ Fix: (1) keep export trunk-safe (already true) but **surface** the stuck bookmark via `canon.notes`
+instead of silent swallow; (2) add a `gitman doctor` **colocated-refs** check (jj bookmark ↔
+`refs/heads/*` desync, incl. leftover refs with no bookmark); (3) add a **reconcile** ref-heal that
+deletes leftover refs and re-syncs (`git_import`/`git_export`).
+
+## Gap C — survivor lane overlapping the adopted trunk (CONFIRMED, dangerous)
+
+- With **`@` on the survivor lane**, adopt rebases it onto a conflicting trunk → **conflict committed**,
+  working copy checked out onto the conflicted commit → **jj conflict markers written into the tracked
+  file on disk** (`<<<<<<< … %%%%%%% … +++++++ … >>>>>>>`). `is_stale=False` (checkout happened).
+- This is exactly the real-world corruption: had the file been `core.py`, the CLI bricks.
+
+→ Fix: adopt must **never commit a conflicted survivor rebase**. Roll back that single rebase (raise
+inside the tx → pyjutsu reverts it), leave the lane on its prior base, report it CONFLICT with
+guidance (`gitman sync` to rebase+resolve, or `gitman abandon` if redundant). No checkout of a
+conflicted commit ⇒ no markers on disk. Trunk advance + merged-lane retirement still succeed.
+
+## Full forge-loop rehearsal (DoD bar)
+
+Drove the **real `gitman` CLI** through `publish → (forge squash-merge + branch delete) → adopt` on
+a scratch colocated repo + bare origin: `start/save/publish` two lanes, forge squash-merges one and
+deletes its branch, `gitman adopt`. Result: **ADOPTED** — trunk advanced, `feat-a` retired,
+`feat-b` rebased survivor; `status` CANONICAL, `doctor` HEALTHY (incl. `colocated-refs ok`), **zero
+manual `pyjutsu`/`git` surgery**. Bar cleared.
+
+Two findings from the rehearsal:
+
+- **`adopt --dry-run` crashed (RevsetError, exit 3) on a conflicted trunk** — the survivor-preview
+  loop ran `{trunk}..{lane}` revsets against a conflicted `<trunk>`. Real `adopt` blocks cleanly
+  (raises GitmanError → `--force`), but dry-run didn't early-return. **Fixed**: classify divergence
+  first, skip the survivor preview when diverged. Regression test added.
+- **An *untracked* file in the worktree diverges local trunk** — building a lane with raw
+  auto-snapshot tx while `@` still carries the trunk bookmark snapshots the untracked file *into
+  trunk*, so a later forge squash conflicts. This is a **raw-ops/test artifact, not a gitman flow
+  bug**: real `gitman start` runs over an empty `@` child of trunk and folds in-progress work into a
+  *lane*, never trunk — and the skill mandates keeping `gitman.toml` **tracked on trunk**. The
+  rehearsal commits the config to trunk and passes. (Worth remembering: don't leave non-gitignored
+  untracked files sitting on a bare trunk `@`.)

--- a/docs/GITMAN_CONCEPT.md
+++ b/docs/GITMAN_CONCEPT.md
@@ -179,7 +179,7 @@ model requires; everything else is deferred until friction proves it.
 | `sync` | `gitman sync [--all]` | Fetch trunk + rebase the current lane (or `--all` lanes) onto it. | `jj git fetch` + `jj rebase` |
 | `publish` | `gitman publish` | Push the current lane; branch = lane name. Verify hook first. | `jj git push` (forge extra: + open/update PR) |
 | `land` | `gitman land [<lane>…]` | Fold lane(s) into trunk, advance trunk, retire the lane(s). | rebase + ff trunk + bookmark/workspace cleanup (forge extra: merge PR) |
-| `adopt` | `gitman adopt [--force] [--dry-run]` | Adopt a forge-merged trunk: advance local trunk to `origin/<trunk>`, rebase survivors, retire merged lanes. | `jj git fetch` (auto-FF trunk) + content-based retire + un-stale `@` |
+| `adopt` | `gitman adopt [--force] [--dry-run]` | Adopt a forge-merged trunk: advance local trunk to `origin/<trunk>`, rebase survivors, retire merged lanes. | fetch + **explicit** trunk FF + content-based retire + roll-back conflicting survivors + un-stale `@` |
 | `abandon` | `gitman abandon [<lane>]` | Discard a lane (terminal). | `jj abandon` + bookmark delete + workspace cleanup |
 | `undo` | `gitman undo [--op <id>] [--list]` | Revert the last intent, or to a chosen op. | `jj undo` / `jj op restore` |
 | `resolve` | `gitman resolve [--list]` | Surface remaining conflicts / confirm cleared. | `jj resolve --list` |
@@ -236,14 +236,27 @@ merges all produce a new SHA), leaving the local trunk behind `origin/<trunk>`. 
 the only other one the transactional postcondition exempts from the trunk-frozen rule.
 
 `gitman adopt`:
-1. **Fetches** the remote. jj auto-fast-forwards the local `<trunk>` bookmark to the forge head
-   in the clean case, and prunes lanes whose remote branch was deleted (`--delete-branch`).
+1. **Fetches** the remote, then **advances trunk explicitly**. When origin is strictly ahead
+   (local trunk an ancestor of the forge head) `adopt` sets `<trunk>` to `<trunk>@<remote>` itself
+   rather than trusting jj's fetch auto-FF — which can silently not happen when the colocated git
+   refs / jj tracking desync, leaving trunk behind with no error. The explicit set is a no-op when
+   the fetch already advanced trunk; trunk advancement is now **fetch-independent**. The fetch also
+   prunes lanes whose remote branch was deleted (`--delete-branch`).
 2. **Retires merged lanes by content, not SHA** — a lane is "already merged" iff it is empty
    after rebasing onto the adopted trunk (true across squash N→1, rebase-merge N→N re-hashed,
-   and merge-commit ancestry). Genuine survivors are rebased onto the new trunk and **kept**.
+   and merge-commit ancestry). Genuine survivors are rebased onto the new trunk and **kept**. A
+   survivor whose rebase **conflicts** is **rolled back and left on its prior base** (reported
+   `CONFLICT`): `adopt` never commits a conflicted rebase, so no checkout can materialize jj
+   conflict markers into tracked source on disk. Resolve it later with `gitman sync`, or `abandon`
+   it if it was an already-merged duplicate.
 3. **Refuses safely on divergence.** Un-pushed local lands + a moved origin make jj record a
    *conflicted* trunk bookmark; `adopt` refuses (push first) unless `--force` hard-sets trunk to
    the forge head (dropping the un-pushed lands; undoable). `--dry-run` reports the plan only.
+
+Mutating intents mirror jj's bookmarks into the colocated git after each op. If a stuck
+`refs/heads/<lane>` (e.g. an abandoned lane's leftover ref) makes that export partially fail, the
+desync is **surfaced** (a report note + a `gitman doctor` `colocated-refs` check) rather than
+swallowed, and `gitman reconcile` heals it (re-sync refs to jj, drop leftovers) — see §11.
 
 Stays CANONICAL throughout and is a single `gitman undo` step. **`sync` never advances trunk**
 (it fetches lanes-only and rebases onto *local* trunk) — trunk advancement is `land`'s or
@@ -402,7 +415,10 @@ Constraints that are only *documented* drift. The lane model holds by constructi
 - **One deviation handler, not N.** External mutation (raw `jj`/`git`, a human) is the one
   thing Gitman can't prevent. So `status` classifies the repo as **canonical** or
   **off-canonical** and there is exactly one recovery path — `gitman reconcile` — which
-  adopts stray changes into lanes or abandons them. No per-deviant-state handling.
+  adopts stray changes into lanes or abandons them. No per-deviant-state handling. `reconcile`
+  also heals **colocated git-ref drift** (jj bookmark ≠ `refs/heads/<name>`, or an abandoned
+  lane's leftover ref that makes `git_export` fail): it re-syncs the refs to jj — the source of
+  truth — and drops the leftovers. `gitman doctor`'s `colocated-refs` check surfaces the drift.
 
 ## 12. The undo model (the headline feature)
 

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -543,6 +543,10 @@ def _retire_lane(session: Session, trunk: str, lane: str, published_before: set[
             notes.append(f"remote branch '{lane}' not deleted (delete it manually): {exc}")
 
 
+class _SurvivorConflict(Exception):
+    """Internal sentinel: roll back a conflicting survivor rebase tx without committing it."""
+
+
 def _reconcile_lane_against_adopted_trunk(
     session: Session,
     trunk: str,
@@ -556,10 +560,15 @@ def _reconcile_lane_against_adopted_trunk(
 ) -> None:
     """Reconcile one surviving lane against the freshly-adopted trunk (content-based, not SHA).
 
-    Three cases, one emptiness-after-rebase test (works across squash N→1, rebase-merge N→N
-    re-hashed, and merge-commit ancestry — independent of SHA/change-id):
+    Cases, on one emptiness-after-rebase test (works across squash N→1, rebase-merge N→N re-hashed,
+    and merge-commit ancestry — independent of SHA/change-id):
       * `trunk..lane` already empty  → lane is an ancestor of the new trunk → retire (no rebase).
-      * rebase onto trunk conflicts  → leave the conflicted rebase, mark CONFLICT (non-blocking).
+      * rebase onto trunk conflicts  → **roll the rebase back**, leave the lane on its prior base,
+        mark CONFLICT (non-blocking). Committing a conflicted rebase would let a checkout (e.g. `@`
+        on this lane, or end-of-adopt `update_stale`) materialize jj conflict markers into tracked
+        source on disk — which can corrupt files adopt itself depends on and brick the CLI (gap C).
+        The lane stays valid (just behind trunk); the user resolves it with an explicit `gitman
+        sync`, or abandons it if the conflict is because the lane is an already-merged duplicate.
       * post-rebase range all empty  → merged → retire (abandon the emptied commits + delete bookmark).
       * otherwise                    → genuine survivor → keep the rebase onto the new trunk.
     """
@@ -568,11 +577,17 @@ def _reconcile_lane_against_adopted_trunk(
         retired.append(lane)
         return
 
-    with session.ws.transaction("gitman:adopt-rebase", auto_snapshot=False) as tx:
-        rebased_head = tx.rebase(lane, onto=trunk, mode="branch")
-    if rebased_head.has_conflict:  # survivor that conflicts — non-blocking, do NOT abandon
+    try:
+        with session.ws.transaction("gitman:adopt-rebase", auto_snapshot=False) as tx:
+            rebased_head = tx.rebase(lane, onto=trunk, mode="branch")
+            if rebased_head.has_conflict:
+                raise _SurvivorConflict  # abort the tx → lane untouched, no conflicted checkout
+    except _SurvivorConflict:
         conflicts.append(lane)
-        notes.append(f"conflict (resolve, then sync): {lane}")
+        notes.append(
+            f"left on prior base — rebase onto {trunk} conflicts: {lane} "
+            f"(`gitman sync` to rebase + resolve, or `gitman abandon {lane}` if already merged)."
+        )
         return
 
     range_after = session.view().log(f"{trunk}..{lane}")  # re-read after the rebase op committed
@@ -607,7 +622,12 @@ def _adopt_dry_run(session: Session, trunk: str, remote: str):
                 messages.append(f"no {trunk}@{remote} — nothing to adopt; is the trunk pushed?")
                 return IntentResult(intent="adopt", outcome="PLAN", messages=messages, exit_code=1)
             surviving = set(lane_names(session, trunk))
-            if _trunk_conflicted(view, trunk) or _trunk_diverged_no_ff(view, trunk, origin_trunk, remote):
+            # A *conflicted* trunk makes any `{trunk}..` revset raise, so classify divergence FIRST
+            # and skip the survivor preview when diverged (it needs `--force` to resolve trunk before
+            # survivors can be reconciled). Without this guard the survivor loop's `view.log` crashed
+            # the dry run with a RevsetError instead of reporting the plan (round-09 rehearsal).
+            diverged = _trunk_conflicted(view, trunk) or _trunk_diverged_no_ff(view, trunk, origin_trunk, remote)
+            if diverged:
                 messages.append(f"trunk diverged from {remote} — needs `--force` (drops divergent local commits).")
             else:
                 # `behind` = forge commits not yet local; trunk only advances when origin is strictly
@@ -622,11 +642,14 @@ def _adopt_dry_run(session: Session, trunk: str, remote: str):
                     messages.append(f"{trunk} already current — would reconcile lanes only.")
             for lane in sorted(lanes_before - surviving):
                 messages.append(f"would retire (forge-merged, branch deleted): {lane}")
-            for lane in sorted(surviving):
-                if not view.log(f"{trunk}..{lane}"):
-                    messages.append(f"would retire (already an ancestor of trunk): {lane}")
-                else:
-                    messages.append(f"would rebase onto trunk (retire if emptied): {lane}")
+            if diverged:
+                messages.append("survivor-lane preview unavailable until trunk is resolved (`--force`).")
+            else:
+                for lane in sorted(surviving):
+                    if not view.log(f"{trunk}..{lane}"):
+                        messages.append(f"would retire (already an ancestor of trunk): {lane}")
+                    else:
+                        messages.append(f"would rebase onto trunk (retire if emptied): {lane}")
         finally:
             session.ws.restore_operation(op_before)  # undo the fetch's FF/prune → no net mutation
     return IntentResult(
@@ -708,6 +731,21 @@ def do_adopt(session: Session, *, force: bool, dry_run: bool):
                 notes.append(
                     f"forced {trunk} to {remote} — {len(dropped)} divergent local commit(s) dropped (undoable)."
                 )
+            else:
+                # Clean fast-forward: origin is strictly ahead (local trunk is an ancestor of the
+                # forge head). The fetch *usually* auto-FFs the local trunk bookmark, but that is not
+                # guaranteed when the colocated git refs / jj tracking are desynced (round-09 gap A) —
+                # and a silently-stale trunk is the worst failure. Advance trunk EXPLICITLY so it never
+                # depends on the fetch: when origin is strictly ahead and trunk hasn't already reached
+                # it, set the bookmark to the forge head (a no-op when the fetch already advanced it).
+                # The postcondition exempts `adopt` from the trunk-frozen rule, so this stands.
+                local_trunk_now = view.resolve(trunk).commit_id
+                if local_trunk_now != origin_trunk.commit_id and not view.log(
+                    f"{origin_trunk.commit_id}..{trunk}"  # ahead == 0: never move trunk backward
+                ):
+                    with session.ws.transaction("gitman:adopt-ff", auto_snapshot=False) as tx:
+                        tx.set_bookmark(trunk, f"{trunk}@{remote}")
+                    notes.append(f"advanced {trunk} → {origin_trunk.commit_id[:12]} (explicit fast-forward).")
 
             surviving = set(lane_names(session, trunk))
             for lane in sorted(lanes_before - surviving):  # pruned by the fetch (forge-merged + deleted)
@@ -752,7 +790,10 @@ def do_adopt(session: Session, *, force: bool, dry_run: bool):
         messages.append(f"rebased {len(rebased)} survivor(s) onto {trunk}: {', '.join(rebased)}.")
     if conflicts:
         joined = ", ".join(conflicts)
-        messages.append(f"{len(conflicts)} survivor(s) conflict — `gitman resolve`, then `gitman sync`: {joined}.")
+        messages.append(
+            f"{len(conflicts)} survivor(s) couldn't rebase onto {trunk} (left on prior base, worktree "
+            f"untouched): {joined} — `gitman sync` to rebase + resolve, or `gitman abandon` if already merged."
+        )
     notes.append("`gitman undo` reverts trunk + lanes; the forge merge and deleted remote branches are not restored.")
 
     return IntentResult(

--- a/src/gitman/doctor.py
+++ b/src/gitman/doctor.py
@@ -116,6 +116,26 @@ def run_doctor(repo_root: Path, config: GitmanConfig | None = None) -> DoctorRep
     else:
         checks.append(Check(WARN, "version-source", "no [version] source (version/release unavailable)"))
 
+    # colocated jj-bookmark ↔ git-ref drift (round-09 gap B): a stuck/leftover ref makes every
+    # later `git_export` raise, silently desyncing trunk. Surface it (warn, recoverable) so it
+    # can't hide; `gitman reconcile` re-syncs. Skipped when the repo isn't colocated/loadable.
+    if ws is not None and _is_colocated(repo_root):
+        try:
+            from gitman.state import colocated_ref_desync
+
+            mismatched, leftover = colocated_ref_desync(ws.head(), repo_root)
+        except Exception:  # noqa: BLE001 — a probe failure must not fail doctor
+            mismatched, leftover = [], []
+        if not mismatched and not leftover:
+            checks.append(Check(OK, "colocated-refs", "jj bookmarks ↔ git refs in sync"))
+        else:
+            bits = []
+            if mismatched:
+                bits.append(f"{len(mismatched)} bookmark(s) out of sync: {', '.join(n for n, _, _ in mismatched)}")
+            if leftover:
+                bits.append(f"{len(leftover)} leftover git ref(s): {', '.join(leftover)}")
+            checks.append(Check(WARN, "colocated-refs", "; ".join(bits) + " — run `gitman reconcile`"))
+
     return DoctorReport(checks)
 
 

--- a/src/gitman/invariants.py
+++ b/src/gitman/invariants.py
@@ -182,8 +182,8 @@ def _postcondition(session: Session, intent: str, trunk_before: str | None, op_b
     return after
 
 
-def _export_colocated_git(session: Session) -> None:
-    """Mirror jj's refs into the colocated git after a successful mutation.
+def _export_colocated_git(session: Session) -> list[str]:
+    """Mirror jj's refs into the colocated git after a successful mutation. Returns surfacing notes.
 
     jj-lib (via pyjutsu) does NOT auto-export to git — the jj *CLI* runs an explicit export after
     every op so a colocated repo stays consistent for bare `git log`/`status`/`push`. gitman is that
@@ -192,19 +192,30 @@ def _export_colocated_git(session: Session) -> None:
     `git push <trunk>` ships a stale ref. Runs last, after the undo checkpoint, so a (rare) export
     failure never undoes an already-committed, already-recorded intent.
 
-    **Best-effort**, matching the jj CLI: `git::export_refs` can partially fail for an individual
-    bookmark whose git ref diverged from jj's last-exported position (e.g. a branch rewound by
-    `gitman undo`), and pyjutsu surfaces that as a `PyjutsuError`. The jj CLI warns and continues
-    rather than aborting the op; we do the same — the conflicting branch simply stays at its old git
-    position (the pre-export status quo), while every other ref exports. The gitman intent itself has
-    already succeeded and is authoritative in jj.
+    **Best-effort**, matching the jj CLI: `git::export_refs` writes every ref it can — including
+    `<trunk>` — then reports the bookmarks it couldn't (a ref diverged from jj's last-exported
+    position: a branch rewound by `gitman undo`, or an abandoned lane's lingering `refs/heads/<lane>`).
+    pyjutsu raises a `PyjutsuError` listing them. We do NOT auto-heal here (deleting/importing refs
+    mid-intent is too sharp, and could resurrect an abandoned lane) — but we no longer swallow it
+    *silently*: round-09 gap B showed one stuck lane ref makes every *later* export raise too, so the
+    desync (incl. a lagging trunk ref) must surface. Return a note naming the stuck ref(s) →
+    `gitman reconcile` heals them. The intent itself has already succeeded and is authoritative in jj.
     """
     from pyjutsu import PyjutsuError
 
     try:
         session.ws.git_export()
+        return []
     except PyjutsuError:
-        pass  # best-effort mirror; jj remains source of truth (see docstring)
+        from gitman.state import colocated_ref_desync
+
+        try:
+            mismatched, leftover = colocated_ref_desync(session.view(), session.repo_root)
+            stuck = sorted([n for n, _, _ in mismatched] + leftover)
+        except Exception:  # noqa: BLE001 — surfacing must never mask the (already-committed) intent
+            stuck = []
+        names = ", ".join(stuck) if stuck else "some bookmarks"
+        return [f"colocated git ref(s) stale for: {names} — run `gitman reconcile` to re-sync."]
 
 
 @dataclass
@@ -241,6 +252,8 @@ def canonical_tx(session: Session, intent: str) -> Iterator[Transaction]:
             yield tx  # body raises ⇒ pyjutsu rolls back, op_before intact
         _postcondition(session, intent, trunk_before, op_before)
         write_undo_checkpoint(session.repo_root, op_before, intent)
+        # A stuck colocated ref can't be surfaced through the bare-tx yield, but `gitman status` /
+        # `gitman doctor` report the desync, and `gitman reconcile` heals it (round-09 gap B).
         _export_colocated_git(session)
 
 
@@ -269,4 +282,4 @@ def canonical_guard(session: Session, intent: str) -> Iterator[Canon]:
             raise
         canon.state = _postcondition(session, intent, trunk_before, op_before)
         write_undo_checkpoint(session.repo_root, op_before, intent)
-        _export_colocated_git(session)
+        canon.notes += _export_colocated_git(session)  # surface any stuck colocated ref (gap B)

--- a/src/gitman/reconcile.py
+++ b/src/gitman/reconcile.py
@@ -1,9 +1,11 @@
 """`gitman reconcile`: the single recovery path from off-canonical (concept §11, §20).
 
-Non-interactive (agent context): by default it **adopts** each stray change into an
-auto-named lane (`adopted-<change_id>` bookmark); `--abandon` discards them instead. It
-runs without the canonical precheck (the repo is off-canonical by definition) and records
-an undo checkpoint so `gitman undo` can revert it.
+Non-interactive (agent context): it heals two desyncs in one pass — (1) **off-canonical strays**
+(non-empty changes outside every lane): by default each is **adopted** into an auto-named lane
+(`adopted-<change_id>` bookmark), or discarded with `--abandon`; (2) **colocated git-ref drift**
+(round-09 gap B): a live bookmark whose `refs/heads/<name>` lags jj, or an abandoned lane's
+leftover ref that makes every `git_export` raise. It runs without the canonical precheck (the repo
+is off-canonical by definition) and records an undo checkpoint so `gitman undo` can revert it.
 """
 
 from __future__ import annotations
@@ -16,35 +18,77 @@ if TYPE_CHECKING:
     from gitman.session import Session
 
 
+def _heal_colocated_refs(session: Session) -> list[str]:
+    """Re-sync colocated git refs to jj (the source of truth): force each out-of-sync live
+    bookmark's `refs/heads/<name>` to its jj commit, delete every leftover ref with no jj
+    bookmark, then `git_import()`+`git_export()` to reconcile jj's `@git` tracking. Setting refs
+    explicitly (vs. plain import) avoids resurrecting an abandoned lane. Raw `git update-ref` is
+    the sanctioned colocated-ref recovery surface (round-09 gap B; validated in probes)."""
+    import subprocess
+
+    from pyjutsu import PyjutsuError
+
+    from gitman.state import _is_colocated, colocated_ref_desync
+
+    if not _is_colocated(session.repo_root):
+        return []
+    mismatched, leftover = colocated_ref_desync(session.view(), session.repo_root)
+    if not mismatched and not leftover:
+        return []
+    for name, jj_id, _git_id in mismatched:
+        subprocess.run(["git", "update-ref", f"refs/heads/{name}", jj_id],
+                       cwd=session.repo_root, capture_output=True)
+    for name in leftover:
+        subprocess.run(["git", "update-ref", "-d", f"refs/heads/{name}"],
+                       cwd=session.repo_root, capture_output=True)
+    try:
+        session.ws.git_import()
+        session.ws.git_export()
+    except PyjutsuError:
+        pass  # refs are already corrected on disk; tracking re-syncs on the next clean export
+    notes: list[str] = []
+    if mismatched:
+        notes.append(f"re-synced colocated git ref(s): {', '.join(n for n, _, _ in mismatched)}.")
+    if leftover:
+        notes.append(f"removed leftover colocated git ref(s): {', '.join(leftover)}.")
+    return notes
+
+
 def do_reconcile(session: Session, abandon_: bool):
     from gitman.invariants import repo_lock, write_undo_checkpoint
     from gitman.models import IntentResult
-    from gitman.state import capture_state, find_strays
+    from gitman.state import capture_state, colocated_ref_desync, find_strays
 
     trunk = require_trunk(session.config)
     with repo_lock(session.repo_root):
         view = session.fresh_view()  # snapshot dirty @ first
         strays = find_strays(view, trunk)
-        if not strays:
+        mismatched, leftover = colocated_ref_desync(view, session.repo_root)
+        if not strays and not mismatched and not leftover:
             return IntentResult(
-                intent="reconcile", outcome="CLEAN", messages=["already canonical — no strays."]
+                intent="reconcile", outcome="CLEAN", messages=["already canonical — no strays, refs in sync."]
             )
 
         op_before = session.ws.head_operation()
+        ref_notes = _heal_colocated_refs(session)  # gap B: heal git-ref drift first
         existing = {b.name for b in view.bookmarks() if b.remote is None}
         actions: list[str] = []
-        with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
-            for change in strays:
-                if abandon_:
-                    tx.abandon(change.change_id)
-                    actions.append(f"abandoned {change.change_id}")
-                else:
-                    name = f"adopted-{change.change_id[:8]}"
-                    if name in existing:
-                        name = f"adopted-{change.change_id}"
-                    tx.create_bookmark(name, change.change_id)
-                    existing.add(name)
-                    actions.append(f"adopted {change.change_id} → lane '{name}'")
+        if strays:
+            with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
+                for change in strays:
+                    if abandon_:
+                        tx.abandon(change.change_id)
+                        actions.append(f"abandoned {change.change_id}")
+                    else:
+                        name = f"adopted-{change.change_id[:8]}"
+                        if name in existing:
+                            name = f"adopted-{change.change_id}"
+                        tx.create_bookmark(name, change.change_id)
+                        existing.add(name)
+                        actions.append(f"adopted {change.change_id} → lane '{name}'")
+        actions += ref_notes
+        if not actions:
+            actions = ["nothing to do."]
         write_undo_checkpoint(session.repo_root, op_before, "reconcile")
         state = capture_state(session)
 

--- a/src/gitman/state.py
+++ b/src/gitman/state.py
@@ -107,6 +107,52 @@ def _trunk_remote_relation(session: Session, view: RepoView, trunk: str) -> tupl
     return behind, ahead, remote
 
 
+def _git_refs_heads(repo_root: Path) -> dict[str, str]:
+    """`{bookmark_name: commit_sha}` from the colocated `refs/heads/*` (raw `git` read).
+
+    The one place gitman reads colocated git refs directly: detecting jj-bookmark↔git-ref desync
+    (round-09 gap B). jj commit ids ARE the git SHAs in a colocated repo, so the values compare
+    directly against `view.resolve(name).commit_id`. Returns `{}` if git can't be read.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname:lstrip=2) %(objectname)", "refs/heads/"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    refs: dict[str, str] = {}
+    if proc.returncode == 0:
+        for line in proc.stdout.splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                refs[parts[0]] = parts[1]
+    return refs
+
+
+def colocated_ref_desync(view: RepoView, repo_root: Path) -> tuple[list[tuple[str, str, str | None]], list[str]]:
+    """Detect jj-bookmark ↔ colocated-git-ref drift (round-09 gap B).
+
+    Returns `(mismatched, leftover)`:
+      * `mismatched` — `(name, jj_id, git_id)` for each *local* (non-conflicted) jj bookmark whose
+        `refs/heads/<name>` is missing or points elsewhere (jj is the source of truth).
+      * `leftover`   — `refs/heads/<name>` with no matching local jj bookmark (e.g. an abandoned
+        lane's lingering ref — the kind that makes every later `git_export` raise).
+    """
+    refs = _git_refs_heads(repo_root)
+    local: dict[str, str] = {}
+    for b in view.bookmarks():
+        if b.remote is None and not b.conflicted:
+            try:
+                local[b.name] = view.resolve(b.name).commit_id
+            except RevsetError:
+                pass
+    mismatched = [(name, jj_id, refs.get(name)) for name, jj_id in local.items() if refs.get(name) != jj_id]
+    leftover = sorted(name for name in refs if name not in local)
+    return mismatched, leftover
+
+
 def find_strays(view: RepoView, trunk: str) -> list[Change]:
     """Non-empty changes descended from trunk that belong to no lane (basic off-canonical signal)."""
     return [_change(c) for c in view.log(_stray_revset(trunk)) if not c.is_empty]

--- a/tests/test_adopt_integration.py
+++ b/tests/test_adopt_integration.py
@@ -227,6 +227,19 @@ def test_adopt_diverged_blocks_without_force(tmp_path: Path):
     assert state.trunk.commit_id == trunk_before
 
 
+def test_adopt_dry_run_on_diverged_trunk_blocks_not_crashes(tmp_path: Path):
+    """A conflicted trunk makes `{trunk}..` revsets raise. `adopt --dry-run` must classify the
+    divergence and report a clean PLAN (needs --force), not crash with a RevsetError (exit 3)."""
+    work, remote, ws = _with_remote(tmp_path)
+    _make_diverged(work, remote, tmp_path, ws)
+
+    res = do_adopt(_sess(work), force=False, dry_run=True)  # must not raise RevsetError
+
+    assert res.outcome == "PLAN"
+    assert res.exit_code == 0  # dry run never fails
+    assert any("diverged" in m and "--force" in m for m in res.messages), res.messages
+
+
 def test_adopt_diverged_force_takes_origin(tmp_path: Path):
     work, remote, ws = _with_remote(tmp_path)
     _make_diverged(work, remote, tmp_path, ws)
@@ -289,6 +302,51 @@ def test_adopt_reconciles_rewritten_origin_trunk(tmp_path: Path):
     assert state.trunk.commit_id != local_c  # the divergent local commit is gone
 
 
+# --- 5c. gap C: a conflicting survivor never corrupts the worktree -------------------
+
+
+def test_adopt_conflicting_survivor_leaves_worktree_clean(tmp_path: Path):
+    """A survivor lane whose content overlaps the adopted trunk must NOT have jj conflict markers
+    materialized into tracked source on disk (round-09 gap C — that corrupted core.py and bricked
+    the CLI). adopt advances trunk + retires merged lanes, but rolls back the conflicting rebase:
+    the lane stays on its prior base, unconflicted, worktree untouched."""
+    work, remote, ws = _with_remote(tmp_path)
+
+    # Build a survivor lane editing shared.txt, and LEAVE @ on it (the dangerous cd'd-on-lane shape).
+    with ws.transaction("start feat") as tx:
+        tx.new("main")
+        tx.create_bookmark("feat", "@")
+    (work / "shared.txt").write_text("feature line 1\nfeature line 2\n")
+    ws.snapshot()
+    with ws.transaction("describe feat") as tx:
+        tx.describe("@", "feat edits shared.txt")
+    ws.git_push("origin", "feat", allow_new=True)
+    ws.snapshot()  # @ stays on feat
+
+    # Forge advances trunk with a CONFLICTING edit to the same file; keeps feat alive (survivor).
+    other = _clone(remote, tmp_path, "squash")
+    (other / "shared.txt").write_text("trunk line 1\ntrunk line 2\n")
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "trunk edits shared.txt", cwd=other)
+    _git("push", "origin", "HEAD:main", cwd=other)
+
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+
+    assert res.outcome == "CONFLICT", res.messages
+    assert res.exit_code == 1
+    # trunk advanced despite the conflicting survivor
+    assert _resolve(work, "main") == _resolve(work, "main@origin")
+    # THE GUARANTEE: no conflict markers materialized into the tracked file on disk
+    content = (work / "shared.txt").read_text()
+    assert not any(mk in content for mk in ("<<<<<<<", ">>>>>>>", "%%%%%%%", "+++++++")), content
+    assert "feature line 1" in content  # still the lane's own content, intact
+    # the lane survives, NOT conflicted in jj (the rebase was rolled back)
+    state = capture_state(_sess(work))
+    assert state.canonical
+    feat = next(lane for lane in state.lanes if lane.name == "feat")
+    assert not feat.conflict
+
+
 # --- 6. --dry-run mutates nothing ----------------------------------------------------
 
 
@@ -341,6 +399,47 @@ def test_adopt_already_current(tmp_path: Path):
     assert res.outcome == "ALREADY_CURRENT"
     assert res.exit_code == 0
     assert _resolve(work, "main") == trunk_before
+
+
+# --- 8b. gap A: adopt advances trunk even when the fetch does NOT auto-FF ------------
+
+
+class _NoFastForwardWS:
+    """Wrap a Workspace so `git_fetch` updates remote-tracking but leaves the local trunk
+    bookmark behind — the round-09 gap-A desync (a fetch that silently doesn't auto-FF).
+    Everything else delegates to the real workspace."""
+
+    def __init__(self, real, trunk: str):
+        self._real = real
+        self._trunk = trunk
+
+    def git_fetch(self, *args, **kwargs):
+        before = self._real.head().resolve(self._trunk).commit_id
+        out = self._real.git_fetch(*args, **kwargs)
+        after = self._real.head().resolve(self._trunk).commit_id
+        if after != before:  # the fetch auto-FF'd — undo just the local bookmark move
+            with self._real.transaction("test:simulate-no-ff", auto_snapshot=False) as tx:
+                tx.set_bookmark(self._trunk, before)
+        return out
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_adopt_advances_trunk_when_fetch_does_not_ff(tmp_path: Path):
+    """Origin strictly ahead (clean FF), but the fetch leaves local trunk behind. adopt must
+    still advance trunk to origin via the explicit set_bookmark — deterministic, fetch-independent."""
+    work, remote, ws = _with_remote(tmp_path)
+    _advance_main(remote, tmp_path)  # origin strictly ahead; local main is a strict ancestor
+
+    sess = _sess(work)
+    sess.ws = _NoFastForwardWS(sess.ws, "main")  # force the no-auto-FF desync
+    res = do_adopt(sess, force=False, dry_run=False)
+
+    assert res.outcome == "ADOPTED", res.messages
+    assert res.exit_code == 0
+    assert _resolve(work, "main") == _resolve(work, "main@origin")  # advanced despite no auto-FF
+    assert capture_state(_sess(work)).canonical
 
 
 # --- 9. no remote → exit 2 -----------------------------------------------------------

--- a/tests/test_colocated_refs.py
+++ b/tests/test_colocated_refs.py
@@ -1,0 +1,137 @@
+"""Round-09 gap B: colocated jj-bookmark ↔ git-ref drift detection + heal.
+
+A leftover `refs/heads/<lane>` (abandoned lane) or a live bookmark whose git ref lags jj makes
+every later `git_export` raise — silently desyncing trunk. `gitman doctor` must surface it,
+`_export_colocated_git` must return a surfacing note (not swallow), and `gitman reconcile` must
+heal it without resurrecting the abandoned lane. In-process over pyjutsu, colocated work repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pyjutsu import PyjutsuError, Workspace
+
+from gitman.config import GitmanConfig
+from gitman.reconcile import do_reconcile
+from gitman.session import Session
+from gitman.state import colocated_ref_desync
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def _git(*args, cwd: Path):
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _gref(work: Path, ref: str) -> str | None:
+    p = subprocess.run(["git", "rev-parse", ref], cwd=work, capture_output=True, text=True)
+    return p.stdout.strip() if p.returncode == 0 else None
+
+
+def _colocated(tmp_path: Path) -> tuple[Path, Workspace]:
+    work = tmp_path / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.git_export()
+    return work, ws
+
+
+def _make_lane(ws: Workspace, work: Path, lane: str, fn: str) -> None:
+    with ws.transaction(f"start {lane}") as tx:
+        tx.new("main")
+        tx.create_bookmark(lane, "@")
+    (work / fn).write_text(lane.upper() + "\n")
+    ws.snapshot()
+    with ws.transaction(f"desc {lane}") as tx:
+        tx.describe("@", lane)
+    with ws.transaction(f"park {lane}") as tx:
+        tx.new("main")
+
+
+def _induce_desync(work: Path, ws: Workspace) -> str:
+    """Abandon `gone` (leftover diverged ref) + corrupt live `feat`'s ref. Returns feat's jj id."""
+    _make_lane(ws, work, "gone", "g.txt")
+    _make_lane(ws, work, "feat", "ft.txt")
+    ws.git_export()
+    feat_jj = ws.head().resolve("feat").commit_id
+    with ws.transaction("abandon gone") as tx:
+        for c in ws.head().log("main..gone"):
+            tx.abandon(c.change_id)
+        tx.delete_bookmark("gone")
+    main_ref = _gref(work, "refs/heads/main")
+    _git("update-ref", "refs/heads/gone", main_ref, cwd=work)  # diverged leftover
+    _git("update-ref", "refs/heads/feat", main_ref, cwd=work)  # live bookmark, wrong ref
+    return feat_jj
+
+
+def test_detect_colocated_ref_desync(tmp_path: Path):
+    work, ws = _colocated(tmp_path)
+    feat_jj = _induce_desync(work, ws)
+
+    mismatched, leftover = colocated_ref_desync(ws.head(), work)
+    assert "gone" in leftover  # abandoned lane's lingering ref
+    assert any(name == "feat" and jj == feat_jj for name, jj, _git in mismatched)
+    # plain export raises because of the stuck leftover (the progressive-desync trigger)
+    try:
+        ws.git_export()
+        raise AssertionError("expected git_export to raise on the stuck leftover ref")
+    except PyjutsuError as exc:
+        assert "gone" in str(exc)
+
+
+def test_export_helper_surfaces_instead_of_swallowing(tmp_path: Path):
+    from gitman.invariants import _export_colocated_git
+
+    work, ws = _colocated(tmp_path)
+    _induce_desync(work, ws)
+
+    notes = _export_colocated_git(_sess(work))
+    assert notes, "a stuck colocated ref must surface a note, not be swallowed silently"
+    assert "gone" in notes[0]
+    assert "reconcile" in notes[0]
+
+
+def test_doctor_warns_on_desync(tmp_path: Path):
+    from gitman.doctor import WARN, run_doctor
+
+    work, ws = _colocated(tmp_path)
+    _induce_desync(work, ws)
+
+    report = run_doctor(work)
+    check = next(c for c in report.checks if c.name == "colocated-refs")
+    assert check.level == WARN
+    assert "gone" in check.detail
+
+
+def test_reconcile_heals_desync_without_resurrecting(tmp_path: Path):
+    from gitman.doctor import OK, run_doctor
+
+    work, ws = _colocated(tmp_path)
+    feat_jj = _induce_desync(work, ws)
+
+    res = do_reconcile(_sess(work), abandon_=False)
+    assert res.exit_code == 0, res.messages
+
+    # refs re-synced to jj truth; leftover gone; abandoned lane NOT resurrected; feat preserved.
+    fresh = _sess(work).view()
+    locals_ = {b.name for b in fresh.bookmarks() if b.remote is None}
+    assert "gone" not in locals_  # not resurrected
+    assert "feat" in locals_  # live bookmark preserved
+    assert _gref(work, "refs/heads/gone") is None
+    assert _gref(work, "refs/heads/feat") == feat_jj
+    mismatched, leftover = colocated_ref_desync(fresh, work)
+    assert not mismatched and not leftover
+    # a clean export now succeeds, and doctor is back in sync
+    ws.git_export()
+    check = next(c for c in run_doctor(work).checks if c.name == "colocated-refs")
+    assert check.level == OK


### PR DESCRIPTION
Follow-up to round 07 (`gitman adopt`, PRs #22 + #23). Dogfooding adopt on this repo's own forge-merged trunk exposed sharp edges that forced manual `pyjutsu`/`git` surgery. This round makes adopt and the colocated-git export path deterministic and self-healing. **83 tests green, lint clean, doctor HEALTHY.**

## Gap A — deterministic clean-FF trunk advance
`do_adopt` now explicitly `set_bookmark(trunk, trunk@remote)` when origin is strictly ahead (`behind>0 && ahead==0`), instead of trusting jj's fetch auto-FF (which could silently leave trunk behind on desynced refs, reporting `ADOPTED` with no error). Trunk advancement is now fetch-independent; the explicit set is a no-op when the fetch already advanced it. Regression test simulates a fetch that doesn't auto-FF.

## Gap B — colocated jj-bookmark ↔ git-ref drift surfaced + healed
Real mechanism (probed): `git::export_refs` writes trunk's ref even on partial failure — the residue is a **leftover abandoned-lane `refs/heads/<lane>` that makes every later `git_export` raise**, which `_export_colocated_git` swallowed silently.
- `_export_colocated_git` now returns a surfacing note (via `canon.notes`) instead of swallowing.
- `gitman doctor` gains a `colocated-refs` check.
- `gitman reconcile` heals the drift (force live refs to jj truth, delete leftovers, `git_import`+`git_export`) **without resurrecting abandoned lanes** (plain `git_import` would).

## Gap C — adopt never corrupts the worktree
A survivor lane whose rebase onto the adopted trunk conflicts is **rolled back and left on its prior base, unconflicted** — no checkout, so no jj conflict markers are ever written into tracked source on disk (the failure that bricked `core.py` in the real incident). Trunk still advances and merged lanes still retire; the survivor is reported `CONFLICT` with guidance (`gitman sync`, or `abandon` if already merged).

## Also
- `adopt --dry-run` no longer crashes (RevsetError) on a conflicted trunk — classifies divergence first, reports a clean PLAN.
- Docs/skill: colocated `gh` detached-HEAD quirk (`gh api` branch-delete), trunk-push decision (forge loop is the sanctioned path), concept + reconcile updates.

## Verification
- +6 tests (gap A, gap B ×4, gap C, dry-run-on-diverged).
- Full forge-loop rehearsal (`publish → squash-merge → adopt`) through the real CLI completes with **zero manual `pyjutsu`/`git` surgery**.