### PR TITLE
round-08: gitman split — carve one lane's change into two sibling lanes (+ Fix-2 forge-loop doc)

### DIFF
--- a/.claude/skills/gitman/SKILL.md
+++ b/.claude/skills/gitman/SKILL.md
@@ -15,6 +15,7 @@ A **lane** is one unit of work: a named bookmark (= git branch) on trunk, kept l
 ```
 gitman start <name>         # begin a lane (add --workspace to isolate it in its own dir)
 gitman switch <lane>         # resume a parked lane: move @ back onto an existing lane's change
+gitman split --paths <sel> --into <lane>   # carve entangled paths into a second sibling lane
 # ...edit files...
 gitman save -m "<message>"  # describe the current change
 gitman status               # see trunk + all lanes (canonical or off-canonical)
@@ -34,6 +35,15 @@ to strand an unnamed dirty `@` (save/start/abandon it first), and reports cleanl
 checked out in another `--workspace` (`cd` there to resume). `gitman start <existing>` now points
 here instead of dead-ending.
 
+`split` is the lane-**partition** verb: when two concerns entangle in one draft change,
+`gitman split --paths <sel>… --into <new-lane> [-m <desc>]` carves the selected paths onto a new
+sibling lane on trunk and leaves the remainder on the original — both independently
+landable/publishable. `@` stays on the **remainder** (original) lane; continue on the carved one
+with `gitman switch <new-lane>`. `--paths` selects **whole files** (exact path, a `dir/` prefix, or
+a glob like `'src/**'` — repeat `--paths` for several); hunk-level/partial-file split is deferred.
+It refuses (exit 3) a multi-change or non-trunk-rooted lane, a selector matching nothing, or one
+covering the whole change. One `gitman undo` reverts the whole split.
+
 ## Forge PRs: `publish → PR → merge → adopt`
 
 When you review/merge on the **forge** instead of landing locally — `gitman publish`, open a PR,
@@ -41,13 +51,25 @@ click **Merge** (squash / merge-commit / rebase all re-hash to a new SHA on `ori
 the local trunk falls behind. Pull it forward with **one command**:
 
 ```
-gh pr merge --squash --delete-branch    # (or via the web UI)
+gh pr merge --squash        # (or via the web UI); do NOT pass --delete-branch
 gitman adopt                # advance local trunk to origin/<trunk>, retire merged lanes,
                             #   rebase un-merged survivors; stays canonical, undoable
+# OPTIONAL cleanup, only AFTER adopt (the local lane is already retired → no tracking conflict):
+gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<lane>   # or delete in the web UI
 gitman adopt --dry-run      # preview the plan without mutating
 gitman adopt --force        # only if trunk diverged (un-pushed local lands + origin moved):
                             #   hard-set trunk to origin, dropping the un-pushed lands (undoable)
 ```
+
+**Order matters — delete the lane's remote branch *after* `adopt`, not before.** Deleting it first
+(e.g. `gh pr merge --delete-branch`) drops the remote branch of a still-tracked **local** lane,
+which leaves the local bookmark **conflicted** (`<lane>@origin` tracked-but-empty vs a live local
+target) instead of pruned — and both `gitman adopt` and `gitman reconcile` then raise
+`RevsetError: Name '<lane>' is conflicted` with no front door. `adopt` retires merged lanes by
+**content**, so let it run first; the remote-branch delete is optional cleanup afterward.
+*(Deferred hardening, not built yet: teaching `adopt`/`reconcile` to treat a conflicted **lane**
+bookmark the way they already treat a conflicted **trunk** — retire-by-content if its tip is in
+trunk, else surface cleanly.)*
 
 `adopt` retires forge-merged lanes by **content** (works across squash/merge/rebase), so you
 never run the old raw-git reconcile dance (`rm -rf .jj` / `git reset --hard` — **deprecated**;
@@ -65,12 +87,15 @@ In a colocated jj repo git's `HEAD` is detached (parked at `@`'s parent), so som
 porcelain that assumes a checked-out branch misbehaves — **the forge action still succeeds**:
 
 - `gh pr merge … --delete-branch` prints `could not determine current branch: not on any branch`.
-  **The merge itself succeeds**; only the *local* branch-delete step fails. Delete the merged
-  **remote** branch explicitly instead:
+  **The merge itself succeeds**; only the *local* branch-delete step fails. Don't reach for the
+  remote-branch delete to compensate: run `gitman adopt` first (it retires the local lane by
+  content), then — **optionally, afterward** — delete the merged **remote** branch:
   ```
-  gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<lane>
+  gitman adopt                                                  # retires the local lane first
+  gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<lane>   # optional, AFTER adopt (or web UI)
   ```
-  (or just merge in the web UI). Then `gitman adopt` retires the local lane.
+  Deleting the remote branch *before* `adopt` leaves a conflicted local bookmark that wedges both
+  `adopt` and `reconcile` (see the order note above).
 
 ### Pushing trunk to `origin`
 

