### PR TITLE
round-10: gitman switch — resume an existing lane (#10)

### DIFF
--- a/.claude/skills/gitman/SKILL.md
+++ b/.claude/skills/gitman/SKILL.md
@@ -14,6 +14,7 @@ A **lane** is one unit of work: a named bookmark (= git branch) on trunk, kept l
 
 ```
 gitman start <name>         # begin a lane (add --workspace to isolate it in its own dir)
+gitman switch <lane>         # resume a parked lane: move @ back onto an existing lane's change
 # ...edit files...
 gitman save -m "<message>"  # describe the current change
 gitman status               # see trunk + all lanes (canonical or off-canonical)
@@ -25,6 +26,13 @@ gitman abandon [<lane>]     # discard a lane
 
 `sync` fetches **lanes-only** and rebases onto the *local* trunk — it never advances trunk and
 signposts `gitman adopt` when origin's trunk has moved.
+
+`switch` is the only lane-**navigation** verb: when `@` leaves a lane without ending it (a second
+agent ran `start` in the **same** workspace and stranded yours; you started a sibling; you landed
+one of several lanes), `gitman switch <lane>` puts `@` back on it. It never mutates trunk, refuses
+to strand an unnamed dirty `@` (save/start/abandon it first), and reports cleanly if the lane is
+checked out in another `--workspace` (`cd` there to resume). `gitman start <existing>` now points
+here instead of dead-ending.
 
 ## Forge PRs: `publish → PR → merge → adopt`
 

--- a/.scratch/projects/10-resume-existing-lane/ISSUE.md
+++ b/.scratch/projects/10-resume-existing-lane/ISSUE.md
@@ -1,0 +1,164 @@
+# 10 — `gitman switch`: no way to move `@` back to an existing lane
+
+> **Found:** 2026-06-29, finishing a **flora** curator session. A second agent ran
+> `gitman start <other-lane>` **in the same workspace**, which moved `@` onto the new
+> lane and **stranded the lane I was working on** (`curator-character-filter`). The
+> lane's commit was preserved, but gitman offers **no front-door way to put `@` back
+> on it** to keep working. `start` only *creates*; raw `jj` is both forbidden *and*
+> unavailable (no CLI). This is a concrete, fixable capability gap.
+
+## TL;DR — what we want
+
+| # | Want | Where | Severity |
+|---|------|-------|----------|
+| R1 | A first-class **`gitman switch <lane>`** that moves `@` onto an existing lane's change so you can resume it | new `src/gitman/cli.py` cmd + `core.do_switch` | **high** (only missing lane-navigation op) |
+| R2 | Implemented by composing the **existing** `PyTransaction.edit(revset)` primitive — **no new Pyjutsu bindings** | `src/gitman/core.py`, `lanes.py` | high |
+| R3 | `gitman start <existing-name>` should **point at `switch`** instead of a silent no-op (today it just prints "already exists") | `core.do_start` | medium |
+
+`start` opens a lane, `save` describes it, `land`/`abandon` end it, `sync` rebases it
+— but once `@` leaves a lane, **nothing moves it back**. Switching between existing
+lanes is a routine VCS operation everywhere except gitman.
+
+---
+
+## The scenario (concrete, from this session)
+
+Two agents shared the **same colocated workspace** (`~/Documents/Projects/flora`):
+
+- Agent A (me) had committed curator work on lane **`curator-character-filter`**, with
+  more edits in flight on it.
+- Agent B ran **`gitman start curator-prompt-capture-data-stage`** in the same dir.
+  `start` does `tx.new(trunk)` (`core.py:161,194`) → a new sibling change on trunk, and
+  `@` moved onto it. Agent A's lane was left as a commit with **no `@` on it**.
+
+```
+$ gitman status
+Gitman status — CANONICAL · 2 lanes
+trunk: main @ 36cc84f…
+  curator-character-filter           draft      1 change, +679 −11
+* curator-prompt-capture-data-stage  published  1 change, +726 −31   · you are here
+```
+
+I needed to **return to `curator-character-filter`** to finish a perf fix. There is no
+gitman command to do that:
+
+```
+$ gitman start curator-character-filter
+lane 'curator-character-filter' already exists.        # exit 0 — no-op, @ unmoved
+
+$ gitman switch / checkout / resume / edit / work / goto / use   # none exist
+Usage: gitman [OPTIONS] COMMAND ...  Error: No such command.
+```
+
+And the usual escape hatch is closed twice over:
+
+- **Raw `jj` is forbidden** (breaks canonicity → forces `reconcile`), and
+- **there is no `jj` CLI at all** here — gitman drives jj-lib via **pyjutsu**
+  (`jj: command not found`, even inside devenv). So `jj edit <lane>` is not available
+  even as a rule-violation.
+- **`gitman undo --op`** would rewind `@`, but only by reverting *past Agent B's now-
+  published lane* — destructive to someone else's landed work. Not viable.
+
+**Why this will recur:** multi-agent / multi-session work routinely lands two lanes in
+one workspace (a teammate or background agent starts a lane; you inherit a moved `@`).
+`--workspace` *prevents* the entanglement up front, but offers no cure once two lanes
+already coexist in one dir. "Switch to that other lane" is the missing primitive.
+
+---
+
+## Capability investigation (so the fix is grounded)
+
+### gitman surface — no switch/navigation verb
+
+`gitman --help` commands: `doctor, status, start, save, seed, publish, land, abandon,
+sync, adopt, resolve, undo, version, release, init, reconcile`. Probed and absent:
+`switch, checkout, resume, edit, work, goto, use`. Command registration lives in
+`src/gitman/cli.py` (17 `@app.command()`s); each delegates to a `do_*` in
+`src/gitman/core.py`. `start` moves `@` via `tx.new(trunk)` (`core.py:161,194`).
+
+### pyjutsu already exposes the exact primitive
+
+gitman mutates through **jj-lib embedded via pyjutsu** (no `jj` CLI). The transaction
+stub `Pyjutsu/python/pyjutsu/_pyjutsu.pyi` exposes, alongside the `new`/`rebase`/
+`restore`/bookmark methods gitman already uses:
+
+```
+105: class PyTransaction:
+109:     def new(self, parents: list[str] | None = ...) -> dict[str, object]: ...
+110:     def edit(self, revset_str: str) -> dict[str, object]: ...      # ← the primitive we need
+```
+
+`edit(revset_str)` is jj's "make this existing commit the working copy" — precisely a
+lane switch when `revset_str` is the lane bookmark. gitman already composes its sibling
+`tx.new(...)`; **`tx.edit(...)` is unused**. So `gitman switch` is implementable at the
+gitman layer today with **no Pyjutsu changes**.
+
+**Conclusion:** a one-transaction `gitman switch <lane>` = resolve the lane bookmark →
+`tx.edit(<lane>)` → report + `Undo:` line. Low cost, high value, no new bindings.
+
+---
+
+## Proposed UX (for discussion)
+
+```
+gitman switch curator-character-filter      # move @ onto that lane's change, resume it
+```
+
+Sketch of behaviour:
+
+1. Resolve `<lane>` to its bookmark/commit; error if unknown, or if it is `trunk`
+   (trunk is frozen — switching onto it is a no-op/disallowed).
+2. Precondition: current `@` is clean or is itself a named lane (don't strand an
+   *undescribed* draft — if `@` has uncommitted, unbookmarked work, refuse with a hint
+   to `save`/`start`/`abandon` first, mirroring how other ops guard canonicity).
+3. In one transaction: `tx.edit(<lane>)` so `@` becomes that lane's change.
+4. Emit a `status`-style report (now `* <lane> · you are here`) + a whole-intent
+   `Undo:` line, and verify `status` stays **CANONICAL**.
+
+Open design questions:
+
+- **Naming:** `switch` (git-familiar) vs `resume` vs `goto`. Recommend `switch`.
+- **`start` overlap (R3):** make `gitman start <existing>` either error-with-hint
+  ("lane exists — use `gitman switch <name>`") or transparently delegate to `switch`,
+  instead of today's silent "already exists" no-op that leaves `@` unmoved.
+- **Dirty `@`:** refuse, auto-`save`, or auto-stash? Refuse-with-hint is safest for v1.
+- **Workspace interaction:** if `<lane>` is checked out in another `--workspace`, jj
+  forbids a second checkout — detect and report cleanly rather than surfacing a raw
+  `WorkingCopyError`.
+
+---
+
+## Acceptance criteria
+
+1. `gitman switch <lane>` moves `@` onto an existing lane's change; `gitman status`
+   then shows that lane as `· you are here` and remains **CANONICAL** before/after.
+2. Runs entirely through a pyjutsu transaction (`tx.edit`) — **no raw `jj`/`git`**, and
+   **no Pyjutsu changes** (the `edit` binding already exists).
+3. **`gitman undo`** reverts the switch as a single intent.
+4. Clear errors for: unknown lane, `<lane>` == trunk, a dirty/unbookmarked `@` that
+   would be stranded, and a lane already checked out in another workspace.
+5. `gitman start <existing>` no longer dead-ends — it points the user at `switch`
+   (R3), and the two share one resolution/guard path.
+6. Docs + the agent skill (`.claude/skills/gitman/SKILL.md`) updated to list `switch`
+   in the lane loop; a test in `gitman/tests/` covering the
+   stranded-lane-in-shared-workspace case from this issue.
+
+---
+
+## Relationship to 08
+
+[08-split-lane-capability](../08-split-lane-capability/ISSUE.md) is the sibling gap:
+08 *divides* one lane's entangled change into two; this (10) *navigates* `@` between
+lanes that already exist. Both stem from the same root — **multiple efforts sharing one
+workspace** — and both are blocked by the same "no raw jj, and no jj CLI anyway"
+constraint. `split` + `switch` together close the multi-lane-in-one-dir story.
+
+---
+
+## Workaround used this session (so nothing was lost)
+
+None available through gitman. Agent A's `curator-character-filter` lane is intact as a
+commit (verified: the gender/skin/sort work is all present on the branch via read-only
+`git show curator-character-filter:<file>`), but `@` cannot be returned to it with the
+sanctioned tooling — which is the whole motivation for `switch`. Finishing that lane's
+remaining perf fix is **blocked on this gap**.

--- a/.scratch/projects/10-resume-existing-lane/KICKOFF.md
+++ b/.scratch/projects/10-resume-existing-lane/KICKOFF.md
@@ -1,0 +1,95 @@
+# KICKOFF — Round 10: `gitman switch` (resume an existing lane)
+
+> Paste everything below the line into a fresh gitman session to start this round.
+> Builds the only missing lane-navigation verb. Authority docs already exist — this round is
+> implementation + tests, not design. Follows round-09 (adopt hardening, landed via PR #24).
+
+---
+
+You're implementing **`gitman switch <lane>`** — a first-class intent that moves the working-copy
+`@` onto an **existing** lane's change so a stranded/parked lane can be resumed. Today `start` only
+*creates*; once `@` leaves a lane (a second agent ran `start` in the same workspace, you started a
+sibling, or you landed one of several lanes) **nothing moves `@` back**, and raw `jj` is both
+forbidden *and* unavailable (no CLI — jj is embedded via pyjutsu). This closes that gap.
+
+The design is **done and grounded** — read it, don't re-derive it:
+
+**Read first (authority + the plan you're executing):**
+1. `.scratch/projects/10-resume-existing-lane/PLAN.md` — **the spec you implement**: behaviour,
+   guards, file-by-file changes, the 8 tests, and the 4-slice build order. Follow it.
+2. `.scratch/projects/10-resume-existing-lane/ISSUE.md` — the motivating scenario + acceptance
+   criteria (stranded `curator-character-filter` lane in a shared workspace).
+3. `src/gitman/core.py` — `do_start` (`~:141`, the non-workspace path is the template),
+   `do_abandon` (`~:417`, the error-message + lane-resolution pattern to mirror).
+4. `src/gitman/invariants.py` — `canonical_tx` (`~:238`, the single-transaction sugar `switch`
+   uses) and `_postcondition` (`~:169`, the trunk guard `switch` passes unmodified — no exemption).
+5. `src/gitman/lanes.py` — `lane_names`, `current_lane`, `require_current_lane`, `ensure_unique`
+   (the R3 message edit lives here).
+6. `Pyjutsu/python/pyjutsu/_pyjutsu.pyi:110` — `PyTransaction.edit(revset_str)`, the unused binding
+   that is the whole engine. **No pyjutsu changes are needed.**
+7. `tests/test_lifecycle_integration.py` — the harness to mirror (`_init`/`_sess`, drive `do_*`
+   directly, assert via `capture_state`).
+
+**Current state (don't re-derive):** `main` is CANONICAL, trunk @ `446070c9` (round-09 adopt
+hardening landed). `gitman doctor` HEALTHY (incl. `colocated-refs ok`). 83 tests pass. You start on
+lane **`resume-existing-lane`**, which already carries this project's `ISSUE.md`/`PLAN.md`/`KICKOFF.md`
+as one saved draft change — **continue on it** (don't `start` a new lane; that would strand this one,
+which is literally the bug we're fixing).
+
+---
+
+## What to build (summary — PLAN.md is the full spec)
+
+`gitman switch <lane>`: resolve trunk + lane → guard → one `canonical_tx` doing `tx.edit(<lane>)` →
+`status`-style report + `Undo:` line. Guards: unknown lane (exit 3), `<lane> == trunk` (exit 3),
+already-current (NOOP, exit 0), would-strand-an-unnamed-dirty-`@` (exit 1, hint save/start/abandon),
+lane checked out in another `--workspace` (exit 1, clean message instead of raw `WorkingCopyError`).
+Plus **R3**: `gitman start <existing>` stops dead-ending — `ensure_unique`'s "already exists" message
+points at `gitman switch <name>`.
+
+## Build order (each slice lint+test green before the next — see PLAN.md §Build order)
+1. **Slice 1** — `do_switch` happy path + CLI command (resolve, unknown/trunk guards, NOOP,
+   `canonical_tx` + `tx.edit`, report). Tests 1–4. *(highest value, smallest change)*
+2. **Slice 2** — strand guard (refuse to orphan unnamed dirty work). Test 5.
+3. **Slice 3** — undo round-trip (test 6) + R3 `ensure_unique` message edit (test 7).
+4. **Slice 4** — workspace-checked-out detection/message (test 8) + docs (`GITMAN_CONCEPT.md`
+   intents table + lane-loop line; `SKILL.md` lane-loop cheatsheet).
+
+Verify each slice inside devenv (the `gitman:lint`/`gitman:test` task names aren't on PATH):
+```
+devenv shell -- bash -c '"$DEVENV_STATE/venv/bin/ruff" check src tests && "$DEVENV_STATE/venv/bin/pytest" -q'
+```
+
+## First moves (before writing code)
+- Confirm the two cheap unknowns flagged in PLAN.md §Risks: (a) `tx.edit(<bookmark-name>)` resolves a
+  bookmark name as a revset — strong precedent: `do_sync` passes a bare lane name to `tx.rebase`
+  (`core.py:~492`); verify, and if it needs an explicit revset just pass the bookmark string. (b)
+  whether `models.IntentResult.outcome`/`intent` are constrained literals — if so add
+  `SWITCHED`/`switch` (and confirm `NOOP` is already allowed; `do_save` returns it). Check
+  `render.py` doesn't whitelist outcome verbs.
+
+## Project rules (non-negotiable)
+- Everything inside devenv (`devenv shell -- bash -c '...'`; batch commands — each launch
+  re-evaluates the env). The venv tools live at `$DEVENV_STATE/venv/bin`.
+- Dogfood VC through `gitman` — never raw `jj`/`git`. jj is embedded via pyjutsu (`../Pyjutsu`); no
+  `jj` CLI, no `-T` templates. Reads via `Session.view()`/`fresh_view()`; mutations via
+  `ws.transaction(...)`. **Stay on lane `resume-existing-lane`; `gitman save` at each green slice.**
+- **Don't publish/land/push without an explicit ask.** No AI-authorship trailers in commits/PRs/docs.
+
+## Definition of done
+- [ ] `gitman switch <lane>` moves `@` onto an existing lane; `status` shows it `· you are here` and
+      stays CANONICAL before/after; runs through a single `tx.edit` transaction (no raw jj/git, no
+      pyjutsu changes).
+- [ ] `gitman undo` reverts a switch as one intent.
+- [ ] Clear errors for: unknown lane, `<lane> == trunk`, would-strand-unnamed-`@`, and a lane
+      checked out in another workspace.
+- [ ] `gitman start <existing>` points at `switch` (R3).
+- [ ] `GITMAN_CONCEPT.md` intents table + `SKILL.md` lane loop list `switch`; new
+      `tests/test_switch_integration.py` covers the stranded-lane case + all guards (8 tests).
+- [ ] `gitman doctor` HEALTHY; full suite green; each slice green before the next.
+- [ ] All ISSUE.md acceptance criteria met (see PLAN.md §Acceptance criteria for the mapping).
+
+## After this round
+`08-split-lane-capability` (`gitman split` — carve entangled work into two lanes; ISSUE-stage,
+path-scoped MVP, also no pyjutsu changes) is the sibling gap. `split` + `switch` together close the
+multiple-efforts-in-one-workspace story.

--- a/.scratch/projects/10-resume-existing-lane/PLAN.md
+++ b/.scratch/projects/10-resume-existing-lane/PLAN.md
@@ -1,0 +1,205 @@
+# PLAN — 10: `gitman switch <lane>` (move `@` back onto an existing lane)
+
+> Implementation plan for [ISSUE.md](./ISSUE.md). Grounded in the gitman 0.2.2 codebase as it
+> stands on `main` after round-09 landed (trunk @ `446070c9`). Sibling effort:
+> [08-split-lane-capability](../08-split-lane-capability/ISSUE.md).
+
+## Goal (one sentence)
+
+Add a first-class **`gitman switch <lane>`** intent that moves the working-copy `@` onto an
+existing lane's change so a stranded/parked lane can be resumed — implemented by composing the
+**already-exposed** `PyTransaction.edit(revset)` primitive, with **no new pyjutsu bindings** and
+no raw `jj`/`git`.
+
+## Why now / scope guard
+
+This is the **only missing lane-navigation verb**. `start` opens, `save` describes, `land`/`abandon`
+end, `sync` rebases — but once `@` leaves a lane (a second agent ran `start` in the same workspace;
+you `start`ed a sibling; you landed one of several lanes), nothing moves `@` back. The cure is one
+transaction: resolve the lane bookmark → `tx.edit(<lane>)`. Everything else in this plan is guard
+rails around that single call.
+
+**Out of scope (defer):** dirty-`@` auto-save/stash (we refuse with a hint), interactive lane
+picker, switching *into* another `--workspace` (jj forbids a second checkout — we detect + report).
+
+---
+
+## Grounding: the exact primitives this composes
+
+All verified in the current tree:
+
+- **`PyTransaction.edit(revset_str)`** — `Pyjutsu/python/pyjutsu/_pyjutsu.pyi:110`. jj's "make this
+  commit the working copy." Currently **unused** by gitman (we use the sibling `tx.new` in
+  `do_start`, `core.py:161`). This is the whole engine.
+- **`canonical_tx(session, intent)`** — `invariants.py:238`. Single-transaction sugar: takes the
+  lock, asserts fresh, prechecks canonical, snapshots `op_before`, yields the `tx`, then runs the
+  postcondition (assert still-canonical + trunk-unchanged-unless-`land`; auto-restore `op_before`
+  on violation), writes the undo checkpoint, exports colocated git. **`switch` is a textbook
+  `canonical_tx` intent** — exactly like `do_start`'s non-workspace path (`core.py:153`).
+- **Lane registry** — `lanes.py`: `lane_names(session, trunk)` (`:20`), `current_lane(session,
+  trunk)` (`:26`), `require_current_lane` (`:32`). Reused for resolution + guards.
+- **`session.view().working_copy()`** — frozen read exposing `.is_empty`, `.bookmarks`,
+  `.description` (used by `_adoptable_work` `core.py:204`, `do_save` `core.py:224`).
+- **`IntentResult`** + `capture_state(session)` — every `do_*` returns this; `cli._finish_intent`
+  renders it. The post-state drives the `status`-style report (`* <lane> · you are here`).
+- **Postcondition trunk guard:** `_postcondition` (`invariants.py:169`) reverts any op that moves
+  trunk outside `land`/`adopt`. `switch` never touches trunk, so it passes unmodified — **no
+  exemption needed** (unlike adopt). This is a safety feature: if a bad revset somehow moved trunk,
+  switch auto-rolls-back.
+
+---
+
+## Behaviour spec
+
+`gitman switch <lane>`:
+
+1. **Resolve trunk** (`require_trunk`) and the target lane.
+2. **Guard — unknown lane:** if `<lane> ∉ lane_names(session, trunk)` → `GitmanError("no such lane
+   '<lane>'.", exit_code=3)` (mirror `do_abandon` `core.py:426`). Exit 3 = invalid usage.
+3. **Guard — trunk:** if `<lane> == trunk` → `GitmanError("'<trunk>' is the frozen trunk — switch
+   onto a lane, not trunk.", exit_code=3)`. (Trunk is frozen/I1; parking `@` directly on it is not a
+   lane resume.)
+4. **No-op fast path:** if `current_lane(session, trunk) == <lane>` → return `IntentResult(outcome=
+   "NOOP", …)` with message "already on lane '<lane>'." exit 0. Cheap, no tx, no lock churn.
+5. **Guard — don't strand undescribed work:** if the *current* `@` would be orphaned by moving away
+   — i.e. `@` is **non-empty AND carries no lane bookmark** (`wc.is_empty == False and not
+   {b for b in wc.bookmarks if b != trunk}`) — refuse:
+   `GitmanError("uncommitted work on an unnamed change would be stranded — `gitman save -m …` (if
+   it's a lane), `gitman start <name>` (to name it), or `gitman abandon` first.", exit_code=1)`.
+   Exit 1 = VC decision needed. (This mirrors the ISSUE's "don't strand an undescribed draft".)
+   - Note: if `@` *is* on a named lane, switching away is safe — that lane is preserved as a
+     bookmarked change exactly as today's accidental `start` already does. No guard needed.
+6. **Switch (one transaction):**
+   ```python
+   with canonical_tx(session, "switch") as tx:
+       tx.edit(name)          # name resolves as a bookmark revset → @ becomes that lane's change
+   ```
+   A raise inside rolls back (pyjutsu); the postcondition then asserts canonical + trunk-unchanged.
+7. **Report:** `IntentResult(intent="switch", outcome="SWITCHED", lane=name, messages=["switched @
+   onto lane '<name>'."], undo_command="gitman undo", state=capture_state(session))`. The rendered
+   status shows `* <name> · you are here`.
+8. **Errors from jj:** a lane checked out in **another `--workspace`** makes `tx.edit` raise
+   `WorkingCopyError`/`WorkspaceError` → mapped by `map_pyjutsu_error` (`core.py:55`) to exit 2.
+   **Improve the message:** catch and re-raise as `GitmanError("lane '<name>' is checked out in
+   another workspace — `cd` to its workspace dir to resume it.", exit_code=1)` when the lane has an
+   associated workspace (`name in {w.name for w in session.ws.workspaces()}`), so the user gets a
+   front-door hint instead of a raw infra error.
+
+### R3 — `gitman start <existing>` stops dead-ending
+
+Today `do_start` calls `ensure_unique` (`lanes.py:49`), which raises `GitmanError("lane '<name>'
+already exists.", exit_code=3)` on a collision — a dead-end. Change the message **only** (keep the
+raise + exit 3) to point at the new verb:
+
+```
+lane '<name>' already exists — use `gitman switch <name>` to resume it.
+```
+
+Implementation choice (pick one, recommend **A** for least surprise):
+- **A (recommended):** edit the message in `ensure_unique` (`lanes.py:53-54`) to append the hint.
+  One-line change; `start` keeps refusing (no silent/implicit switch), but now signposts `switch`.
+  Keeps `start` purely creational — no hidden mode switch.
+- **B:** in `do_start`, catch the collision and *delegate* to `do_switch`. Rejected for v1:
+  conflates two intents, makes `start`'s outcome non-deterministic, complicates undo semantics.
+
+---
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `src/gitman/core.py` | Add `def do_switch(session, name)` in the "lane lifecycle" block (next to `do_start`, ~`core.py:141`). Composes the spec above via `canonical_tx`. Add a small `_lane_workspaces(session)` helper or inline the workspace-name check for guard 8. |
+| `src/gitman/cli.py` | Register `@app.command()` `def switch(name: Annotated[str, typer.Argument(...)])` next to `start` (~`cli.py:111`); body `_finish_intent(do_switch(_session(), name))`. Docstring: "Move @ onto an existing lane's change to resume it." |
+| `src/gitman/lanes.py` | `ensure_unique` (`:49`): append the `gitman switch` hint to the "already exists" message (R3, option A). |
+| `src/gitman/models.py` | If `IntentResult.outcome` / `intent` are constrained literals, add `"SWITCHED"`/`"switch"` (and `"NOOP"` if not already present — `do_save` already returns `NOOP`, so likely fine). Verify before assuming. |
+| `src/gitman/render.py` | Confirm the generic intent renderer handles a `SWITCHED` outcome (it renders `IntentResult` uniformly with a status block + Undo line — likely no change; verify the outcome→glyph map doesn't whitelist verbs). |
+| `docs/GITMAN_CONCEPT.md` | Add `switch` to the intents table + a one-liner in the lane-loop narration ("`switch` moves `@` between existing lanes; navigation, never mutates trunk"). |
+| `.claude/skills/gitman/SKILL.md` | Add `switch` to the lane loop cheatsheet (between `start` and `save`): "Resume a parked lane: `gitman switch <lane>`." Note the stranded-lane-in-shared-workspace scenario. |
+| `tests/test_switch_integration.py` (new) | Tests below. |
+
+---
+
+## Tests (new `tests/test_switch_integration.py`)
+
+Mirror `tests/test_lifecycle_integration.py` harness: `_init(tmp_path)` builds a colocated `main`
+with one file; `_sess(tmp_path)` returns a fresh `Session` per call (one-session-per-invocation).
+Drive `do_start`/`do_save`/`do_switch`/`do_abandon` directly and assert via `capture_state`.
+
+1. **`test_switch_resumes_stranded_lane`** (the ISSUE's headline case): `do_start("lane-a")`,
+   `do_save("a work")`; `do_start("lane-b")` (strands `lane-a`, `@` now on `lane-b`); assert
+   `current_lane == "lane-b"`. Then `do_switch("lane-a")`; assert `current_lane == "lane-a"` and
+   `capture_state(...).canonical is True`. Assert `lane-b` still exists (not lost).
+2. **`test_switch_noop_when_already_current`**: on `lane-a`, `do_switch("lane-a")` → `outcome ==
+   "NOOP"`, `@` unmoved, canonical.
+3. **`test_switch_unknown_lane_errors`**: `do_switch("nope")` raises `GitmanError` with exit_code 3.
+4. **`test_switch_onto_trunk_refused`**: `do_switch("main")` raises `GitmanError` exit_code 3.
+5. **`test_switch_refuses_to_strand_unnamed_dirty_work`**: get `@` onto a non-empty unbookmarked
+   change (e.g. land/abandon to leave `@` on a bare trunk child, then edit a file so it's
+   non-empty), `do_switch("lane-a")` raises `GitmanError` exit_code 1 mentioning `save`/`start`/
+   `abandon`. (Construct the precondition the way `_adoptable_work` detects it.)
+6. **`test_switch_undo_round_trips`**: record `current_lane`, `do_switch` to another lane,
+   `do_undo(...)`, assert `@` is back and canonical (switch is one intent → one undo).
+7. **`test_start_existing_hints_switch`** (R3): `do_start("lane-a")` twice; second raises
+   `GitmanError` exit 3 whose message contains `gitman switch`.
+8. *(optional, if workspace harness is cheap)* **`test_switch_into_workspaced_lane_reports_cleanly`**:
+   `do_start("lane-w", workspace=True)`, then from the default workspace `do_switch("lane-w")`
+   raises `GitmanError` exit 1 mentioning "another workspace" rather than a raw `WorkingCopyError`.
+
+Run after each slice: `devenv shell -- bash -c '"$DEVENV_STATE/venv/bin/ruff" check src tests &&
+"$DEVENV_STATE/venv/bin/pytest" -q'` (the `gitman:lint`/`gitman:test` devenv-task names aren't on
+PATH — invoke the venv binaries directly, per CLAUDE.md).
+
+---
+
+## Build order (each slice green before the next)
+
+1. **Slice 1 — core happy path:** `do_switch` (resolve + unknown/trunk guard + no-op + `canonical_tx`
+   `tx.edit` + report) and the `switch` CLI command. Tests 1–4. This is the value; smallest change.
+2. **Slice 2 — strand guard:** add guard 5 (refuse to orphan unnamed dirty work). Test 5.
+3. **Slice 3 — undo + R3:** confirm undo round-trip (test 6); update `ensure_unique` message (R3),
+   test 7.
+4. **Slice 4 — workspace edge + docs:** workspace-checked-out detection/message (guard 8, test 8);
+   update `GITMAN_CONCEPT.md` + `SKILL.md`.
+
+Keep it on a lane (`resume-existing-lane`, already current). `gitman save` at each green slice.
+**Don't publish/land/push without an explicit ask** (CLAUDE.md).
+
+---
+
+## Acceptance criteria (from ISSUE, mapped)
+
+- [ ] `gitman switch <lane>` moves `@` onto an existing lane; `status` then shows it `· you are
+      here` and stays **CANONICAL** before/after. *(Slice 1; tests 1–2)*
+- [ ] Runs entirely through one pyjutsu transaction (`tx.edit`) — **no raw `jj`/`git`**, **no
+      Pyjutsu changes** (`edit` already bound). *(Slice 1)*
+- [ ] `gitman undo` reverts the switch as a single intent. *(Slice 3; test 6)*
+- [ ] Clear errors for: unknown lane, `<lane> == trunk`, dirty/unbookmarked `@` that would be
+      stranded, and a lane checked out in another workspace. *(Slices 1/2/4; tests 3,4,5,8)*
+- [ ] `gitman start <existing>` no longer dead-ends — points at `switch` (R3). *(Slice 3; test 7)*
+- [ ] Docs + `SKILL.md` list `switch` in the lane loop; a test covers the stranded-lane case.
+      *(Slice 4; test 1)*
+
+## Risks / open questions
+
+- **`tx.edit` revset resolution:** confirm `edit(name)` resolves a *bookmark name* (not just a
+  commit id). `do_abandon` already passes bookmark names to `tx.abandon`-adjacent revsets, and
+  `tx.rebase(lane, …)` in `do_sync` (`core.py:492`) takes a bare lane name — strong signal that a
+  bookmark name is a valid revset arg. Verify in slice 1; if it needs an explicit revset, pass the
+  bookmark string as-is (jj resolves a bookmark name as a revset).
+- **Naming:** `switch` (recommended, git-familiar) vs `resume`/`goto`. ISSUE recommends `switch`.
+- **Outcome literal plumbing:** check whether `models.IntentResult` / `render.py` constrain the
+  `outcome` set; if so add `SWITCHED`. Trivial but don't skip (would raise a validation error).
+- **Multi-change lane:** `tx.edit(<lane>)` lands `@` on the lane's **bookmarked head** commit, which
+  is correct for a linear lane (I5). No special handling needed; the lane stays linear.
+
+## Implementation note (as built) — guard 8 deviates from §8
+
+§8 assumed `tx.edit(<lane>)` would **raise** (`WorkingCopyError`/`WorkspaceError`) when the lane is
+checked out in another `--workspace`, to be caught and re-messaged. **A probe showed it does not**:
+jj-lib's `edit` silently moves `@` onto a commit already checked out elsewhere, creating a
+**divergent dual-`@`** (two workspaces on one commit) with no error. So guard 8 is implemented as a
+**deterministic pre-check** instead of a catch: refuse when `name ∈ {w.name for w in
+session.ws.workspaces()} − {session.ws.name}` (the lane owns *another* workspace), exit 1 with the
+`cd`-there hint. `session.ws.name` (a str property, not a method) gives the current workspace name,
+so switching *within* a lane's own workspace is still allowed. No try/except around `tx.edit`
+remains. The other three guards (unknown/trunk/strand) and R3 match §-spec exactly.

--- a/docs/GITMAN_CONCEPT.md
+++ b/docs/GITMAN_CONCEPT.md
@@ -121,7 +121,9 @@ start ──▶ draft ──(edit · save · sync · resolve)──▶ published
 
 A lane is always in exactly one of three states — **draft** (being edited), **published**
 (pushed / PR open), **landed/abandoned** (terminal). That bounds everything `status` must
-render.
+render. When `@` leaves a lane without ending it (a sibling `start` in the same workspace, a
+landed neighbour), **`switch <lane>`** moves `@` back onto an existing lane to resume it —
+navigation *between* lanes, never a trunk mutation.
 
 ## 6. Architecture
 
@@ -168,13 +170,14 @@ Base deps kept lean: `pydantic`, `typer`. `jj` and `git` binaries come from deve
 
 ## 7. Intent vocabulary — v1
 
-Twelve intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
+Thirteen intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
 model requires; everything else is deferred until friction proves it.
 
 | Intent | Signature | What it does | Underneath |
 |---|---|---|---|
 | `status` | `gitman status [--json]` | Canonical/off-canonical report: trunk + all lanes. | `jj log`/`op log`/`workspace list` (+git numstat) |
 | `start` | `gitman start <name> [--workspace]` | Create a lane (new change on trunk + bookmark `<name>`); `--workspace` isolates it. | `jj new <trunk>` + `jj bookmark create` (+ `jj workspace add`) |
+| `switch` | `gitman switch <lane>` | Move `@` onto an existing lane's change to resume it (navigation, never mutates trunk). Refuses to strand an unnamed dirty `@`; reports a lane checked out in another workspace. | `jj edit <lane>` |
 | `save` | `gitman save [-m <desc>]` | Describe the current lane's change. | `jj describe` |
 | `sync` | `gitman sync [--all]` | Fetch trunk + rebase the current lane (or `--all` lanes) onto it. | `jj git fetch` + `jj rebase` |
 | `publish` | `gitman publish` | Push the current lane; branch = lane name. Verify hook first. | `jj git push` (forge extra: + open/update PR) |

--- a/src/gitman/cli.py
+++ b/src/gitman/cli.py
@@ -120,6 +120,16 @@ def start(
 
 
 @app.command()
+def switch(
+    name: Annotated[str, typer.Argument(help="The existing lane to resume.")],
+) -> None:
+    """Move @ onto an existing lane's change to resume it."""
+    from gitman.core import do_switch
+
+    _finish_intent(do_switch(_session(), name))
+
+
+@app.command()
 def save(
     message: Annotated[str | None, typer.Option("-m", "--message", help="Describe the current change.")] = None,
 ) -> None:

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -211,6 +211,66 @@ def _adoptable_work(session: Session, trunk: str) -> bool:
     return bool(session.view().log(f"@ & ({trunk}..)"))
 
 
+def do_switch(session: Session, name: str):
+    """Move `@` onto an existing lane's change so a stranded/parked lane can be resumed.
+
+    The only lane-*navigation* verb: `start` creates, `land`/`abandon` end, `sync` rebases — but
+    once `@` leaves a lane (a sibling `start` in the same workspace, a landed neighbour) nothing
+    moves it back. One `tx.edit(<lane>)` does that; the rest is guard rails. Navigation only —
+    never touches trunk, so the canonical_tx trunk guard passes unmodified (no exemption).
+    """
+    from gitman.invariants import canonical_tx
+    from gitman.lanes import current_lane, lane_names
+    from gitman.models import IntentResult
+    from gitman.state import capture_state
+
+    trunk = require_trunk(session.config)
+    if name == trunk:
+        raise GitmanError(
+            f"'{trunk}' is the frozen trunk — switch onto a lane, not trunk.", exit_code=3
+        )
+    if name not in lane_names(session, trunk):
+        raise GitmanError(f"no such lane '{name}'.", exit_code=3)
+    cur = current_lane(session, trunk)
+    if cur == name:
+        return IntentResult(
+            intent="switch",
+            outcome="NOOP",
+            lane=name,
+            messages=[f"already on lane '{name}'."],
+        )
+    # Refuse to orphan an undescribed draft: if `@` carries no lane bookmark yet has on-disk work,
+    # switching away would strand it nowhere-named. Named lanes are safe (preserved as today's
+    # accidental `start` already does). (verb: save/start/abandon)
+    if cur is None and not session.view().working_copy().is_empty:
+        raise GitmanError(
+            "uncommitted work on an unnamed change would be stranded — "
+            "`gitman save -m …` (if it's a lane), `gitman start <name>` (to name it), "
+            "or `gitman abandon` first.",
+            exit_code=1,
+        )
+    # A lane with its own `--workspace` is checked out *there*. jj-lib's `edit` won't refuse a
+    # second checkout (it'd silently create a divergent dual-`@`), so detect it up front: refuse
+    # unless we *are* that workspace, and point at the `cd`-there front door instead of exit 2.
+    other_workspaces = {w.name for w in session.ws.workspaces()} - {session.ws.name}
+    if name in other_workspaces:
+        raise GitmanError(
+            f"lane '{name}' is checked out in another workspace — "
+            f"`cd` to its workspace dir to resume it.",
+            exit_code=1,
+        )
+    with canonical_tx(session, "switch") as tx:
+        tx.edit(name)  # bookmark name resolves as a revset → @ becomes that lane's change
+    return IntentResult(
+        intent="switch",
+        outcome="SWITCHED",
+        lane=name,
+        messages=[f"switched @ onto lane '{name}'."],
+        undo_command="gitman undo",
+        state=capture_state(session),
+    )
+
+
 def do_save(session: Session, message: str | None):
     from gitman.invariants import canonical_tx
     from gitman.lanes import require_current_lane

--- a/src/gitman/lanes.py
+++ b/src/gitman/lanes.py
@@ -51,4 +51,7 @@ def ensure_unique(session: Session, trunk: str, name: str) -> None:
     if name == trunk:
         raise GitmanError(f"lane name '{name}' collides with trunk.", exit_code=3)
     if name in lane_names(session, trunk) | {trunk}:
-        raise GitmanError(f"lane '{name}' already exists.", exit_code=3)
+        raise GitmanError(
+            f"lane '{name}' already exists — use `gitman switch {name}` to resume it.",
+            exit_code=3,
+        )

--- a/tests/test_switch_integration.py
+++ b/tests/test_switch_integration.py
@@ -1,0 +1,178 @@
+"""Live integration tests for `gitman switch <lane>` — the lane-navigation verb (round 10).
+
+Build real colocated jj repos **through pyjutsu** (in-process, no `jj` CLI) and drive `do_switch`
+over a `Session`, mirroring `tests/test_lifecycle_integration.py`. Covers the stranded-lane resume
+(the motivating ISSUE), every guard (unknown lane / trunk / strand / cross-workspace), the NOOP
+fast path, the undo round-trip, and the R3 `start <existing>` hint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import (
+    GitmanError,
+    do_land,
+    do_save,
+    do_start,
+    do_switch,
+    do_undo,
+)
+from gitman.lanes import current_lane
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _init(d: Path) -> Workspace:
+    """trunk `main` with one committed file `f.txt`."""
+    ws = Workspace.init(d, colocate=True)
+    (d / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:  # auto-snapshot folds f.txt into @
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    return ws
+
+
+def _sess(d: Path) -> Session:
+    """A fresh Session per call — mirrors one-session-per-CLI-invocation."""
+    return Session.load(d, CFG)
+
+
+def _cur(d: Path) -> str | None:
+    return current_lane(_sess(d), "main")
+
+
+# --- the headline case + happy path (slice 1) ----------------------------------------
+
+
+def test_switch_resumes_stranded_lane(tmp_path: Path):
+    """ISSUE headline: a sibling `start` strands lane-a; `switch` puts `@` back on it."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    (tmp_path / "f.txt").write_text("base\na\n")
+    do_save(_sess(tmp_path), "a work")
+    do_start(_sess(tmp_path), "lane-b", workspace=False)  # strands lane-a; @ now on lane-b
+    assert _cur(tmp_path) == "lane-b"
+
+    res = do_switch(_sess(tmp_path), "lane-a")
+    assert res.outcome == "SWITCHED"
+    assert res.undo_command == "gitman undo"
+    after = capture_state(_sess(tmp_path))
+    assert after.current_lane == "lane-a"
+    assert after.canonical
+    # lane-b is preserved (not lost) — both lanes still exist.
+    assert {lane.name for lane in after.lanes} == {"lane-a", "lane-b"}
+
+
+def test_switch_noop_when_already_current(tmp_path: Path):
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    res = do_switch(_sess(tmp_path), "lane-a")
+    assert res.outcome == "NOOP"
+    assert _cur(tmp_path) == "lane-a"
+    assert capture_state(_sess(tmp_path)).canonical
+
+
+def test_switch_unknown_lane_errors(tmp_path: Path):
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    with pytest.raises(GitmanError) as exc:
+        do_switch(_sess(tmp_path), "nope")
+    assert exc.value.exit_code == 3
+
+
+def test_switch_onto_trunk_refused(tmp_path: Path):
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    with pytest.raises(GitmanError) as exc:
+        do_switch(_sess(tmp_path), "main")
+    assert exc.value.exit_code == 3
+    assert "trunk" in str(exc.value)
+
+
+# --- strand guard (slice 2) ----------------------------------------------------------
+
+
+def test_switch_refuses_to_strand_unnamed_dirty_work(tmp_path: Path):
+    """An unnamed, non-empty `@` would be orphaned by switching away — refuse with a hint."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    (tmp_path / "f.txt").write_text("base\na\n")
+    do_save(_sess(tmp_path), "a work")
+    do_start(_sess(tmp_path), "lane-b", workspace=False)
+    (tmp_path / "f.txt").write_text("base\nb\n")
+    do_save(_sess(tmp_path), "b work")
+    # Land lane-b → @ becomes a fresh empty, unbookmarked child of the advanced trunk.
+    do_land(_sess(tmp_path), ["lane-b"])
+    assert _cur(tmp_path) is None
+    # Make that unnamed @ non-empty: now switching away would strand it.
+    (tmp_path / "g.txt").write_text("loose\n")
+
+    with pytest.raises(GitmanError) as exc:
+        do_switch(_sess(tmp_path), "lane-a")
+    assert exc.value.exit_code == 1
+    msg = str(exc.value)
+    assert "save" in msg and "start" in msg and "abandon" in msg
+
+
+# --- undo round-trip + R3 hint (slice 3) ---------------------------------------------
+
+
+def test_switch_undo_round_trips(tmp_path: Path):
+    """A switch is one intent → one `gitman undo` puts `@` back on the prior lane."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    (tmp_path / "f.txt").write_text("base\na\n")
+    do_save(_sess(tmp_path), "a work")
+    do_start(_sess(tmp_path), "lane-b", workspace=False)  # @ now on lane-b
+    assert _cur(tmp_path) == "lane-b"
+
+    do_switch(_sess(tmp_path), "lane-a")
+    assert _cur(tmp_path) == "lane-a"
+
+    do_undo(_sess(tmp_path), op=None, list_=False)
+    restored = capture_state(_sess(tmp_path))
+    assert restored.current_lane == "lane-b"
+    assert restored.canonical
+
+
+def test_start_existing_hints_switch(tmp_path: Path):
+    """R3: `start <existing>` no longer dead-ends — it points at `gitman switch`."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)
+    with pytest.raises(GitmanError) as exc:
+        do_start(_sess(tmp_path), "lane-a", workspace=False)
+    assert exc.value.exit_code == 3
+    assert "gitman switch" in str(exc.value)
+
+
+# --- cross-workspace edge (slice 4) --------------------------------------------------
+
+
+def test_switch_into_workspaced_lane_reports_cleanly(tmp_path: Path):
+    """A lane checked out in its own `--workspace` can't be re-checked-out from the default
+    workspace; report exit 1 with a `cd`-there hint, not a raw WorkingCopyError (exit 2)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Nested repo so the workspace dir (sibling of repo) is predictable, mirroring the
+    # lifecycle test's workspace harness.
+    ws = Workspace.init(repo, colocate=True)
+    (repo / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+        tx.new(["main"])  # leave @ on a fresh empty child of trunk, as `gitman init` does
+
+    do_start(_sess(repo), "lane-w", workspace=True)  # lane-w lives in its own workspace
+    assert _cur(repo) is None  # default workspace's @ is not on lane-w
+
+    with pytest.raises(GitmanError) as exc:
+        do_switch(_sess(repo), "lane-w")
+    assert exc.value.exit_code == 1
+    assert "another workspace" in str(exc.value)


### PR DESCRIPTION
Adds **`gitman switch <lane>`** — the only missing lane-navigation verb. Once `@` leaves a lane (a sibling `start` in the same workspace, a landed neighbour) nothing moved it back; `switch` closes that gap with one `tx.edit(<lane>)` transaction (no new pyjutsu bindings, no raw jj/git).

Implements `.scratch/projects/10-resume-existing-lane/` (ISSUE + PLAN).

## What's in it
- **`core.do_switch`** — resolve trunk → guards → `canonical_tx` doing `tx.edit(<lane>)` → `status`-style report + `Undo:` line. Navigation only; never touches trunk, so the postcondition trunk guard passes unmodified.
- **`cli.py`** — `gitman switch <name>`.
- **R3** — `lanes.ensure_unique`'s "already exists" message now points at `gitman switch <name>` instead of dead-ending.
- **Docs** — `GITMAN_CONCEPT.md` intents table + lane-lifecycle narration; `.claude/skills/gitman/SKILL.md` lane-loop cheatsheet.

## Guards
unknown lane (exit 3) · `== trunk` (exit 3) · already-current NOOP (exit 0) · would-strand-an-unnamed-dirty-`@` (exit 1) · lane checked out in another `--workspace` (exit 1).

## Deviation from PLAN §8 (documented in PLAN.md + memory)
PLAN assumed `tx.edit` *raises* for a lane checked out in another workspace. A probe showed jj-lib instead **silently creates a divergent dual-`@`** (no exception), so the cross-workspace guard is a deterministic **pre-check** (`name ∈ workspaces() − {ws.name}`) rather than a try/except.

## Tests
New `tests/test_switch_integration.py` — 8 tests: stranded-lane resume (the ISSUE headline), every guard, undo round-trip, R3 hint. **Full suite: 91 passed** (was 83). `gitman doctor` HEALTHY.