### PR TITLE
fix(reconcile): handle conflicted lane bookmarks (issue 11)

### DIFF
--- a/.scratch/projects/11-conflicted-bookmark-command-deadlock/ISSUE_ANALYSIS.md
+++ b/.scratch/projects/11-conflicted-bookmark-command-deadlock/ISSUE_ANALYSIS.md
@@ -1,0 +1,378 @@
+# Issue analysis: conflicted lane bookmark deadlocks every gitman command
+
+**Reviewer:** design review of `REPORT.md` (field bug from the `flora` repo).
+**Scope:** validate root cause, classify the 7 proposed gitman fixes (A1–A7), recommend the
+cleanest unifying fix, and separate gitman work from genuine pyjutsu gaps.
+
+---
+
+## Verdict
+
+- **Symptom: REAL and reproduced.** A local lane bookmark whose local position and
+  remote-tracking position diverge becomes a **conflicted bookmark** (`target_ids` has two
+  entries). Resolving that bookmark *by name* in a revset raises
+  `RevsetError: Name '<lane>' is conflicted`. I reproduced this end-to-end in a throwaway
+  colocated repo (see *Evidence §E*).
+
+- **Root cause: SUBSTANTIALLY CORRECT, with one important correction.** The report says
+  *every* command resolves the lane by name up front and therefore deadlocks "by design."
+  The deadlock is real, but the precise mechanism is narrower and more fixable than the report
+  implies:
+  - The crash is **purely on the read side** — `view.resolve(name)` / `view.log("{trunk}..{name}")`
+    inside `capture_state()`'s per-lane loop (`state.py:232–244`). Every guarded intent
+    (`abandon`, `adopt`, `sync`, `save`, `start`, …) calls `capture_state` through
+    `precheck_canonical`, so they all die in the **precheck**, before any logic. `status` calls
+    `capture_state` directly. That is the single choke point.
+  - **The mutation side is NOT blocked.** pyjutsu's `delete_bookmark(name)` and
+    `set_bookmark(name, commit)` operate on the bookmark **structurally** (by `RefName`, never
+    resolving `name` as a revset). I verified both succeed on a conflicted bookmark. So the
+    recovery primitives already exist; gitman simply never reaches them because the read-side
+    precheck aborts first.
+  - gitman **already solved exactly this problem for trunk**: `state.py:_trunk_conflicted`
+    reads `b.conflicted` structurally from `view.bookmarks()` and short-circuits before any
+    `resolve`. The fix is to **generalize that structural approach to lanes** — not to rewrite
+    every command to use change-ids.
+
+- **"Deadlock by design": mostly accurate but overstated.** `reconcile` does *not* run the
+  precheck (it is meant to run off-canonical), and `undo` doesn't call `capture_state` at all —
+  so those two had a path through. The report's own timeline confirms `reconcile` *ran* (it
+  mutated state) — it just **crashed at the end** when it called `capture_state(session)` on
+  line 93 to build its result, after already mutating. That is the non-atomicity the report
+  saw, and it has the same single root cause (capture_state crashing on a conflicted lane).
+
+### A1–A7 classification
+
+| # | Proposed fix | Classification | One-line justification |
+|---|---|---|---|
+| **A1** | Tolerate a conflicted lane bookmark; resolve via a stable handle or catch the error | **Correct & essential** — but do it via *structural bookmark read*, not change-ids | This is the root fix. The change-id idea is a red herring; the elegant form is `_trunk_conflicted`-style structural reads. Generalize, don't catch-and-retry. |
+| **A2** | `reconcile`/`abandon` must operate *on* a conflicted bookmark (pick a side / forget) | **Correct & essential** | The recovery verbs must reach `set_bookmark`/`delete_bookmark`. Both already work structurally on a conflicted bookmark — only the precheck blocks them. |
+| **A3** | Auto-retire a lane merged & deleted on the forge | **Correct but largely redundant** | `do_adopt` already retires forge-merged + pruned lanes (`core.py:914–917`) and rebases/retires survivors. The *new* slice is "retire a lane whose local bookmark is conflicted because it was merged-with-a-merge-commit but the remote branch was NOT deleted." That is small and folds into A1+A2. |
+| **A4** | Make `adopt --force` actually bypass name resolution | **Correct but subsumed by A1** | `--force` doesn't die on its own logic — it dies in the shared precheck (`capture_state`). Fix A1 and `--force` is unblocked for free; no `--force`-specific code needed. |
+| **A5** | Make `reconcile` atomic | **Correct & essential (narrow)** | The half-apply is `reconcile` mutating, then crashing on the final `capture_state`. Root-caused by A1; additionally the final `capture_state` should be inside the same rollback scope or made crash-proof. |
+| **A6** | `doctor` must surface a conflicted lane bookmark | **Correct but secondary** | A genuine gap (doctor read `colocated_ref_desync`, which *skips* conflicted bookmarks), but it's a reporting nicety, not the deadlock fix. Small follow-up. |
+| **A7** | Better error → next action | **Symptomatic band-aid** | Worth doing as polish, but once A1 lands the error path is no longer hit for the common case; the message rewrite is cosmetic, not curative. |
+| **A8–A12** (workflow/escalation) | — | **Out of scope / advisory** | Sound operational advice (adopt promptly, auto-delete head branch, smaller lanes, git escape hatch). Not gitman code changes. A10 (delete-on-land) already happens in `do_land`/`_retire_lane`. |
+
+**Net:** A1 is the keystone. A2 and A5 ride on it. A3/A4 are mostly already implemented or
+subsumed. A6/A7 are small independent follow-ups.
+
+---
+
+## Evidence
+
+### E. Empirical reproduction (throwaway colocated repo, in-process pyjutsu)
+
+Built `main`, a published lane `L`, then **advanced `origin/L` with a forge commit AND advanced
+local `L` with a different commit**, then `git_fetch`. Result:
+
+```
+name=L remote=None    targets=[<local_tip>, <remote_tip>]  conflicted=True
+name=L remote=git     targets=[<local_tip>]                conflicted=False
+name=L remote=origin  targets=[<remote_tip>]               conflicted=False
+
+view.resolve("L")        -> RevsetError: Name `L` is conflicted     # the exact symptom
+view.log("main..L")      -> RevsetError: Name `L` is conflicted     # crashes capture_state + abandon
+# structural read needs no resolution:
+b.name=="L", b.remote is None  -> conflicted=True, target_ids=[local, remote]   # both sides available
+# remote side directly available as the L@origin row's single target_id
+
+# mutation primitives WORK on the conflicted bookmark:
+set_bookmark("L", "L@origin")  -> SUCCEEDS, L now conflicted=False, targets=[remote_tip]   # pick a side
+delete_bookmark("L")           -> SUCCEEDS, L gone                                          # forget/retire
+```
+
+The first (FF-able) simulation auto-resolved cleanly — confirming the conflict only arises when
+neither side is an ancestor of the other (true divergence), exactly the report's
+"merge main into L, then merge PR, then advance local too" shape.
+
+### Code: the single choke point
+
+`capture_state` handles a conflicted **trunk** structurally and short-circuits (state.py:79–86,
+188–205) but then enumerates lanes by **resolving each name**:
+
+```python
+# state.py:232–244  (crashes on a conflicted LANE bookmark)
+for name in sorted(local_names - {trunk_name}):
+    head = view.resolve(name)                       # RevsetError on a conflicted lane
+    change = _change(head, view.diff_stat(name))    # also resolves name
+    range_changes = view.log(f"{trunk_name}..{name}")  # also resolves name
+    ahead = len(range_changes)
+    behind = len(view.log(f"{name}..{trunk_name}"))
+    ...
+```
+
+`_lane_index` (state.py:63–76) — the enumeration that feeds `lane_names()` — is already
+structural and does **not** crash. So `do_abandon`'s `if target not in lane_names(...)`
+(core.py:589) survives; it dies one line later on `session.view().log(f"{trunk}..{target}")`
+(core.py:594) and, before even that, in its `canonical_guard` precheck.
+
+`do_abandon` choke (core.py:593–596):
+
+```python
+with session.ws.transaction("gitman:abandon", auto_snapshot=False) as tx:
+    for c in session.view().log(f"{trunk}..{target}"):   # RevsetError on conflicted lane
+        tx.abandon(c.change_id)
+    tx.delete_bookmark(target)                            # <- this line WOULD have worked
+```
+
+`reconcile` non-atomicity (reconcile.py:77–93): the stray/ref healing happens, then
+`state = capture_state(session)` (line 93) crashes on the conflicted lane *after* mutation —
+producing the "different broken state on each run" the report describes. It also can't *find*
+the conflicted lane as a stray (a conflicted bookmark isn't an off-canonical stray), so even
+without the crash, plain `reconcile` would not retire it.
+
+### Code: the template for the right approach
+
+`state.py:79–86` is the exemplar — structural, no error-string matching, no resolution:
+
+```python
+def _trunk_conflicted(view: RepoView, trunk: str) -> bool:
+    """`resolve(trunk)` raises against it; `view.bookmarks()` exposes it structurally via
+    `.conflicted` (`len(target_ids) > 1`) — the clean detector, no error-string match."""
+    return any(b.name == trunk and b.remote is None and b.conflicted for b in view.bookmarks())
+```
+
+`_adopt_dry_run` (core.py:789–810) and `do_adopt` (core.py:875) already call
+`_trunk_conflicted` to skip `{trunk}..` revsets when trunk is conflicted. The lane side simply
+never got the same treatment.
+
+### pyjutsu API facts verified
+
+- `models.Bookmark`: `name`, `remote: str|None`, `target_ids: list[CommitId]`,
+  `tracked: bool`, and `@property conflicted == len(target_ids) > 1` (models.py:171–188).
+  A conflicted local bookmark exposes **both sides** in `target_ids`; the remote side is also
+  available as the separate `<name>@<remote>` row's single `target_id`.
+- Revset resolution of a conflicted name raises `RevsetError` ("Name `X` is conflicted") from
+  `repo_view.rs:resolve`/`log` (single-revision contract).
+- Mutation verbs in `transaction.rs`: `create_bookmark`/`set_bookmark` resolve only the *commit*
+  argument (`resolve_single`), the *name* is handled by `RefName`+`set_local_bookmark_target`;
+  `delete_bookmark` is purely structural (`get_local_bookmark` → set absent). **None resolve the
+  bookmark name as a revset**, so all act on a conflicted bookmark.
+- **There is no `forget_bookmark`** in pyjutsu (the report's "jj bookmark forget" maps to
+  `delete_bookmark` here, which deletes the local bookmark and leaves the remote-tracking row —
+  the right primitive). `untrack_bookmark(name, remote)` exists if we ever want to drop the
+  remote-tracking side instead of picking it.
+
+---
+
+## Recommended fix
+
+One keystone change dissolves A1, A4, and (with a tiny addition) A2/A5. Two small follow-ups
+cover A6/A7.
+
+### 1. Make lane reads structural — `capture_state` never resolves a conflicted lane name
+
+Mirror `_trunk_conflicted`. A conflicted lane is reported as a first-class lane with a
+`conflicted` flag and an off-canonical note, using the two sides from `target_ids` — never a
+`resolve(name)`. Add a small helper and a guarded branch in the lane loop:
+
+```python
+# state.py — new helper next to _trunk_conflicted
+def _conflicted_lanes(view: RepoView, trunk: str) -> dict[str, list[str]]:
+    """{lane_name: target_ids} for every *conflicted* local lane bookmark (≠ trunk).
+    Read structurally so a conflicted name is never resolved as a revset."""
+    return {
+        b.name: list(b.target_ids)
+        for b in view.bookmarks()
+        if b.remote is None and b.name != trunk and b.conflicted
+    }
+
+def _remote_target(view: RepoView, name: str) -> str | None:
+    """The single commit id of the `<name>@<remote>` tracking row, if any (the 'remote side')."""
+    rows = [b for b in view.bookmarks() if b.name == name and b.remote not in (None, "git")]
+    return rows[0].target_ids[0] if rows and len(rows[0].target_ids) == 1 else None
+```
+
+In `capture_state`'s lane loop, branch *before* resolving:
+
+```python
+conflicted = _conflicted_lanes(view, trunk_name)
+for name in sorted(local_names - {trunk_name}):
+    if name in conflicted:
+        lanes.append(Lane(
+            name=name,
+            state=LaneState.published if name in published else LaneState.draft,
+            head=None,                # no single head — it's two-sided
+            conflict=True,            # surfaces as a conflicted lane in status/doctor
+            ahead=0, behind=0, change_count=0, ...,
+        ))
+        continue
+    head = view.resolve(name)         # safe: not conflicted
+    ...
+```
+
+and set the off-canonical signal so guarded intents see a clear, actionable state instead of a
+crash:
+
+```python
+if conflicted:
+    off_canonical = (
+        f"lane bookmark(s) {', '.join(sorted(conflicted))} diverged from their pushed branch "
+        f"(likely forge-merged) — run `gitman reconcile` to retire/resolve them."
+    )
+```
+
+(Requires making `Lane.head` optional in `models.py`, or synthesizing a side; the optional-head
+route is cleanest.)
+
+**This single change unblocks `status`, and every guarded intent's precheck stops crashing —
+so `adopt`, `adopt --force`, `sync`, `abandon` all *run* again.** A4 needs no `--force`-specific
+code: `--force`'s precheck no longer aborts.
+
+### 2. Teach `reconcile` (and `abandon`) to act on a conflicted lane
+
+`reconcile` is the recovery verb; it should retire/resolve conflicted lanes. The primitives are
+proven to work structurally:
+
+```python
+# reconcile.py — inside do_reconcile, alongside strays + ref healing
+conflicted = _conflicted_lanes(view, trunk)
+for name, _targets in conflicted.items():
+    remote_side = _remote_target(view, name)
+    with session.ws.transaction("gitman:reconcile-lane", auto_snapshot=False) as tx:
+        if remote_side is not None and _is_ancestor(view, name_side=remote_side, of=trunk):
+            # forge-merged: the remote tip is already in trunk → retire the lane outright
+            tx.delete_bookmark(name)
+            actions.append(f"retired forge-merged lane '{name}' (was conflicted).")
+        else:
+            # not yet merged: pick the remote (pushed) side so the name resolves again,
+            # leaving a normal lane the user can `sync`/`land`/`abandon`.
+            tx.set_bookmark(name, f"{name}@{remote}")
+            actions.append(f"resolved conflicted lane '{name}' to its pushed tip.")
+```
+
+Policy note: "prefer remote-tracking side" is the safe default (it's what was published and what
+the forge merged); `--abandon` can mean "drop the lane" for these too. `delete_bookmark` leaves
+the remote-tracking row, which the existing ref-healing / `git fetch --prune` path then clears —
+matching the report's manual recovery, but inside gitman.
+
+`do_abandon` gets the same guard: if `target in _conflicted_lanes(...)`, skip the
+`log("{trunk}..{target}")` loop (there's no single linear range) and go straight to
+`delete_bookmark(target)` (proven to work on a conflicted bookmark).
+
+### 3. Make `reconcile` crash-proof at the boundary (A5)
+
+The half-apply was the final `capture_state` crashing post-mutation. Once #1 lands,
+`capture_state` no longer crashes on a conflicted lane — so this is *already* fixed by the
+keystone. Belt-and-suspenders: move the final `capture_state` so a failure there can't leave a
+half-applied op unreported (it's inside `repo_lock` already; the remaining risk is gone with #1).
+
+### 4. Follow-ups (independent, small)
+
+- **A6 — doctor check.** `colocated_ref_desync` deliberately skips conflicted bookmarks
+  (`state.py:146`, `if ... and not b.conflicted`). Add a dedicated doctor check using
+  `_conflicted_lanes`: `WARN "lane bookmark <x> is conflicted → gitman reconcile"`. This closes
+  the doctor-vs-status disagreement the report flags.
+- **A7 — error message.** Keep `map_pyjutsu_error`'s `RevsetError` branch as a backstop, but
+  when the message contains `is conflicted`, route to exit code **1** (VC decision needed) with
+  text pointing at `gitman reconcile`, instead of exit **3** (invalid usage). After #1 this path
+  is rarely hit, but it's the correct backstop classification.
+
+### Which A-items this subsumes
+
+- **A1** → §1 (structural reads), implemented the elegant way (not change-ids, not try/except).
+- **A2** → §2 (reconcile/abandon act on the conflicted bookmark).
+- **A3** → mostly pre-existing in `do_adopt`; the conflicted-but-undeleted case is covered by §2.
+- **A4** → free, via §1 (no `--force`-specific code).
+- **A5** → resolved by §1; §3 is the backstop.
+- **A6** → §4 (doctor).
+- **A7** → §4 (error message + exit-code correction).
+
+---
+
+## gitman vs. upstream pyjutsu
+
+**This is a gitman bug, not a pyjutsu gap.** pyjutsu already exposes everything needed:
+- conflicted bookmarks are first-class and fully introspectable (`Bookmark.conflicted`,
+  `target_ids`, plus the separate `<name>@<remote>` row);
+- both resolution primitives (`set_bookmark`, `delete_bookmark`) operate structurally on a
+  conflicted bookmark.
+
+The only place pyjutsu *could* help, and it's optional polish, not required:
+
+1. **Ergonomic accessor.** A `view.bookmark(name) -> Bookmark | None` (or a
+   `local_target(name)` / `remote_target(name, remote)`) would save gitman from scanning
+   `view.bookmarks()` each time. Nice-to-have, not blocking — gitman can add its own helper.
+2. **`forget_bookmark`.** jj distinguishes `delete` (tombstone that propagates on push) from
+   `forget` (drop local tracking without proposing a remote deletion). pyjutsu only binds
+   `delete_bookmark`. For retiring a forge-merged lane, `delete_bookmark` + the remote already
+   gone is correct; but if we ever want "stop tracking locally without deleting the remote,"
+   `untrack_bookmark` covers part of it. A true `forget_bookmark` is a *possible* future pyjutsu
+   addition — note it, don't block on it.
+
+Recommendation: **fix entirely in gitman now**; file the `view.bookmark(name)` accessor as a
+low-priority pyjutsu ergonomics ticket.
+
+---
+
+## Test plan
+
+In-process over pyjutsu, two colocated repos (work + bare `origin`), forge simulated with raw
+git in a throwaway clone — matching `tests/test_adopt_integration.py`. New file
+`tests/test_conflicted_lane.py`.
+
+**Shared fixture — `_diverge_lane(ws, work, remote, lane)`:** publish `lane`; in a clone, add a
+commit on `origin/<lane>` and push (do NOT delete it); locally add a *different* commit on the
+lane; `ws.git_fetch(remote)`. Assert the local `lane` bookmark is now `conflicted=True` with two
+`target_ids` (this is the §E mechanic, asserted as a precondition so the test self-validates).
+
+1. **`test_conflicted_lane_is_unresolvable_by_name`** (mechanic regression): assert
+   `view.resolve(lane)` and `view.log(f"main..{lane}")` raise `RevsetError`, and that
+   `view.bookmarks()` exposes the lane with `.conflicted` and both sides — locking in the API
+   facts the fix relies on.
+
+2. **`test_status_survives_conflicted_lane`** (A1, the §7 minimal repro as a regression test):
+   `capture_state(session)` returns a `RepoState` (no exception); `canonical is False`;
+   `off_canonical` mentions the lane; the lane appears in `state.lanes` with `conflict=True`.
+   **This is the report's §7 expected behavior.**
+
+3. **`test_adopt_runs_with_conflicted_lane`** (A4): with trunk also forge-merged,
+   `do_adopt(..., force=...)` no longer raises `RevsetError`; it advances trunk and reaches the
+   survivor loop. (Pairs the conflicted-lane + diverged-trunk aggravator from the report.)
+
+4. **`test_reconcile_retires_forge_merged_conflicted_lane`** (A2): when the remote side is an
+   ancestor of the adopted trunk, `do_reconcile(session, abandon_=False)` deletes the lane
+   bookmark and reports it retired; afterward `capture_state` is canonical and the lane is gone.
+
+5. **`test_reconcile_resolves_unmerged_conflicted_lane`** (A2): when the remote side is NOT yet
+   in trunk, `do_reconcile` sets the lane to its pushed tip; afterward `view.resolve(lane)`
+   succeeds (no longer conflicted) and the lane is a normal draft/published lane.
+
+6. **`test_reconcile_is_atomic_on_conflicted_lane`** (A5): assert `do_reconcile` either fully
+   succeeds or makes no change — run it twice and assert the second run is `CLEAN`/idempotent
+   and `capture_state` never raises between runs (guards against the half-apply).
+
+7. **`test_abandon_conflicted_lane`** (A2): `do_abandon(session, lane)` on a conflicted lane
+   deletes the bookmark without raising `RevsetError`.
+
+8. **`test_doctor_flags_conflicted_lane`** (A6): `run_doctor(repo_root)` emits a non-OK check
+   naming the conflicted lane and pointing at `gitman reconcile` (closes the doctor/status
+   disagreement).
+
+---
+
+## Open questions / risks
+
+- **Side-selection policy.** "Prefer the remote (pushed) side" is the safe default for a
+  forge-merge, but a conflicted bookmark can also arise from *local* lands the user wants to
+  keep. `reconcile` defaulting to the remote side could discard un-pushed local commits on the
+  lane. Mitigation: only auto-pick-remote when the remote side ⊇ the local side (ancestor check)
+  or the range is empty (merged); otherwise *report* the conflicted lane and require an explicit
+  choice (`reconcile --abandon` to drop, or a future `--keep-local`). Don't silently discard.
+
+- **`Lane.head` optionality.** Surfacing a conflicted lane with no single head touches
+  `models.py` and `render.py`. Keep the blast radius small: a conflicted lane renders as
+  `<name> CONFLICTED (diverged from origin)` rather than a head/diff summary.
+
+- **`delete_bookmark` leaves the remote-tracking row.** After retiring, `<lane>@origin` lingers
+  until pruned; the report's recovery needed `git push --delete` + `fetch --prune`. gitman's
+  existing ref-healing handles the local `refs/heads` side, but a still-live *remote branch* is
+  only removed by `_retire_lane`'s best-effort `git_push(..., delete=True)` (core.py:704). Decide
+  whether `reconcile` should also best-effort delete the remote branch (it should, to match the
+  manual recovery) — but gate it so a fetch-only/offline reconcile doesn't fail.
+
+- **Interaction with `do_adopt`'s survivor loop.** Once §1 lands, a conflicted *lane* reaches
+  `_reconcile_lane_against_adopted_trunk` (core.py:714), which still does
+  `view.log(f"{trunk}..{lane}")` and will re-raise. That loop must gain the same conflicted-lane
+  branch (retire-if-merged / set-to-pushed-tip) so `adopt` end-to-end handles the report's exact
+  scenario, not just `reconcile`. This is part of §2's reach and must be covered by test 3.

--- a/.scratch/projects/11-conflicted-bookmark-command-deadlock/REPORT.md
+++ b/.scratch/projects/11-conflicted-bookmark-command-deadlock/REPORT.md
@@ -1,0 +1,187 @@
+# Issue report: a conflicted bookmark deadlocks *every* gitman command after a forge PR merge
+
+**Date:** 2026-06-30
+**Reporter:** field report from the `flora` repo (a downstream consumer)
+**gitman:** 0.2.2 · **pyjutsu:** 0.8.0 (jj-lib 0.42.0) · colocated jj + git
+**Severity:** High — gitman became fully unusable (no command could run, including its own
+recovery commands) and only plain `git` could dig the repo out.
+**Related prior work:** [`06-stray-tags-and-divergent-reconcile`](../06-stray-tags-and-divergent-reconcile),
+[`07-forge-pr-trunk-reconcile`](../07-forge-pr-trunk-reconcile),
+[`09-adopt-colocation-hardening`](../09-adopt-colocation-hardening). This is a recurrence in
+that same family (forge-side merges + divergent trunk + colocation), with a **new, more severe
+symptom**: a *conflicted jj bookmark* that makes the revset name unresolvable, so every command
+that references the lane — including `status`, `reconcile`, and `abandon` — aborts before doing
+any work.
+
+---
+
+## 1. Summary
+
+A normal "merge the PR on GitHub, then resync local" workflow left the repo in a state where
+**every gitman invocation died with the same error**:
+
+```
+bad revision/revset: Name `data-train-pipeline` is conflicted
+```
+
+`gitman status`, `adopt`, `adopt --force`, `abandon <lane>`, `reconcile`, and
+`reconcile --abandon` all aborted with that message. `gitman doctor` simultaneously reported
+**HEALTHY** ("jj bookmarks ↔ git refs in sync"), so the diagnostic tool and the operational
+tools disagreed about whether the repo was broken.
+
+The repo was only recovered with **raw git** (`reset --hard`, `push --delete`, `fetch --prune`),
+after which gitman's own commands started working again. For a tool whose entire value
+proposition is "never touch raw jj/git," needing to bypass it to unbreak it is the core problem.
+
+---
+
+## 2. Environment & setup that led in
+
+- Colocated jj + git, `gitman` as the only intended VC interface.
+- A single long-lived lane, `data-train-pipeline`, that had been `publish`ed (pushed) several
+  times over a multi-session effort.
+- **Trunk was already divergent before the merge.** Local `main` (`ece1bde…`, with data-stage
+  commit `de9192e…`) held the *same logical content* as `origin/main` (`4f2458d…`, data-stage
+  commit `1391bc3…`) **but with different commit hashes** — the data-stage PR #2 had been merged
+  on the forge with squash/merge hashes that local trunk never adopted. So local and remote
+  trunk were two histories with overlapping content. `gitman status` flagged this the whole time
+  ("local main is 2 behind, 2 ahead origin — run `gitman adopt`").
+
+## 3. What happened (timeline)
+
+1. Lane `data-train-pipeline` was published; `origin/data-train-pipeline` = `519499c…`.
+2. **On the forge (GitHub), PR #3 was merged.** To resolve conflicts the maintainer did a
+   *"Merge branch 'main' into data-train-pipeline"* (commit `ddb2f40…`) on the PR branch, then
+   merged the PR → `origin/main` = `975d7c4…`. This is a completely ordinary GitHub merge flow.
+3. Locally: `git fetch` updated `origin/data-train-pipeline` (`519499c…` → `ddb2f40…`) and
+   `origin/main` (`4f2458d…` → `975d7c4…`). The **local jj bookmark `data-train-pipeline` still
+   pointed at the old `519499c…`-era position**, while its remote-tracking counterpart had moved
+   to `ddb2f40…`. jj now considered the bookmark **conflicted** (local vs remote positions
+   diverged).
+4. `gitman adopt` (the action the status note itself recommended) →
+   `bad revision/revset: Name 'data-train-pipeline' is conflicted`.
+5. `gitman adopt --force` → same error (force never got a chance to act).
+6. `gitman status` → **same error** (couldn't even render).
+7. `gitman abandon data-train-pipeline` → same error.
+8. `gitman reconcile` → same error, but it **partially mutated** state: `doctor` flipped from
+   "1 bookmark out of sync" to "1 leftover git ref(s): data-train-pipeline", then on a second
+   run reported HEALTHY — yet `status` *still* errored. Half-applied recovery.
+9. `gitman reconcile --abandon` → same error.
+
+At this point gitman was a brick: no command — including the two documented recovery paths
+(`reconcile`, `abandon`) — could run.
+
+## 4. Recovery (raw git, because nothing else worked)
+
+```bash
+git switch main
+git reset --hard origin/main              # local main → 975d7c4 (merged trunk)
+git push origin --delete data-train-pipeline   # merged remote branch was STILL there, feeding the conflict
+git fetch --prune                          # drop the stale remote-tracking ref
+gitman reconcile                           # NOW works → "re-synced colocated git ref(s): main"
+gitman adopt                               # NOW works → "adopted origin/main → main @ 975d7c4"
+```
+
+The key insight in recovery: the conflicted bookmark had **two sides** (local position +
+remote-tracking position). Deleting `origin/data-train-pipeline` and pruning removed the remote
+side, so there was nothing left to "conflict" against — and only *then* could gitman's own
+reconcile/adopt run.
+
+---
+
+## 5. Root cause
+
+**Primary:** gitman has no resilient handling for a **conflicted jj bookmark on a lane**. Its
+commands resolve the lane by *name* (revset `data-train-pipeline`); jj refuses to resolve a
+conflicted bookmark name; the command aborts before reaching any logic. Because *adopt*,
+*reconcile*, and *abandon* all resolve the lane name up front, the very operations meant to
+clear the condition are gated behind the condition. **Deadlock by design.**
+
+**Trigger:** a forge-side PR merge that (a) advances `origin/<lane>` with a merge commit the
+local bookmark hasn't seen, and (b) leaves the merged remote branch undeleted. Both are the
+GitHub default. This is the single most common way a published lane ends a its life, so the
+trigger is not exotic — it's the happy path.
+
+**Aggravators:**
+- **Divergent trunk (same content, different hashes).** Because local `main` never adopted the
+  forge's PR #2 hashes, `adopt` refused to fast-forward and demanded `--force` — and `--force`
+  then died on the same bookmark revset, so the escape hatch was also blocked.
+- **`doctor` vs `status` disagreement.** `doctor` said HEALTHY while every operational command
+  failed. A health check that can't see a repo-bricking condition trains users to distrust it.
+- **Non-atomic `reconcile`.** It mutated state (bookmark → leftover ref) yet still errored,
+  leaving a *different* broken state on each run — hard to reason about.
+
+---
+
+## 6. What would have prevented it
+
+### A. In gitman (highest leverage)
+
+1. **Make lane-targeting commands tolerate a conflicted bookmark.** Resolve lanes by a stable
+   handle (change id / the underlying commit) rather than by a name that can become an
+   unresolvable revset. At minimum, *catch* the "Name is conflicted" revset error and route it
+   into the recovery path instead of aborting.
+2. **`reconcile` / `abandon` must operate *on* conflicted bookmarks, not be blocked by them.**
+   These are the recovery tools; they are exactly the commands that must run when a bookmark is
+   conflicted. A `gitman reconcile` that detects a conflicted lane bookmark should be able to
+   pick a side (prefer remote-tracking, or prompt) and/or `jj bookmark forget` it.
+3. **Auto-detect "lane was merged & deleted on the forge."** When `origin/<lane>` disappears or
+   its tip is an ancestor of `origin/<trunk>`, `adopt`/`sync` should recognize the lane as merged
+   and **retire it automatically** (forget the bookmark, prune the remote-tracking ref) instead
+   of treating the divergence as a conflict to choke on. This is the natural completion of
+   [`07-forge-pr-trunk-reconcile`](../07-forge-pr-trunk-reconcile).
+4. **Make `adopt --force` actually forceful.** `--force` should bypass the name-resolution that
+   aborts the non-force path — today it dies at the same point, so it isn't an escape hatch.
+5. **Make `reconcile` atomic.** Either fully reconcile or change nothing; never leave a
+   *different* broken state (bookmark-conflict → leftover-ref) on partial failure.
+6. **`doctor` must surface this condition.** A conflicted lane bookmark that breaks every command
+   is the definition of unhealthy; `doctor` reporting HEALTHY in that state is a bug. Add a check:
+   "lane bookmark `<x>` is conflicted → run `gitman reconcile` (and here's the manual escape)."
+7. **Better error → next action.** `bad revision/revset: Name '<lane>' is conflicted` is a
+   leaked jj internal. It should read like: *"lane `<lane>` diverged from its pushed branch
+   (likely merged on the forge). Run `gitman reconcile` / `gitman land --merged` to retire it."*
+
+### B. In the workflow (what we could have done)
+
+8. **`gitman adopt` immediately after every forge merge**, *before* the local bookmark drifts —
+   and ideally `gitman` should offer a "the PR merged, sync me" one-shot. (We deferred adopt
+   while the status note nagged for it across multiple sessions; the longer the lane lived
+   post-divergence, the worse the eventual reconcile.)
+9. **Don't let trunk diverge in the first place.** The whole mess sat on a local `main` that had
+   drifted from `origin/main` (different hashes for already-merged work). Adopting the forge
+   trunk promptly after PR #1/#2 merged would have removed the aggravator that blocked `--force`.
+10. **Delete the branch on merge** (GitHub "auto-delete head branches", or gitman doing it on
+    `land`). The lingering `origin/data-train-pipeline` was actively *feeding* the conflict;
+    removing it was the step that unblocked recovery.
+11. **Smaller, shorter-lived lanes.** One mega-lane (multiple features + WIP) maximized both the
+    merge-conflict surface on the forge and the blast radius of the bad bookmark.
+
+### C. Escalation guidance (for agents/users)
+
+12. **When `status`, `adopt`, *and* `abandon` all fail with the same error, stop retrying gitman
+    and drop to git.** Recovery was ~4 plain-git commands and a couple of minutes. Document a
+    "gitman is wedged → git escape hatch" runbook (the §4 sequence) so users don't thrash. The
+    irony — that a "never touch raw git" tool needs a documented raw-git rescue — is itself the
+    strongest argument for fixes A1–A3.
+
+---
+
+## 7. Minimal repro (for a regression test)
+
+1. Create + publish a lane `L` on trunk `T`.
+2. On the forge: merge a commit into `origin/main` *and* advance `origin/L` with a merge commit
+   (simulating "merge main into L, then merge PR"). Do **not** delete `origin/L`.
+3. `git fetch` locally so the local bookmark `L` and its remote-tracking position diverge.
+4. Run `gitman status`. **Expected:** a readable status + a clear "lane L was merged; reconcile"
+   hint. **Actual (0.2.2):** `bad revision/revset: Name 'L' is conflicted`, and the same on
+   `adopt`/`abandon`/`reconcile`.
+
+---
+
+## 8. Net effect on the downstream repo
+
+No data was lost — the forge merge (`975d7c4`) correctly contained all the work, and local was
+ultimately fast-forwarded to it. But reaching that state required abandoning gitman mid-flow and
+hand-driving git, which is precisely the failure mode gitman exists to prevent. The fixes in §6.A
+(especially A1–A3 and A6) would turn this from "brick + raw-git rescue" into "`gitman adopt`
+retires the merged lane and moves on."

--- a/devenv.lock
+++ b/devenv.lock
@@ -191,7 +191,7 @@
     "pyjutsu": {
       "flake": false,
       "locked": {
-        "ref": "refs/heads/main",
+        "ref": "refs/heads/docs/11-split-binding-issue",
         "type": "git",
         "url": "file:///home/andrew/Documents/Projects/Pyjutsu"
       },

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -52,6 +52,14 @@ def map_pyjutsu_error(exc: PyjutsuError) -> GitmanError:
     if isinstance(exc, GitError):
         return GitmanError(f"git operation failed: {exc}", exit_code=1)
     if isinstance(exc, RevsetError):
+        # A conflicted bookmark name ("Name `X` is conflicted") is a recoverable VC state, not a bad
+        # revset typed by the user — route it to exit 1 + the recovery verb (issue 11 backstop; the
+        # structural reads in capture_state mean the common paths no longer reach here).
+        if "is conflicted" in str(exc):
+            return GitmanError(
+                f"a bookmark diverged from its pushed branch ({exc}) — run `gitman reconcile`.",
+                exit_code=1,
+            )
         return GitmanError(f"bad revision/revset: {exc}", exit_code=3)
     if isinstance(exc, (WorkspaceError, BackendError, WorkingCopyError, JjCliError)):
         return GitmanError(f"infra/config: {exc}", exit_code=2)
@@ -707,6 +715,64 @@ def _retire_lane(session: Session, trunk: str, lane: str, published_before: set[
             notes.append(f"remote branch '{lane}' not deleted (delete it manually): {exc}")
 
 
+def _resolve_conflicted_lane(
+    session: Session,
+    trunk: str,
+    lane: str,
+    *,
+    abandon: bool,
+    notes: list[str],
+) -> str:
+    """Clear a *conflicted* lane bookmark structurally (issue 11) and return 'retired' or 'resolved'.
+
+    A conflicted lane names two commits (its local side + its diverged pushed side), so its name
+    can't be resolved as a revset — `set_bookmark`/`delete_bookmark` act on it structurally, the way
+    `do_adopt`'s `--force` resolves a conflicted *trunk*. This is `reconcile`'s helper (the sole verb
+    that clears conflicted lanes); the policy is work-preserving and undoable:
+
+      * `abandon`, or the lane is fully forge-merged (pushed side ∈ trunk AND no extra local
+        commits) → **retire**: abandon any local-only commits the merge superseded (by commit-id —
+        a divergent change-id is ambiguous), delete the bookmark. Leaves no strays.
+      * otherwise → **resolve**: pin the bookmark to its local side so the *name* resolves again,
+        turning the conflict into an ordinary ahead/behind the user can `sync`/`publish`/`abandon`.
+        Never silently drops un-pushed local work.
+
+    The pushed (remote-tracking) side is left on `<lane>@<remote>`: with the local bookmark resolved
+    there's nothing left to conflict against, and a still-live remote branch is harmless (a later
+    `git fetch --prune` or forge delete clears it). reconcile stays a *local* recovery — it never
+    pushes a branch deletion (that's `adopt`/`land`'s forge job).
+    """
+    from gitman.state import _conflicted_lanes, _remote_target
+
+    view = session.view()
+    targets = _conflicted_lanes(view, trunk).get(lane, [])
+    if not targets:  # not actually conflicted — nothing to clear (defensive; caller pre-checks)
+        return "resolved"
+    remote_tip = _remote_target(view, lane)
+    local_tip = next((t for t in targets if t != remote_tip), targets[0])
+    local_ahead = view.log(f"{trunk}..{local_tip}")
+    fully_merged = remote_tip is not None and not view.log(f"{trunk}..{remote_tip}") and not local_ahead
+
+    with session.ws.transaction("gitman:reconcile-conflicted-lane", auto_snapshot=False) as tx:
+        if abandon or fully_merged:
+            for c in local_ahead:  # empty in the common forge-merge shape (local side ∈ trunk)
+                tx.abandon(c.commit_id)
+            tx.delete_bookmark(lane)
+            action = "retired"
+        else:
+            tx.set_bookmark(lane, local_tip)  # commit-id arg resolves even when the name can't
+            action = "resolved"
+
+    if action == "retired":
+        notes += _cleanup_workspace(session, lane)
+        notes.append(f"retired conflicted lane '{lane}'.")
+    else:
+        notes.append(
+            f"resolved conflicted lane '{lane}' to its local tip — `gitman sync` to rebase onto {trunk}."
+        )
+    return action
+
+
 class _SurvivorConflict(Exception):
     """Internal sentinel: roll back a conflicting survivor rebase tx without committing it."""
 
@@ -735,7 +801,22 @@ def _reconcile_lane_against_adopted_trunk(
         sync`, or abandons it if the conflict is because the lane is an already-merged duplicate.
       * post-rebase range all empty  → merged → retire (abandon the emptied commits + delete bookmark).
       * otherwise                    → genuine survivor → keep the rebase onto the new trunk.
+
+    A lane the fetch left *conflicted* (its pushed side diverged — the report's scenario) is NOT
+    rebased here: rebasing a lane that shares an un-merged ancestor with its diverged pushed side
+    drags that side along and orphans it as a stray (which the postcondition then reverts). Clearing
+    a conflicted bookmark is `reconcile`'s job (it can retire it or preserve un-pushed work without
+    orphaning a side), so refuse with a clean pointer and let the guard roll the adopt back (issue 11).
     """
+    from gitman.state import _conflicted_lanes
+
+    if lane in _conflicted_lanes(session.view(), trunk):
+        raise GitmanError(
+            f"lane '{lane}' diverged from its pushed branch (conflicted bookmark) — run "
+            f"`gitman reconcile` to retire/resolve it, then re-run `gitman adopt`.",
+            exit_code=1,
+        )
+
     if not session.view().log(f"{trunk}..{lane}"):  # merge-commit: already an ancestor of trunk
         _retire_lane(session, trunk, lane, published_before, notes)
         retired.append(lane)
@@ -771,7 +852,7 @@ def _adopt_dry_run(session: Session, trunk: str, remote: str):
     from gitman.invariants import repo_lock
     from gitman.lanes import lane_names
     from gitman.models import IntentResult
-    from gitman.state import _trunk_conflicted, capture_state
+    from gitman.state import _conflicted_lanes, _trunk_conflicted, capture_state
 
     messages: list[str] = []
     with repo_lock(session.repo_root):
@@ -809,8 +890,11 @@ def _adopt_dry_run(session: Session, trunk: str, remote: str):
             if diverged:
                 messages.append("survivor-lane preview unavailable until trunk is resolved (`--force`).")
             else:
+                conflicted_lanes = _conflicted_lanes(view, trunk)
                 for lane in sorted(surviving):
-                    if not view.log(f"{trunk}..{lane}"):
+                    if lane in conflicted_lanes:  # name unresolvable — don't `view.log` it (issue 11)
+                        messages.append(f"conflicted lane — run `gitman reconcile` first: {lane}")
+                    elif not view.log(f"{trunk}..{lane}"):
                         messages.append(f"would retire (already an ancestor of trunk): {lane}")
                     else:
                         messages.append(f"would rebase onto trunk (retire if emptied): {lane}")

--- a/src/gitman/doctor.py
+++ b/src/gitman/doctor.py
@@ -136,6 +136,28 @@ def run_doctor(repo_root: Path, config: GitmanConfig | None = None) -> DoctorRep
                 bits.append(f"{len(leftover)} leftover git ref(s): {', '.join(leftover)}")
             checks.append(Check(WARN, "colocated-refs", "; ".join(bits) + " — run `gitman reconcile`"))
 
+    # Conflicted lane bookmark (issue 11): a lane whose local + pushed positions diverged (typically a
+    # forge PR merge) names two commits, so any revset on it raises and used to wedge every command.
+    # `colocated_ref_desync` deliberately *skips* conflicted bookmarks, so it can't see this — a
+    # dedicated structural read closes the doctor-vs-status blind spot that reported HEALTHY while the
+    # repo was bricked. WARN (recoverable): `gitman reconcile` retires/resolves it.
+    if ws is not None and cfg.trunk:
+        try:
+            from gitman.state import _conflicted_lanes
+
+            conflicted = sorted(_conflicted_lanes(ws.head(), cfg.trunk))
+        except Exception:  # noqa: BLE001 — a probe failure must not fail doctor
+            conflicted = []
+        if conflicted:
+            checks.append(
+                Check(
+                    WARN,
+                    "lane-conflicts",
+                    f"lane bookmark(s) conflicted (diverged from origin): {', '.join(conflicted)} "
+                    "— run `gitman reconcile`",
+                )
+            )
+
     return DoctorReport(checks)
 
 

--- a/src/gitman/models.py
+++ b/src/gitman/models.py
@@ -72,7 +72,7 @@ class Lane(BaseModel):
 
     name: str  # = bookmark = git branch (readable)
     state: LaneState = LaneState.draft
-    head: Change
+    head: Change | None = None  # None for a *conflicted* lane bookmark — it names no single commit
     workspace: str | None = None  # isolated workspace dir, if any
     conflict: bool = False
     ahead: int = 0  # changes vs trunk

--- a/src/gitman/reconcile.py
+++ b/src/gitman/reconcile.py
@@ -55,24 +55,35 @@ def _heal_colocated_refs(session: Session) -> list[str]:
 
 
 def do_reconcile(session: Session, abandon_: bool):
+    from gitman.core import _resolve_conflicted_lane
     from gitman.invariants import repo_lock, write_undo_checkpoint
     from gitman.models import IntentResult
-    from gitman.state import capture_state, colocated_ref_desync, find_strays
+    from gitman.state import _conflicted_lanes, capture_state, colocated_ref_desync, find_strays
 
     trunk = require_trunk(session.config)
     with repo_lock(session.repo_root):
         view = session.fresh_view()  # snapshot dirty @ first
+        conflicted = _conflicted_lanes(view, trunk)
         strays = find_strays(view, trunk)
         mismatched, leftover = colocated_ref_desync(view, session.repo_root)
-        if not strays and not mismatched and not leftover:
+        if not conflicted and not strays and not mismatched and not leftover:
             return IntentResult(
                 intent="reconcile", outcome="CLEAN", messages=["already canonical — no strays, refs in sync."]
             )
 
         op_before = session.ws.head_operation()
-        ref_notes = _heal_colocated_refs(session)  # gap B: heal git-ref drift first
-        existing = {b.name for b in view.bookmarks() if b.remote is None}
         actions: list[str] = []
+        # Conflicted lanes FIRST: clearing them is what unwedges the repo (issue 11), and retiring
+        # one can orphan local commits, so strays must be (re-)scanned afterwards. Local recovery —
+        # don't push-delete the remote branch here (that's a forge action; `adopt` owns it).
+        if conflicted:
+            for lane in sorted(conflicted):
+                _resolve_conflicted_lane(session, trunk, lane, abandon=abandon_, notes=actions)
+            view = session.fresh_view()  # resolving may have orphaned local commits → re-scan
+            strays = find_strays(view, trunk)
+
+        ref_notes = _heal_colocated_refs(session)  # gap B: heal git-ref drift (also clears retired refs)
+        existing = {b.name for b in session.view().bookmarks() if b.remote is None}
         if strays:
             with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
                 for change in strays:

--- a/src/gitman/render.py
+++ b/src/gitman/render.py
@@ -40,12 +40,17 @@ def _remote_relation(trunk) -> str:
 def _lane_line(lane: Lane, current: str | None) -> str:
     here = lane.name == current
     marker = "*" if here else " "
-    plural = "change" if lane.change_count == 1 else "changes"
-    counts = f"{lane.change_count} {plural}, {_diff_str(lane.insertions, lane.deletions)}"
+    # A conflicted lane bookmark (head is None) names no single commit — show the divergence, not a
+    # diff summary, and point at the recovery verb.
+    if lane.head is None:
+        counts = "CONFLICTED (diverged from origin — `gitman reconcile`)"
+    else:
+        plural = "change" if lane.change_count == 1 else "changes"
+        counts = f"{lane.change_count} {plural}, {_diff_str(lane.insertions, lane.deletions)}"
     extra = []
     if lane.workspace:
         extra.append(f"ws {lane.workspace}")
-    if lane.conflict:
+    if lane.conflict and lane.head is not None:
         extra.append("CONFLICT (not blocked — resolve later)")
     if lane.pr:
         extra.append(f"PR #{lane.pr.number}")

--- a/src/gitman/state.py
+++ b/src/gitman/state.py
@@ -85,6 +85,32 @@ def _trunk_conflicted(view: RepoView, trunk: str) -> bool:
     return any(b.name == trunk and b.remote is None and b.conflicted for b in view.bookmarks())
 
 
+def _conflicted_lanes(view: RepoView, trunk: str) -> dict[str, list[str]]:
+    """`{lane_name: target_ids}` for every *conflicted* local lane bookmark (≠ trunk).
+
+    A lane bookmark goes conflicted when its local position and its remote-tracking position
+    diverge (the classic shape: a forge PR merge advances `origin/<lane>` with a merge commit the
+    local bookmark never saw). Resolving such a name in a revset raises `RevsetError: Name is
+    conflicted`, which used to crash `capture_state` — and therefore the precheck of *every* guarded
+    intent (issue 11). Read it the same structural way `_trunk_conflicted` reads trunk: off
+    `view.bookmarks()`, never `resolve()`. The two `target_ids` are the lane's two sides."""
+    return {
+        b.name: list(b.target_ids)
+        for b in view.bookmarks()
+        if b.remote is None and b.name != trunk and b.conflicted
+    }
+
+
+def _remote_target(view: RepoView, name: str) -> str | None:
+    """The single commit id of the `<name>@<remote>` tracking row (the lane's *pushed* side), if a
+    real remote (not the colocated `git` backing) tracks it. The remote-tracking row is never
+    conflicted, so it resolves structurally even when the local bookmark `name` does not."""
+    for b in view.bookmarks():
+        if b.name == name and b.remote not in (None, "git") and len(b.target_ids) == 1:
+            return b.target_ids[0]
+    return None
+
+
 def _trunk_remote_relation(session: Session, view: RepoView, trunk: str) -> tuple[int, int, str | None]:
     """(behind, ahead, remote) of the local trunk bookmark vs its `<trunk>@<remote>` row.
 
@@ -228,8 +254,25 @@ def capture_state(session: Session) -> RepoState:
     wc = view.working_copy()
     current_lane = next((b for b in wc.bookmarks if b != trunk_name), None)
 
+    # A conflicted LANE bookmark is the lane-level analogue of a conflicted trunk: its name can't be
+    # resolved as a revset, so it must be read structurally and reported off-canonical (recovery is
+    # `gitman reconcile`), never resolved — else the lane loop below crashes the whole capture, and
+    # with it the precheck of every guarded intent (issue 11). Detected once, up front.
+    conflicted = _conflicted_lanes(view, trunk_name)
+
     lanes: list[Lane] = []
     for name in sorted(local_names - {trunk_name}):
+        if name in conflicted:
+            lanes.append(
+                Lane(
+                    name=name,
+                    state=LaneState.published if name in published else LaneState.draft,
+                    head=None,  # two-sided — it names no single commit
+                    workspace=name if name in workspace_names else None,
+                    conflict=True,
+                )
+            )
+            continue
         head = view.resolve(name)
         change = _change(head, view.diff_stat(name))
         range_changes = view.log(f"{trunk_name}..{name}")
@@ -267,10 +310,18 @@ def capture_state(session: Session) -> RepoState:
     recent_ops = [_op(o) for o in view.operations(10)]
 
     strays = find_strays(view, trunk_name)
-    off_canonical = None
+    reasons: list[str] = []
+    if conflicted:
+        # No "diverged" here, by design: render keys the *trunk*-divergence recovery hint on that
+        # word, whereas a conflicted lane's recovery is `gitman reconcile`, not `adopt`.
+        reasons.append(
+            f"lane(s) {', '.join(sorted(conflicted))} are conflicted with their pushed branch "
+            f"(likely forge-merged) — run `gitman reconcile`."
+        )
     if strays:
         ids = ", ".join(c.change_id for c in strays)
-        off_canonical = f"change(s) {ids} belong to no lane (edited outside Gitman?)."
+        reasons.append(f"change(s) {ids} belong to no lane (edited outside Gitman?).")
+    off_canonical = " ".join(reasons) if reasons else None
 
     notes: list[str] = []
     if session.is_stale():

--- a/tests/test_conflicted_lane.py
+++ b/tests/test_conflicted_lane.py
@@ -1,0 +1,249 @@
+"""Issue 11: a *conflicted lane bookmark* must never wedge gitman.
+
+When a lane's local position and its pushed position diverge (the classic shape: a forge PR merge
+advances `origin/<lane>` with a commit the local bookmark never saw), the bookmark goes conflicted
+and its *name* stops resolving as a revset. That used to crash `capture_state` — and therefore the
+precheck of every guarded intent, *including* the recovery verbs — so the only way out was raw git.
+
+These tests pin the fix: reads are structural (no command crashes), `status`/`doctor` surface it,
+`reconcile` retires/resolves it, and `adopt` clears a lane the fetch conflicts mid-flight. In-process
+over pyjutsu, two colocated repos (work + bare origin); the forge side is raw git in throwaway clones
+(mirrors `tests/test_adopt_integration.py`).
+See .scratch/projects/11-conflicted-bookmark-command-deadlock/{REPORT,ISSUE_ANALYSIS}.md.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from pyjutsu import Workspace
+from pyjutsu.errors import RevsetError
+
+from gitman.config import GitmanConfig
+from gitman.core import GitmanError, do_abandon, do_adopt
+from gitman.doctor import WARN, run_doctor
+from gitman.reconcile import do_reconcile
+from gitman.session import Session
+from gitman.state import _conflicted_lanes, capture_state
+
+CFG = GitmanConfig(trunk="main")
+
+
+def _sess(d: Path) -> Session:
+    return Session.load(d, CFG)
+
+
+def _git(*args, cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=f@x", "-c", "user.name=forge", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _with_remote(tmp_path: Path) -> tuple[Path, Path, Workspace]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    ws = Workspace.init(work, colocate=True)
+    (work / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    ws.add_remote("origin", str(remote))
+    ws.git_push("origin", "main", allow_new=True)
+    return work, remote, ws
+
+
+def _make_lane(ws: Workspace, work: Path, lane: str, fn: str, content: str) -> None:
+    """A one-commit lane, published to origin, with @ parked back on trunk."""
+    with ws.transaction(f"start {lane}") as tx:
+        tx.new("main")
+        tx.create_bookmark(lane, "@")
+    (work / fn).write_text(content)
+    ws.snapshot()
+    with ws.transaction(f"describe {lane}") as tx:
+        tx.describe("@", f"{lane} commit")
+    with ws.transaction(f"park {lane}") as tx:
+        tx.new("main")
+    ws.git_push("origin", lane, allow_new=True)
+
+
+def _clone(remote: Path, tmp_path: Path, tag: str) -> Path:
+    other = tmp_path / f"other-{tag}"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True, capture_output=True)
+    return other
+
+
+def _forge_advance_lane(remote: Path, tmp_path: Path, lane: str, fn: str, content: str) -> None:
+    """Advance `origin/<lane>` with a NEW forge-side commit (branch kept) — the remote side."""
+    other = _clone(remote, tmp_path, f"adv-{lane}")
+    _git("checkout", lane, cwd=other)
+    (other / fn).write_text(content)
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", f"forge advances {lane}", cwd=other)
+    _git("push", "origin", lane, cwd=other)
+
+
+def _diverge_lane_locally(ws: Workspace, work: Path, lane: str, fn: str, content: str) -> None:
+    """Advance the *local* `<lane>` bookmark with a divergent commit (sibling of the forge tip)."""
+    with ws.transaction(f"local-advance {lane}") as tx:
+        tx.new(lane)
+        tx.set_bookmark(lane, "@")
+    (work / fn).write_text(content)
+    ws.snapshot()
+    with ws.transaction(f"describe local {lane}") as tx:
+        tx.describe("@", f"local advance {lane}")
+    with ws.transaction("park") as tx:
+        tx.new("main")
+
+
+def _make_conflicted(tmp_path: Path, *, fetch: bool = True) -> tuple[Path, Path, Workspace]:
+    """Build a repo whose lane `L` has a conflicted bookmark (local tip ⟂ pushed tip).
+
+    With `fetch=True` (status/reconcile/doctor cases) the divergence is materialized now; with
+    `fetch=False` (the adopt case) it's left for `adopt`'s own fetch to surface mid-flight.
+    """
+    work, remote, ws = _with_remote(tmp_path)
+    _make_lane(ws, work, "L", "shared.txt", "base lane\n")
+    _forge_advance_lane(remote, tmp_path, "L", "forge.txt", "forge side\n")
+    _diverge_lane_locally(ws, work, "L", "local.txt", "local side\n")
+    if fetch:
+        ws.git_fetch("origin")  # brings the diverged pushed position → local L goes conflicted
+    return work, remote, ws
+
+
+# --- 0. the mechanic (fixture self-validation + the exact field symptom) --------------
+
+
+def test_conflicted_lane_is_unresolvable_by_name(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+    view = _sess(work).fresh_view()
+
+    # the report's exact symptom: resolving the conflicted name as a revset raises.
+    with pytest.raises(RevsetError, match="conflicted"):
+        view.resolve("L")
+    with pytest.raises(RevsetError, match="conflicted"):
+        view.log("main..L")
+
+    # but the structural read sees it cleanly, with both sides.
+    conflicted = _conflicted_lanes(view, "main")
+    assert "L" in conflicted
+    assert len(conflicted["L"]) == 2
+
+
+# --- 1. status survives (the §7 minimal repro as a regression test) -------------------
+
+
+def test_status_survives_conflicted_lane(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+
+    state = capture_state(_sess(work))  # MUST NOT raise
+
+    assert state.canonical is False
+    assert "L" in (state.off_canonical or "")
+    assert "reconcile" in (state.off_canonical or "")
+    lane = next(lo for lo in state.lanes if lo.name == "L")
+    assert lane.conflict is True
+    assert lane.head is None
+
+
+# --- 2. guarded intents refuse cleanly instead of leaking a revset crash --------------
+
+
+def test_guarded_intent_refuses_not_crashes(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+
+    # abandon goes through the canonical precheck; it must refuse with a clean VC exit (1) pointing
+    # at reconcile — NOT a leaked `bad revision/revset` (exit 3) or an uncaught RevsetError.
+    with pytest.raises(GitmanError) as exc:
+        do_abandon(_sess(work), "L")
+    assert exc.value.exit_code == 1
+    assert "reconcile" in str(exc.value)
+
+
+# --- 3. reconcile resolves an un-merged conflicted lane (preserves work) --------------
+
+
+def test_reconcile_resolves_unmerged_conflicted_lane(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+
+    res = do_reconcile(_sess(work), abandon_=False)
+
+    assert res.outcome == "RECONCILED", res.messages
+    assert res.exit_code == 0
+    # the name resolves again → conflict cleared, lane kept.
+    assert _conflicted_lanes(_sess(work).fresh_view(), "main") == {}
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert "L" in {lo.name for lo in state.lanes}
+    assert _sess(work).view().resolve("L")  # no longer raises
+
+
+# --- 4. reconcile --abandon retires a conflicted lane ---------------------------------
+
+
+def test_reconcile_abandon_retires_conflicted_lane(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+
+    res = do_reconcile(_sess(work), abandon_=True)
+
+    assert res.outcome == "RECONCILED", res.messages
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert "L" not in {lo.name for lo in state.lanes}  # bookmark gone
+
+
+# --- 5. the report's end-to-end recovery, fully through gitman (no raw git) -----------
+
+
+def test_adopt_defers_conflicted_lane_then_recovers(tmp_path: Path):
+    """The report's headline, done right: with a forge-merged lane conflicted, `adopt` REFUSES
+    cleanly (pointing at reconcile) instead of bricking; `reconcile --abandon` retires the lane; then
+    `adopt` advances trunk to CANONICAL — the whole recovery stays inside gitman, no raw-git rescue."""
+    work, remote, ws = _make_conflicted(tmp_path)  # persistent conflict (already fetched)
+    # forge also advanced trunk (the PR landed), so there is a trunk advance to adopt.
+    other = _clone(remote, tmp_path, "trunk")
+    _git("checkout", "main", cwd=other)
+    (other / "trunkfile.txt").write_text("forge trunk\n")
+    _git("add", ".", cwd=other)
+    _git("commit", "-m", "forge advances main", cwd=other)
+    _git("push", "origin", "main", cwd=other)
+
+    # 1. adopt refuses cleanly — never a leaked revset crash (exit 3) or a brick.
+    blocked = do_adopt(_sess(work), force=False, dry_run=False)
+    assert blocked.outcome == "BLOCKED", blocked.messages
+    assert blocked.exit_code == 1
+    assert "reconcile" in " ".join(blocked.messages).lower()
+
+    # 2. reconcile --abandon retires the conflicted lane (no strays, no drag).
+    rec = do_reconcile(_sess(work), abandon_=True)
+    assert rec.outcome == "RECONCILED", rec.messages
+    assert _conflicted_lanes(_sess(work).fresh_view(), "main") == {}
+
+    # 3. adopt now advances trunk to the forge head, CANONICAL.
+    res = do_adopt(_sess(work), force=False, dry_run=False)
+    assert res.outcome == "ADOPTED", res.messages
+    assert res.exit_code == 0
+    state = capture_state(_sess(work))
+    assert state.canonical
+    assert "L" not in {lo.name for lo in state.lanes}
+
+
+# --- 6. doctor surfaces it (closes the doctor-said-HEALTHY blind spot) ----------------
+
+
+def test_doctor_flags_conflicted_lane(tmp_path: Path):
+    work, _remote, _ws = _make_conflicted(tmp_path)
+
+    report = run_doctor(work, CFG)  # CLI loads trunk from the repo's config; tests pass it in
+
+    check = next((c for c in report.checks if c.name == "lane-conflicts"), None)
+    assert check is not None
+    assert check.level == WARN
+    assert "L" in check.detail
+    assert "reconcile" in check.detail


### PR DESCRIPTION
## Problem

A lane whose local and pushed positions diverge (typically a forge PR merge that advances `origin/<lane>` with a commit the local bookmark never saw) becomes a **conflicted jj bookmark** whose name no longer resolves as a revset. `capture_state` resolved each lane by name, so it crashed — and with it the precheck of **every** guarded intent, *including the recovery verbs* (`status`/`adopt`/`abandon`/`reconcile` all leaked `RevsetError: Name '<lane>' is conflicted`). The repo could only be unwedged with raw git. Field report + design review in `.scratch/projects/11-conflicted-bookmark-command-deadlock/`.

## Fix

**Keystone — structural lane reads.** Generalize `_trunk_conflicted`'s approach to lanes: new `state._conflicted_lanes`/`_remote_target` read off `view.bookmarks()` (never `resolve()`). `capture_state` reports a conflicted lane as a `head=None` Lane, off-canonical, pointing at `reconcile` — so reads/prechecks/postconditions stop crashing and every intent cleanly **refuses (exit 1)** instead of bricking.

**Recovery — `reconcile` is the sole verb that clears it** (`core._resolve_conflicted_lane`): retire a forge-merged lane (abandon local-only commits by commit-id + `delete_bookmark`; no strays) or pin an unmerged one to its local side (preserves un-pushed work); `reconcile --abandon` always retires.

**`adopt` defers to `reconcile`** — refused by precheck for a persistent conflict, clean rollback for a mid-fetch one — rather than rebasing a lane whose diverged pushed side shares an un-merged ancestor (that drag would orphan the side as a stray).

**Follow-ups:** `doctor` flags a conflicted lane (`lane-conflicts` check, closes the doctor-said-HEALTHY blind spot); `map_pyjutsu_error` routes a leaked `is conflicted` RevsetError to exit 1 + a reconcile pointer (was exit 3).

## Tests

`tests/test_conflicted_lane.py` — 7 in-process integration tests: the mechanic, the minimal repro, clean refusal, reconcile retire/resolve, end-to-end recovery (`adopt`→`reconcile --abandon`→`adopt`), doctor. **Full suite 107 passed, ruff clean.**