--- a/.scratch/projects/08-split-lane-capability/KICKOFF.md
+++ b/.scratch/projects/08-split-lane-capability/KICKOFF.md
@@ -1,0 +1,133 @@
+# KICKOFF — Round 08: `gitman split` (carve entangled work into two lanes) + forge-loop doc fix
+
+> Paste everything below the line into a fresh gitman session to start this round.
+> Builds the last missing **core** lane operation, and rolls in a small forge-loop doc correction
+> surfaced while landing round 10. Authority docs already exist — this round is implementation +
+> tests, not design. Follows round-10 (`gitman switch`, landed via PR #25, trunk @ `ab334b85`).
+
+---
+
+You're implementing **`gitman split --paths <globs> --into <lane>`** — a first-class intent that
+partitions the **current lane's single change** into **two sibling lanes on trunk**: the carved
+paths onto a new lane, the remainder left on the original. Today two concerns that entangle in one
+working-copy change can only be `save`d bundled together; raw `jj` is both forbidden *and*
+unavailable (no CLI — jj is embedded via pyjutsu). This closes that gap. It is the partition-sibling
+of round 10's `switch` (navigate between lanes): **`split` + `switch` together close the
+multiple-efforts-in-one-workspace story.**
+
+You're also rolling in **Fix-2**: a doc correction to the SKILL's `publish → merge → adopt` recipe
+(see §What to build).
+
+The design is **done and grounded** — read it, don't re-derive it:
+
+**Read first (authority + the plan you're executing):**
+1. `.scratch/projects/08-split-lane-capability/PLAN.md` — **the spec you implement**: the sibling-
+   lane split algorithm (`tx.new` + `tx.restore`×2 + bookmarks), guards, the 8 tests, the 4-slice
+   build order, AND the bundled Fix-2 forge-loop doc correction. Follow it.
+2. `.scratch/projects/08-split-lane-capability/ISSUE.md` — the motivating scenario (entangled 004
+   curator + 005 config-spine work in one change) + acceptance criteria. **Note:** the PLAN
+   *supersedes* the ISSUE's "linear `C_a ← C_b`" sketch with **two sibling lanes** (cleaner for
+   gitman's lane model + independently landable) — implement the PLAN's version.
+3. `src/gitman/core.py` — `do_switch` (~`:222`, the round-10 template: resolve → guards →
+   `canonical_tx` → report) and `do_start`/`_adoptable_work` (~`:141/204`, lane-creation + working-
+   copy reads). `do_abandon` (~`:417`) and `do_sync` (~`:490`) show the `log("{trunk}..{lane}")`
+   pattern for resolving a lane's changes.
+4. `src/gitman/invariants.py` — `canonical_tx` (~`:238`, the single-transaction sugar `split` uses)
+   and `_postcondition` (~`:169`, the trunk guard `split` passes unmodified — split never moves
+   trunk, so **no exemption** needed).
+5. `src/gitman/lanes.py` — `lane_names`, `current_lane`, `require_current_lane`, `ensure_unique`
+   (the latter already carries round-10's "… use `gitman switch`" R3 hint; `--into` reuses it).
+6. `Pyjutsu/python/pyjutsu/_pyjutsu.pyi:116` — `PyTransaction.restore(commit, from_, paths)`, the
+   **unused** binding that is the whole split engine. **No pyjutsu changes are needed** for the
+   path-scoped MVP. (`tx.new`/`tx.rebase`/bookmarks are already used across `core.py`.)
+7. `tests/test_switch_integration.py` + `tests/test_lifecycle_integration.py` — the harness to
+   mirror (`_init`/`_sess`, drive `do_*` directly, assert via `capture_state`).
+
+**Current state (don't re-derive):** `main` is CANONICAL, trunk @ `ab334b85` (round-10 `gitman
+switch` landed via PR #25). `gitman doctor` HEALTHY (incl. `colocated-refs ok`). **91 tests pass.**
+You start on lane **`split-lane-capability`**, which already carries this project's
+`ISSUE.md`/`PLAN.md`/`KICKOFF.md` as one saved draft change — **continue on it** (don't `start` a new
+lane; round 10 added `gitman switch` precisely so a stranded lane can be resumed, but here just stay
+put).
+
+---
+
+## What to build (summary — PLAN.md is the full spec)
+
+**1. `gitman split --paths <globs> --into <lane> [-m <msg>]`:** resolve the current lane `L` + its
+single change `C` (parent = trunk) → precondition/empty-partition guards → one `canonical_tx`:
+`tx.new([trunk])` → `tx.restore(A, from_=C, paths=carved)` (carved lane) → `tx.create_bookmark(into,
+A)` (+ `describe`) → `tx.restore(C, from_=trunk, paths=carved)` (remainder, original lane keeps its
+bookmark + description). Two **sibling** lanes on trunk. `@` **stays on the remainder/original
+lane**; the report points at **`gitman switch <into>`** to continue on the carved lane (composes
+round 10). Guards: lane not single-change-on-trunk (exit 3), `--paths` matches nothing / everything
+(exit 3), `--into` already exists (exit 3, round-10 hint). Atomic → one `gitman undo`; CANONICAL
+before/after.
+
+**2. Fix-2 (forge-loop doc correction, PLAN §Fix-2):** in `.claude/skills/gitman/SKILL.md` (and any
+doc repeating the recipe — `grep -rn 'delete-branch\|refs/heads' docs .claude`), move the lane's
+remote-branch delete to **after** `gitman adopt` and mark it optional. WHY: deleting the remote
+branch of a still-tracked local lane **before** adopt leaves a *conflicted* local bookmark that
+wedges both `adopt` and `reconcile` (`RevsetError: … is conflicted`); `adopt` already retires merged
+lanes **by content**, so let it run first. (Leave a one-line pointer that hardening
+`adopt`/`reconcile` against a conflicted *lane* bookmark is a deferred future item — **don't build
+it here.**)
+
+## Build order (each slice lint+test green before the next — see PLAN.md §Build order)
+1. **Slice 1** — `do_split` happy path + CLI command. Tests 1–3. *First, probe the one real unknown:*
+   within a single jj transaction, does a later op see `C` as the original or rewritten tree? Build
+   `A` from `C` **before** rewriting `C`, reference fixed commit-ids (never the bookmark name) for
+   `restore`'s `from_`/`commit`, and confirm `@` follows `C`'s rewrite to the remainder.
+2. **Slice 2** — precondition + empty-partition + `--into`-exists guards. Tests 5–7.
+3. **Slice 3** — undo round-trip (test 4) + `split`→`switch` compose (test 8) + docs
+   (`GITMAN_CONCEPT.md` intents table/lane-loop; `SKILL.md` `split` cheatsheet line).
+4. **Slice 4** — Fix-2 forge-loop doc correction (no code; keep `doctor` HEALTHY).
+
+Verify each slice inside devenv (the `gitman:lint`/`gitman:test` task names aren't on PATH):
+```
+devenv shell -- bash -c '"$DEVENV_STATE/venv/bin/ruff" check src tests && "$DEVENV_STATE/venv/bin/pytest" -q'
+```
+
+## First moves (before writing code)
+- Confirm the cheap unknowns flagged in PLAN.md §Risks: (a) the **in-tx `restore` ordering / `@`-
+  follow** behaviour (build a 2-file probe repo, do the two restores in one tx, assert the partition
+  + `@` lands on the remainder); (b) **`--paths` matching semantics** — jj fileset vs glob (pass a
+  prefix like `a/` and a `a/**` glob, see which the engine honours) and document precisely;
+  (c) **empty-partition detection** — `A.is_empty` post-restore vs a pre-computed changed-path set
+  (`view.diff`/`diff_stat`), pick the cheaper.
+- `outcome`/`intent` on `IntentResult` are plain `str` and `render_intent` is generic (verified in
+  round 10) — no `models.py`/`render.py` changes needed for a `SPLIT` outcome.
+
+## Project rules (non-negotiable)
+- Everything inside devenv (`devenv shell -- bash -c '...'`; batch commands — each launch
+  re-evaluates the env). The venv tools live at `$DEVENV_STATE/venv/bin`.
+- Dogfood VC through `gitman` — never raw `jj`/`git`. jj is embedded via pyjutsu (`../Pyjutsu`); no
+  `jj` CLI, no `-T` templates. Reads via `Session.view()`/`fresh_view()`; mutations via
+  `ws.transaction(...)`. **Stay on lane `split-lane-capability`; `gitman save` at each green slice.**
+- **Don't publish/land/push without an explicit ask.** No AI-authorship trailers in commits/PRs/docs.
+- **Heads-up when you DO land (ask first):** round 10 hit a wedge landing via the forge loop — after
+  `gh pr merge`, run **`gitman adopt` BEFORE** deleting the lane's remote branch (this is literally
+  what Fix-2 corrects). Don't `gh api DELETE` the branch pre-adopt.
+
+## Definition of done
+- [ ] `gitman split --paths <globs> --into <lane>` turns one lane's single change into two sibling
+      lanes (path-set partitioned exactly); `status` CANONICAL before/after; runs through `tx.new` +
+      `tx.restore` only (no raw jj/git, no pyjutsu changes).
+- [ ] `@` stays on the remainder lane; the report suggests `gitman switch <into>`.
+- [ ] `gitman undo` reverts a split as one intent.
+- [ ] Clear errors for: multi-change / non-trunk-rooted lane, empty match, whole-change match,
+      existing `--into`.
+- [ ] `GITMAN_CONCEPT.md` intents table + `SKILL.md` lane loop list `split`; new
+      `tests/test_split_integration.py` covers the entangled-change case + all guards (8 tests).
+- [ ] **Fix-2 applied:** the forge-loop recipe no longer deletes a lane's remote branch before
+      `adopt` (SKILL.md + any docs repeating it); a one-line pointer notes the deferred
+      adopt/reconcile hardening.
+- [ ] `gitman doctor` HEALTHY; full suite green; each slice green before the next.
+- [ ] All ISSUE.md acceptance criteria met (see PLAN.md §Acceptance criteria for the mapping; note
+      the sibling-lane supersede).
+
+## After this round
+With `start`/`switch`/`split`/`save`/`sync`/`publish`/`land`/`abandon`/`adopt` all present, the core
+lane vocabulary is complete. Remaining backlog: **S3 hunk-level/interactive split** (needs a native
+pyjutsu `split` binding — separate issue), and the deferred **adopt/reconcile conflicted-lane
+hardening** (fix #1 from the round-10 finding, if the doc-only Fix-2 proves insufficient).

--- a/.scratch/projects/08-split-lane-capability/PLAN.md
+++ b/.scratch/projects/08-split-lane-capability/PLAN.md
@@ -1,0 +1,235 @@
+# PLAN — 08: `gitman split` (carve entangled work into two lanes) + forge-loop doc fix
+
+> Implementation plan for [ISSUE.md](./ISSUE.md). Grounded in the gitman 0.2.x codebase as it
+> stands on `main` after **round 10** landed (`gitman switch`, PR #25, trunk @ `ab334b85`).
+> Sibling effort already shipped: [10-resume-existing-lane](../10-resume-existing-lane/) —
+> `split` (divide a lane) + `switch` (navigate between lanes) together close the
+> multiple-efforts-in-one-workspace story.
+>
+> This plan bundles **two** deliverables:
+> 1. **`gitman split`** — the path-scoped MVP (the 08 ISSUE; S1+S2, defer S3).
+> 2. **Forge-loop doc fix** — correct the SKILL's `publish → merge → adopt` recipe so it no
+>    longer manufactures a conflicted-bookmark wedge (a round-10 dogfooding finding; see §Fix-2).
+
+## Goal (one sentence)
+
+Add a first-class **`gitman split --paths <globs> --into <lane>`** that partitions the current
+lane's single change into **two sibling lanes on trunk** — the carved paths on a new lane, the
+remainder on the original — composing the already-exposed `tx.new` + `tx.restore` + bookmark
+primitives, with **no new pyjutsu bindings** and no raw `jj`/`git`.
+
+---
+
+## Why now / scope guard
+
+`split` is the last missing *core* lane operation: `start` opens, `switch` navigates (round 10),
+`save` describes, `land`/`abandon` end, `sync` rebases — but nothing **divides** a change once two
+concerns entangle in it (the ISSUE's flora scenario: 004 curator + 005 config spine piled into one
+draft). The cure is one transaction that re-partitions a single change by path-set.
+
+**In scope (MVP, S1+S2):** path-scoped, non-interactive split of a lane that has **exactly one
+change rooted on trunk**, into two **sibling** lanes (each independently landable/publishable).
+
+**Out of scope (defer):**
+- **S3 hunk-level / interactive split** (partial-file selection) — the only variant needing new
+  pyjutsu surface. File a follow-up if pursued.
+- Splitting a **multi-change** lane, or a lane **not** rooted directly on trunk (would need
+  descendant rebasing). MVP refuses these with a clear message.
+- Re-stacking / `--revset` selectors. `--paths` globs only for v1.
+
+---
+
+## Design decisions (resolving the ISSUE's open questions)
+
+- **Two SIBLING lanes, not a linear stack.** The ISSUE sketched a linear `C_a ← C_b`, but gitman's
+  lane model is *siblings off trunk* (I2: every change in exactly one named lane; lanes are trunk
+  children — cf. round-10 tests with `lane-a`/`lane-b` as siblings). Sibling lanes are **independently
+  landable/publishable**, which is exactly what the scenario wanted (land 005 without 004). So
+  `split` produces: `trunk ← A` (carved paths, new `--into` lane) and `trunk ← B` (remainder,
+  original lane), both children of trunk. **Recommended; supersedes the ISSUE's linear sketch.**
+- **`@` stays on the ORIGINAL (remainder) lane**, and the report points at
+  **`gitman switch <into>`** to continue on the carved lane. Least-surprise (you stay where you
+  were) *and* it dogfoods round 10's new verb — the two features compose by design.
+- **Precondition:** the current lane `L` has **exactly one change** and that change's parent is
+  **trunk** (`len(log("{trunk}..L")) == 1`). Otherwise refuse (exit 3) with a message naming the
+  limitation. The change may be described or not — a jj rewrite handles both.
+- **Selector `--paths`:** jj filesets/path-prefixes passed straight to `tx.restore(..., paths=…)`.
+  Document the exact matching semantics (prefix vs glob) after the slice-1 probe; don't promise
+  globbing the engine doesn't do.
+- **`-m <msg>`** describes the **new carved** lane; the remainder keeps `L`'s existing description.
+- **Naming:** `split` (recommended) `--into <new-lane>` (the carved lane). `--into` is
+  `ensure_unique`-checked exactly like `start`; a collision reuses round-10's R3 hint (“… use
+  `gitman switch`”).
+- **Atomic + undoable:** the whole split is one `canonical_guard`/`canonical_tx` body → one
+  `gitman undo`. `status` stays CANONICAL before and after (two sibling lanes are canonical).
+
+---
+
+## Grounding: the exact primitives this composes (all verified in-tree)
+
+- **`PyTransaction.restore(commit, from_, paths)`** — `Pyjutsu/python/pyjutsu/_pyjutsu.pyi:116`.
+  “Revert this path-set in `commit` to `from_`’s content.” **Currently UNUSED by gitman** — this is
+  the split engine. (`grep -rn '\.restore(' src/` → no hits today.)
+- **`PyTransaction.new(parents)`** — creates the carved commit `A` as a fresh child of trunk.
+- **`PyTransaction.rebase(commit, onto, mode="branch")`** — `core.py:422/552/642` precedent (only
+  needed if MVP later supports descendants; the sibling MVP may not need it).
+- **`PyTransaction.create_bookmark/set_bookmark/delete_bookmark/describe/edit`** — name + message
+  each half; `edit` (round 10) re-points `@` if we ever move it.
+- **`session.view().log(f"{trunk}..{lane}")`** — `core.py:490/593` precedent — the single-change
+  precondition check and to resolve `C`.
+- **`canonical_tx` / `canonical_guard`** — `invariants.py:238/264`. `split` never moves trunk, so
+  the postcondition trunk guard passes unmodified (no exemption — unlike land/adopt).
+- **`ensure_unique` (+ round-10 R3 hint)** — `lanes.py:49`. Validates `--into`.
+
+### The split algorithm (path-scoped, two siblings)
+
+Let `L` = current lane, `C` = its single change, `P` = trunk (C’s parent), `carved` = `--paths`.
+
+```
+with canonical_tx(session, "split") as tx:          # one op → one undo
+    a = tx.new([trunk])                  # A: empty child of trunk
+    tx.restore(a_id, from_=C_id, paths=carved)       # A := trunk + carved-paths-from-C
+    tx.create_bookmark(into, a_id)                   # carved lane
+    if message: tx.describe(a_id, message)
+    tx.restore(C_id, from_=trunk, paths=carved)      # C := remainder (carved paths reverted to trunk)
+    # original lane bookmark stays on C automatically (rewrite-follows)
+```
+
+**Risk to verify in slice 1 (flag like round 10 did):** within one jj transaction, does a second
+op see `C` as the *original* tree or the *already-rewritten* one? Capture `C`’s commit-id up front
+and **build `A` from `C` BEFORE rewriting `C`** (as above). If the tx re-resolves a bookmark name to
+the rewritten commit, address by referencing fixed commit-ids, never the `L` bookmark name, for the
+`from_`/`commit` args. Also confirm `@` (which sits on `C`) follows the `C` rewrite to the
+remainder, and that the working copy’s carved files revert on disk after `restore(C, …)`.
+
+### Empty-partition guards (exit 3)
+- **carved matches nothing** → `A` would equal trunk (empty): refuse (“`--paths` matched no changes
+  in lane '<L>'”).
+- **carved matches everything** → `B`/remainder empty: refuse (“`--paths` covers the whole change —
+  use `gitman start`/rename, not split”).
+  Detect by reading `A.is_empty` / the remainder’s emptiness after the restores, or pre-compute the
+  changed-path set of `C` (`view.diff`/`diff_stat`) and compare to the matched set — pick the
+  cheaper; verify in slice 2.
+
+---
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `src/gitman/core.py` | Add `do_split(session, paths, into, message, name=None)` in the lane-lifecycle block (near `do_switch`/`do_start`). Compose the algorithm above under `canonical_tx`; precondition + empty-partition guards; return `IntentResult(intent="split", outcome="SPLIT", …, state=capture_state())`. |
+| `src/gitman/cli.py` | Register `@app.command() def split(...)` next to `switch` (~`cli.py:122`): `--paths` (variadic), `--into` (required), `-m/--message`. Body `_finish_intent(do_split(...))`. |
+| `src/gitman/lanes.py` | None expected (reuse `ensure_unique`, `require_current_lane`). |
+| `src/gitman/models.py` | `outcome`/`intent` are plain `str` (verified round 10) — no change. |
+| `src/gitman/render.py` | Generic intent renderer — no change (verified round 10). |
+| `docs/GITMAN_CONCEPT.md` | Add `split` to the intents table + a lane-loop line (“`split` divides one lane’s change into two sibling lanes; navigation/partition, never mutates trunk”). Bump the intent count (now 14). |
+| `.claude/skills/gitman/SKILL.md` | Add `split` to the lane-loop cheatsheet (near `switch`), **plus the Fix-2 forge-loop correction below.** |
+| `tests/test_split_integration.py` (new) | Tests below. |
+
+---
+
+## Tests (new `tests/test_split_integration.py`)
+
+Mirror `tests/test_switch_integration.py` / `tests/test_lifecycle_integration.py`: `_init` builds a
+colocated `main` with files; `_sess` returns a fresh `Session`; drive `do_*` directly; assert via
+`capture_state`.
+
+1. **`test_split_partitions_into_two_sibling_lanes`** (headline): on lane `feat`, write two disjoint
+   path-sets (e.g. `a/x.txt`, `b/y.txt`), `do_split(paths=["a/**"], into="lane-a", message="a")`.
+   Assert: two lanes `feat` (remainder, has `b/y.txt`) and `lane-a` (has `a/x.txt`), both children of
+   trunk, path-sets partitioned exactly; `capture_state(...).canonical is True`.
+2. **`test_split_message_and_remainder_description`**: carved lane gets `-m`; remainder keeps the
+   original description.
+3. **`test_split_at_stays_on_remainder`**: after split, `current_lane == "feat"` (the original).
+4. **`test_split_undo_round_trips`**: `do_undo` restores the single combined change on one lane.
+5. **`test_split_requires_single_change_on_trunk`**: a multi-change (or non-trunk-rooted) lane →
+   `GitmanError` exit 3.
+6. **`test_split_empty_match_refused`** + **`test_split_whole_change_refused`**: exit 3 each.
+7. **`test_split_into_existing_lane_hints_switch`**: `--into` an existing lane → exit 3 with the
+   round-10 “… use `gitman switch`” hint (reuses `ensure_unique`).
+8. *(optional)* **`test_split_then_switch_continues_carved_lane`**: `do_split` then `do_switch(into)`
+   lands `@` on the carved lane — the round-08 / round-10 compose.
+
+Run after each slice:
+```
+devenv shell -- bash -c '"$DEVENV_STATE/venv/bin/ruff" check src tests && "$DEVENV_STATE/venv/bin/pytest" -q'
+```
+
+---
+
+## Fix-2 — forge-loop doc correction (bundled slice)
+
+**Why (round-10 dogfooding finding):** the SKILL’s forge recipe says, after `gh pr merge`, to
+`gh api -X DELETE …/git/refs/heads/<lane>` (delete the lane’s remote branch) **before** `gitman
+adopt`. Doing so deletes the remote branch of a still-live *tracked* local lane, which leaves the
+local bookmark **conflicted** (`<lane>@origin` tracked-but-empty vs a live local target) instead of
+being pruned. `gitman adopt` and `gitman reconcile` then both raise `RevsetError: Name '<lane>' is
+conflicted` (adopt classifies a conflicted *trunk* but not a conflicted *survivor lane*), aborting
+the whole recovery with no front door — it took raw pyjutsu to clear. **`adopt` already retires a
+merged lane BY CONTENT, so deleting the remote branch first is unnecessary *and* harmful.**
+
+**The fix (docs only — the user chose the doc fix over hardening adopt/reconcile):**
+- **`.claude/skills/gitman/SKILL.md`** — reorder the `publish → PR → merge → adopt` recipe so the
+  remote-branch delete happens **after** `gitman adopt`, and is optional:
+  ```
+  gh pr merge --squash            # (or web UI); do NOT pass --delete-branch
+  gitman adopt                    # retires the merged lane locally BY CONTENT; advances trunk
+  # OPTIONAL cleanup, only AFTER adopt (local lane already retired → no tracking conflict):
+  gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<lane>   # or delete in the web UI
+  ```
+  Add a one-line WHY: “Deleting the lane’s remote branch *before* `adopt` leaves a conflicted local
+  bookmark that wedges both `adopt` and `reconcile` — `adopt` retires merged lanes by content, so
+  let it run first.” Update the round-09 gap-D note accordingly (the `--delete-branch` warning
+  remains true, but the explicit delete moves to *after* adopt).
+- **Grep for the same recipe elsewhere** and fix consistently: `docs/USING_GITMAN.md`,
+  `docs/GITMAN_CONCEPT.md` (forge-loop sections). `grep -rn 'delete-branch\|refs/heads' docs .claude`.
+- **Note the deferred hardening (out of scope, do NOT implement here):** a future round could make
+  `adopt`/`reconcile` treat a conflicted *lane* bookmark the way they treat a conflicted *trunk*
+  (retire-by-content if its tip is already in trunk, else surface cleanly). Leave a one-line pointer
+  in this PLAN / the ISSUE backlog; don’t build it in 08.
+
+**Fix-2 test:** doc-only, so no integration test. Sanity: `gitman doctor` stays HEALTHY; optionally a
+grep-based check that SKILL.md no longer shows `gh api … DELETE` *before* an `adopt` line.
+
+---
+
+## Build order (each slice lint+test green before the next)
+
+1. **Slice 1 — core split happy path:** `do_split` (precondition + `tx.new`+`tx.restore`×2 +
+   bookmarks + describe) and the `split` CLI command. Tests 1–3. Verify the in-tx `restore`
+   ordering/`@`-follow risk first (smallest probe, highest value).
+2. **Slice 2 — guards:** empty-match / whole-change / multi-change-or-non-trunk-rooted /
+   `--into`-exists. Tests 5–7.
+3. **Slice 3 — undo + compose:** undo round-trip (test 4); `split`→`switch` compose (test 8); docs
+   (`GITMAN_CONCEPT.md` table + lane-loop; `SKILL.md` `split` cheatsheet line).
+4. **Slice 4 — Fix-2 forge-loop doc correction** (SKILL.md + any docs that repeat the recipe). No
+   code; keep `doctor` HEALTHY.
+
+Keep it on lane `split-lane-capability` (already current; carries ISSUE/PLAN/KICKOFF). `gitman save`
+at each green slice. **Don’t publish/land/push without an explicit ask.** No AI-attribution in
+commits/PRs/docs.
+
+---
+
+## Acceptance criteria (from ISSUE, mapped)
+
+- [ ] `gitman split --paths <globs> --into <lane>` partitions one lane’s change into **two sibling
+      lanes**, path-set partitioned exactly; `status` CANONICAL before/after. *(Slice 1–2; tests 1–7)*
+- [ ] Runs entirely through pyjutsu transactions (`new`+`restore`) — **no raw `jj`/`git`**, **no
+      Pyjutsu changes**. *(Slice 1)*
+- [ ] `gitman undo` reverts the split as a single intent. *(Slice 3; test 4)*
+- [ ] Clear errors for the unsupported preconditions (multi-change / non-trunk-rooted lane, empty
+      match, whole-change match, existing `--into`). *(Slice 2; tests 5–7)*
+- [ ] Docs + `SKILL.md` list `split` in the lane loop; a test covers the entangled-working-copy
+      case. *(Slice 3; test 1)*
+- [ ] **No Pyjutsu changes** for the MVP (S3 hunk-level is a separate follow-up issue). *(whole plan)*
+- [ ] **Fix-2:** the forge-loop recipe no longer deletes a lane’s remote branch before `adopt`;
+      `doctor` HEALTHY. *(Slice 4)*
+
+## Risks / open questions
+- **In-tx `restore` ordering & `@`-follow** (above) — the one real unknown; probe in slice 1.
+- **`--paths` matching semantics** — confirm jj fileset vs glob; document precisely, don’t overclaim.
+- **Empty-partition detection** — `A.is_empty` post-restore vs pre-computed changed-path set; pick
+  the cheaper after a slice-2 probe.
+- **Described `C`** — rewriting a saved change via `restore` should be fine (normal jj rewrite);
+  confirm the remainder keeps its description and the carved lane takes `-m`.

--- a/docs/GITMAN_CONCEPT.md
+++ b/docs/GITMAN_CONCEPT.md
@@ -123,7 +123,10 @@ A lane is always in exactly one of three states — **draft** (being edited), **
 (pushed / PR open), **landed/abandoned** (terminal). That bounds everything `status` must
 render. When `@` leaves a lane without ending it (a sibling `start` in the same workspace, a
 landed neighbour), **`switch <lane>`** moves `@` back onto an existing lane to resume it —
-navigation *between* lanes, never a trunk mutation.
+navigation *between* lanes, never a trunk mutation. And when two concerns entangle in one draft,
+**`split --paths <sel> --into <lane>`** divides that change into two sibling lanes on trunk (the
+carved paths onto a new lane, the remainder on the original) — a partition *within* the lane set,
+also never a trunk mutation.
 
 ## 6. Architecture
 
@@ -170,14 +173,15 @@ Base deps kept lean: `pydantic`, `typer`. `jj` and `git` binaries come from deve
 
 ## 7. Intent vocabulary — v1
 
-Thirteen intents. Lane lifecycle verbs (`start`/`land`/`abandon`) are the additions the lane
-model requires; everything else is deferred until friction proves it.
+Fourteen intents. Lane lifecycle verbs (`start`/`switch`/`split`/`land`/`abandon`) are the additions
+the lane model requires; everything else is deferred until friction proves it.
 
 | Intent | Signature | What it does | Underneath |
 |---|---|---|---|
 | `status` | `gitman status [--json]` | Canonical/off-canonical report: trunk + all lanes. | `jj log`/`op log`/`workspace list` (+git numstat) |
 | `start` | `gitman start <name> [--workspace]` | Create a lane (new change on trunk + bookmark `<name>`); `--workspace` isolates it. | `jj new <trunk>` + `jj bookmark create` (+ `jj workspace add`) |
 | `switch` | `gitman switch <lane>` | Move `@` onto an existing lane's change to resume it (navigation, never mutates trunk). Refuses to strand an unnamed dirty `@`; reports a lane checked out in another workspace. | `jj edit <lane>` |
+| `split` | `gitman split --paths <sel>… --into <lane> [-m <desc>]` | Partition the current lane's single change into two sibling lanes on trunk: the carved paths onto new lane `<into>`, the remainder on the original. `@` stays on the remainder; never mutates trunk. Path-scoped (whole files); refuses a multi-change/non-trunk-rooted lane, an empty match, or a whole-change match. | `jj new <trunk>` + `jj restore` ×2 + bookmark |
 | `save` | `gitman save [-m <desc>]` | Describe the current lane's change. | `jj describe` |
 | `sync` | `gitman sync [--all]` | Fetch trunk + rebase the current lane (or `--all` lanes) onto it. | `jj git fetch` + `jj rebase` |
 | `publish` | `gitman publish` | Push the current lane; branch = lane name. Verify hook first. | `jj git push` (forge extra: + open/update PR) |
@@ -195,8 +199,9 @@ blocked / off-canonical) · `2` infra/config (no remote, auth, jj/git missing, o
 devenv, no version source) · `3` invalid usage.
 
 **Deferred:** the forge extra's PR `land`/`pr-status`, stacked PRs, `shape`
-(squash/split/reorder), `switch` (parallel lanes use workspaces instead), pre-release
-version metadata, pluggable forges.
+(squash/reorder + **hunk-level/interactive** split — the path-scoped `split` above shipped; only
+partial-file selection needs a native pyjutsu `split` binding), pre-release version metadata,
+pluggable forges.
 
 ## 8. Lane & workspace flow (parallel agents)
 
@@ -543,8 +548,8 @@ the eleven intents (§7) incl. lane lifecycle + workspaces (§8); `RepoState` + 
 (§16); the agent skill (§17); `init`/`doctor`/`reconcile`; devenv boundary.
 
 **Deferred until dogfooding demands it:** the forge extra (PR `publish`/`land`/`pr-status`),
-stacked PRs, `shape` (squash/split/reorder), `switch`, pre-release/build version metadata,
-pluggable forges (GitLab/Gitea).
+stacked PRs, `shape` (squash/reorder + hunk-level/interactive split — path-scoped `split` shipped),
+pre-release/build version metadata, pluggable forges (GitLab/Gitea).
 
 ## 20. Resolved questions
 

--- a/src/gitman/cli.py
+++ b/src/gitman/cli.py
@@ -130,6 +130,21 @@ def switch(
 
 
 @app.command()
+def split(
+    paths: Annotated[
+        list[str],
+        typer.Option("--paths", help="Repo-relative file path(s)/dir-prefix(es)/glob(s) to carve out (repeatable)."),
+    ],
+    into: Annotated[str, typer.Option("--into", help="Name of the new lane to carve the paths onto.")],
+    message: Annotated[str | None, typer.Option("-m", "--message", help="Describe the carved lane.")] = None,
+) -> None:
+    """Partition the current lane's change into two sibling lanes: carved paths onto <into>, rest stays."""
+    from gitman.core import do_split
+
+    _finish_intent(do_split(_session(), paths, into, message))
+
+
+@app.command()
 def save(
     message: Annotated[str | None, typer.Option("-m", "--message", help="Describe the current change.")] = None,
 ) -> None:

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -5,6 +5,7 @@ and the per-intent migrations onto pyjutsu (canonical_tx / canonical_guard). See
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import shutil
 import subprocess
@@ -266,6 +267,109 @@ def do_switch(session: Session, name: str):
         outcome="SWITCHED",
         lane=name,
         messages=[f"switched @ onto lane '{name}'."],
+        undo_command="gitman undo",
+        state=capture_state(session),
+    )
+
+
+def _match_paths(patterns: list[str], changed: list[str]) -> list[str]:
+    """Resolve `--paths` selectors against a change's exact changed-file set.
+
+    `tx.restore`'s path matcher is jj's `FilesMatcher` — **exact repo-relative files only** (a bare
+    directory or a glob matches nothing; verified by probe). So `split` does the ergonomic matching
+    itself: each selector matches a changed path if it equals it, is a directory prefix of it
+    (`src/foo` ⊃ `src/foo/bar.py`), or globs it (`fnmatch`, so `*`/`?`/`[]`/`**` all work). Returns
+    the matched paths in `changed`'s order (deterministic), de-duplicated by first match.
+    """
+    matched: list[str] = []
+    for path in changed:
+        for pat in patterns:
+            prefix = pat.rstrip("/")
+            if path == prefix or path.startswith(prefix + "/") or fnmatch.fnmatch(path, pat):
+                matched.append(path)
+                break
+    return matched
+
+
+def do_split(session: Session, paths: list[str], into: str, message: str | None):
+    """Partition the current lane's single change into two **sibling** lanes on trunk.
+
+    The last missing core lane op: `start` opens, `switch` navigates, `save` describes,
+    `land`/`abandon` end, `sync` rebases — but nothing **divides** a change once two concerns
+    entangle in one working copy. `split` carves the `--paths` subset onto a new `--into` lane and
+    leaves the remainder on the original, both children of trunk (independently landable). Composes
+    `tx.new` + `tx.restore` only — no new pyjutsu surface, no raw jj/git.
+
+    Algorithm (one canonical_tx → one undo; never moves trunk, so the trunk guard passes unmodified):
+    create an empty child of trunk, bookmark it `into` immediately (so it isn't auto-abandoned and
+    can be referenced by a rewrite-following name), fill it with the lane change `C`'s full content,
+    then revert the *remainder* paths in it (→ carved-only); finally revert the *carved* paths in `C`
+    (→ remainder-only) and put `@` back on the original lane. `restore` is referenced by bookmark /
+    change-id throughout, never by a returned commit-id (those re-resolve to the stale pre-rewrite
+    commit in the immutable store). `@` stays on the remainder lane; the report points at
+    `gitman switch <into>` to continue on the carved lane (composes round 10).
+    """
+    from gitman.invariants import canonical_tx
+    from gitman.lanes import ensure_unique, require_current_lane
+    from gitman.models import IntentResult
+    from gitman.state import capture_state
+
+    trunk = require_trunk(session.config)
+    if not paths:
+        raise GitmanError("`gitman split` needs at least one `--paths` selector.", exit_code=3)
+
+    with canonical_tx(session, "split") as tx:
+        # Pre-tx facts: while the tx is open, `session.view()` is still the post-snapshot, pre-tx
+        # head — exactly the before-state these guards need (we read all of it before mutating).
+        view = session.view()
+        lane = require_current_lane(session, trunk)
+        ensure_unique(session, trunk, into)  # exit 3 (+ round-10 `gitman switch` hint) if `into` exists
+        trunk_id = view.resolve(trunk).commit_id
+        wc = view.working_copy()  # the lane's change `C` (its bookmark sits on @)
+        c_change, c_id = wc.change_id, wc.commit_id
+
+        # Precondition: exactly one change, rooted directly on trunk. A stacked/deeper-rooted lane
+        # would need descendant rebasing — out of MVP scope; refuse clearly (exit 3).
+        lane_range = view.log(f"{trunk}..{lane}")
+        if len(lane_range) != 1 or lane_range[0].parent_ids != [trunk_id]:
+            raise GitmanError(
+                f"`gitman split` needs a lane with exactly one change rooted on {trunk}; "
+                f"lane '{lane}' has {len(lane_range)} change(s) (or isn't rooted on trunk). "
+                "Land/abandon the stack down to one change first.",
+                exit_code=3,
+            )
+
+        changed = [f.path for f in view.diff(lane).files]
+        carved = _match_paths(paths, changed)
+        if not carved:
+            raise GitmanError(f"`--paths` matched no changes in lane '{lane}'.", exit_code=3)
+        remainder = [p for p in changed if p not in set(carved)]
+        if not remainder:
+            raise GitmanError(
+                "`--paths` covers the whole change — use `gitman start`/rename, not split.",
+                exit_code=3,
+            )
+
+        # Build the two siblings. Reference the carved lane by its bookmark `into` (rewrite-follows,
+        # never GC'd) and `C` by its change-id `c_change` (stable; the original bookmark follows it).
+        tx.new([trunk_id])  # @ → A, an empty child of trunk
+        tx.create_bookmark(into, "@")  # name + protect A before @ leaves it
+        tx.restore(into, from_=c_id)  # A := C's full content
+        tx.restore(into, from_=trunk_id, paths=remainder)  # A := carved-only (revert the remainder)
+        if message:
+            tx.describe(into, message)
+        tx.restore(c_change, from_=trunk_id, paths=carved)  # C := remainder-only (revert the carved)
+        tx.edit(c_change)  # @ back onto the remainder/original lane
+
+    return IntentResult(
+        intent="split",
+        outcome="SPLIT",
+        lane=lane,
+        messages=[
+            f"carved {len(carved)} path(s) onto new lane '{into}'; "
+            f"{len(remainder)} path(s) remain on '{lane}'."
+        ],
+        notes=[f"`gitman switch {into}` to continue on the carved lane."],
         undo_command="gitman undo",
         state=capture_state(session),
     )

--- a/tests/test_split_integration.py
+++ b/tests/test_split_integration.py
@@ -1,0 +1,217 @@
+"""Live integration tests for `gitman split` — carve one lane's change into two sibling lanes.
+
+Build real colocated jj repos **through pyjutsu** (in-process, no `jj` CLI) and drive `do_split`
+over a `Session`, mirroring `tests/test_switch_integration.py`. Covers the headline entangled-change
+partition, the carved/remainder description split, `@`-stays-on-remainder, the undo round-trip,
+every guard (multi-change / empty-match / whole-change / existing `--into`), and the `split`→`switch`
+compose (round 08 + round 10 together).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.core import (
+    GitmanError,
+    do_save,
+    do_split,
+    do_start,
+    do_switch,
+    do_undo,
+)
+from gitman.lanes import current_lane
+from gitman.session import Session
+from gitman.state import capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _init(d: Path) -> Workspace:
+    """trunk `main` with one committed file `base.txt`, then a fresh empty child as @ (as init does)."""
+    ws = Workspace.init(d, colocate=True)
+    (d / "base.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+        tx.new(["main"])
+    return ws
+
+
+def _sess(d: Path) -> Session:
+    """A fresh Session per call — mirrors one-session-per-CLI-invocation."""
+    return Session.load(d, CFG)
+
+
+def _cur(d: Path) -> str | None:
+    return current_lane(_sess(d), "main")
+
+
+def _lane(state, name: str):
+    return next(lane for lane in state.lanes if lane.name == name)
+
+
+def _entangled(d: Path) -> None:
+    """Open lane `feat` and pile two disjoint path-sets into one draft change."""
+    do_start(_sess(d), "feat", workspace=False)
+    (d / "a").mkdir()
+    (d / "b").mkdir()
+    (d / "a" / "x.txt").write_text("carved\n")
+    (d / "b" / "y.txt").write_text("remain\n")
+    do_save(_sess(d), "entangled 004 + 005 work")
+
+
+def _files(d: Path, rev: str) -> list[str]:
+    return sorted(f.path for f in _sess(d).view().diff(rev).files)
+
+
+# --- headline + happy path (slice 1) -------------------------------------------------
+
+
+def test_split_partitions_into_two_sibling_lanes(tmp_path: Path):
+    """ISSUE headline: entangled `a/**` + `b/**` in one change → two sibling lanes, partitioned."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+
+    res = do_split(_sess(tmp_path), paths=["a"], into="lane-a", message="a work")
+    assert res.outcome == "SPLIT"
+    assert res.undo_command == "gitman undo"
+
+    after = capture_state(_sess(tmp_path))
+    assert after.canonical
+    assert {lane.name for lane in after.lanes} == {"feat", "lane-a"}
+    # exact partition: carved lane has only a/x.txt; remainder lane keeps only b/y.txt
+    assert _files(tmp_path, "lane-a") == ["a/x.txt"]
+    assert _files(tmp_path, "feat") == ["b/y.txt"]
+    # both are single-change children of trunk (siblings)
+    trunk_id = _sess(tmp_path).view().resolve("main").commit_id
+    for name in ("feat", "lane-a"):
+        assert _sess(tmp_path).view().resolve(name).parent_ids == [trunk_id]
+        assert len(_sess(tmp_path).view().log(f"main..{name}")) == 1
+
+
+def test_split_message_and_remainder_description(tmp_path: Path):
+    """Carved lane takes `-m`; the remainder keeps the original change's description."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+
+    do_split(_sess(tmp_path), paths=["a/x.txt"], into="lane-a", message="carved: the a work")
+    view = _sess(tmp_path).view()
+    assert view.resolve("lane-a").description.strip() == "carved: the a work"
+    assert view.resolve("feat").description.strip() == "entangled 004 + 005 work"
+
+
+def test_split_at_stays_on_remainder(tmp_path: Path):
+    """After split, `@` stays on the original (remainder) lane, not the carved one."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+
+    do_split(_sess(tmp_path), paths=["a"], into="lane-a", message="a")
+    assert _cur(tmp_path) == "feat"
+    # the carved files are gone from the working dir; the remainder stays
+    assert not (tmp_path / "a" / "x.txt").exists()
+    assert (tmp_path / "b" / "y.txt").exists()
+
+
+# --- undo round-trip (slice 3) -------------------------------------------------------
+
+
+def test_split_undo_round_trips(tmp_path: Path):
+    """A split is one intent → one `gitman undo` restores the single combined change on one lane."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+
+    do_split(_sess(tmp_path), paths=["a"], into="lane-a", message="a")
+    assert {lane.name for lane in capture_state(_sess(tmp_path)).lanes} == {"feat", "lane-a"}
+
+    do_undo(_sess(tmp_path), op=None, list_=False)
+    restored = capture_state(_sess(tmp_path))
+    assert restored.canonical
+    assert {lane.name for lane in restored.lanes} == {"feat"}
+    assert _files(tmp_path, "feat") == ["a/x.txt", "b/y.txt"]
+    assert (tmp_path / "a" / "x.txt").exists()
+    assert (tmp_path / "b" / "y.txt").exists()
+
+
+# --- guards (slice 2) ----------------------------------------------------------------
+
+
+def test_split_requires_single_change_on_trunk(tmp_path: Path):
+    """A multi-change (stacked) lane can't be split — refuse with exit 3."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "feat", workspace=False)
+    (tmp_path / "x.txt").write_text("one\n")
+    do_save(_sess(tmp_path), "change one")
+    # stack a second change on the same lane (bookmark follows @ to the new tip)
+    sess = _sess(tmp_path)
+    with sess.ws.transaction("gitman:test-stack", auto_snapshot=True) as tx:
+        tx.new("@")
+        tx.set_bookmark("feat", "@")
+    (tmp_path / "z.txt").write_text("two\n")
+    do_save(_sess(tmp_path), "change two")
+
+    with pytest.raises(GitmanError) as exc:
+        do_split(_sess(tmp_path), paths=["x.txt"], into="lane-a", message="x")
+    assert exc.value.exit_code == 3
+
+
+def test_split_empty_match_refused(tmp_path: Path):
+    """`--paths` matching nothing in the change → exit 3."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+    with pytest.raises(GitmanError) as exc:
+        do_split(_sess(tmp_path), paths=["nope/**"], into="lane-a", message="x")
+    assert exc.value.exit_code == 3
+    assert "matched no changes" in str(exc.value)
+    # nothing applied — still one lane, canonical
+    assert {lane.name for lane in capture_state(_sess(tmp_path)).lanes} == {"feat"}
+
+
+def test_split_whole_change_refused(tmp_path: Path):
+    """`--paths` covering the entire change leaves an empty remainder → exit 3."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+    with pytest.raises(GitmanError) as exc:
+        do_split(_sess(tmp_path), paths=["a", "b"], into="lane-a", message="x")
+    assert exc.value.exit_code == 3
+    assert "whole change" in str(exc.value)
+
+
+def test_split_into_existing_lane_hints_switch(tmp_path: Path):
+    """`--into` an existing lane → exit 3 with the round-10 `gitman switch` hint (reuses ensure_unique)."""
+    _init(tmp_path)
+    do_start(_sess(tmp_path), "lane-a", workspace=False)  # pre-existing lane to collide with
+    do_start(_sess(tmp_path), "feat", workspace=False)  # strands lane-a; @ now on feat
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "x.txt").write_text("carved\n")
+    (tmp_path / "b" / "y.txt").write_text("remain\n")
+    do_save(_sess(tmp_path), "entangled")
+
+    with pytest.raises(GitmanError) as exc:
+        do_split(_sess(tmp_path), paths=["a"], into="lane-a", message="x")
+    assert exc.value.exit_code == 3
+    assert "gitman switch" in str(exc.value)
+
+
+# --- compose with round 10 (slice 3) -------------------------------------------------
+
+
+def test_split_then_switch_continues_carved_lane(tmp_path: Path):
+    """`split` then `switch <into>` lands `@` on the carved lane — the round-08 / round-10 compose."""
+    _init(tmp_path)
+    _entangled(tmp_path)
+
+    do_split(_sess(tmp_path), paths=["a"], into="lane-a", message="a")
+    assert _cur(tmp_path) == "feat"
+
+    res = do_switch(_sess(tmp_path), "lane-a")
+    assert res.outcome == "SWITCHED"
+    assert _cur(tmp_path) == "lane-a"
+    # on the carved lane, its file is checked out; the remainder's is not
+    assert (tmp_path / "a" / "x.txt").exists()
+    assert not (tmp_path / "b" / "y.txt").exists()
+    assert capture_state(_sess(tmp_path)).canonical


### PR DESCRIPTION
Adds the last missing **core** lane operation: `gitman split --paths <sel>… --into <lane> [-m]` partitions the current lane's single trunk-rooted change into **two sibling lanes** on trunk — the carved paths onto a new lane, the remainder on the original. `@` stays on the remainder; the report points at `gitman switch <into>` (composes round 10). One `canonical_tx`, one `gitman undo`, never touches trunk.

## What it does
- `core.do_split` + `_match_paths` (glob/`dir/`-prefix/exact selectors expanded against the change's `view.diff().files`; `tx.restore` takes exact files only — jj `FilesMatcher`).
- Algorithm: `tx.new([trunk])` → `create_bookmark(into,"@")` → `restore(into, from_=C)` (fill) → `restore(into, from_=trunk, paths=remainder)` (carve) → `restore(C, from_=trunk, paths=carved)` → `edit(C)`. No new pyjutsu bindings, no raw jj/git.
- `cli.split`; both `--paths` (repeatable) and `--into` required.
- Guards (exit 3): multi-change / non-trunk-rooted lane, empty match, whole-change match, existing `--into` (reuses `ensure_unique`'s `switch` hint).

## Pyjutsu `restore` sharp edges handled (drove the design)
1. `restore` returns a **stale** `Commit` (re-resolved by the original commit-id) — reference the carved lane by **bookmark** and `C` by **change-id**, never a returned commit-id.
2. `paths` is **exact repo-relative files only** — directories/prefixes/globs match nothing; expanded in Python instead.
3. An empty unbookmarked `tx.new` `@` is **auto-abandoned** on `edit`-away — bookmark it first.

## Tests / docs
- `tests/test_split_integration.py` — 9 tests (partition, descriptions, `@`-stays, undo round-trip, 4 guards, `split`→`switch` compose). Suite 91 → 100.
- `docs/GITMAN_CONCEPT.md` intents table (→ 14) + lane-loop; `SKILL.md` lane loop + split paragraph.

## Fix-2 (doc-only, bundled)
`SKILL.md` forge recipe now deletes a lane's remote branch **after** `gitman adopt` (optional), not before — pre-adopt delete leaves a conflicted local bookmark that wedges both `adopt` and `reconcile` (the round-10 finding). Deferred adopt/reconcile conflicted-lane hardening noted, not built here.

`gitman doctor` HEALTHY; `ruff` clean; 100 tests pass.