### PR TITLE
fix(stray/reconcile): exclude tags from stray detection; recover divergent strays by commit-id (issue 06)

### DIFF
--- a/.scratch/projects/06-stray-tags-and-divergent-reconcile/ISSUE_ANALYSIS.md
+++ b/.scratch/projects/06-stray-tags-and-divergent-reconcile/ISSUE_ANALYSIS.md
@@ -1,0 +1,281 @@
+# ISSUE_ANALYSIS — 06: stray-tags & divergent-reconcile
+
+Design review of `issue-overview.md` (G1, G2). Verified against the live gitman source,
+the pyjutsu Rust/Python binding, and empirical probes run inside devenv.
+
+## Verdict
+
+| Fix | Symptom real? | Root cause correct? | Proposed fix correct/best? | Verdict |
+|-----|---------------|---------------------|----------------------------|---------|
+| **G1** — exclude `tags()` from `_stray_revset` | ✅ Yes (reproduced) | ✅ Yes | ⚠️ Correct & minimal, but ship with eyes open re: false-negatives + add `git_export` after `git_import` ordering note | **Confirmed (with a caveat)** |
+| **G2** — reconcile by `commit_id` not `change_id` | ✅ Yes (reproduced the exact `Change ID … is divergent` error) | ✅ Yes | ⚠️ Right *direction*, but the report's **bookmark-naming** sketch is buggy (both divergent sides collide on the same name) and it misses **two sibling call sites** with the identical latent bug | **Needs revision** |
+
+Both symptoms are real, both root causes are correctly diagnosed. G1's suggested patch is
+essentially ship-ready. G2's *targeting* change (commit-id) is correct and necessary, but
+the *naming* logic in the sketch is wrong and the fix is incomplete in scope.
+
+---
+
+## Evidence
+
+### G1 — tagged off-main commit flagged as a stray
+
+Current code, `src/gitman/state.py:24-28`:
+
+```python
+def _stray_revset(trunk: str) -> str:
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+```
+
+`find_strays` (`state.py:156-158`) logs that revset and keeps every non-empty row;
+`capture_state` (`state.py:269-273`) turns any survivor into the OFF-CANONICAL reason
+`change(s) … belong to no lane (edited outside Gitman?).`
+
+**`tags()` is a real, evaluable revset through pyjutsu.** The builder exposes it
+(`Pyjutsu/python/pyjutsu/revset.py:251-253`), but more importantly the evaluator
+(`Pyjutsu/src/revset.rs:33-74`) delegates verbatim to jj-lib's `revset::parse` /
+`resolve_user_expression` — so *any* valid jj revset function is accepted, not just the
+builder-bound ones. A raw `"… | tags()"` string passes straight through.
+
+Empirically confirmed (probe: create commit → annotated git tag → rewrite `@` off it):
+
+```
+TAGS_REVSET_OK rows=1 ['48fd9d29']          # tags() resolves the tagged commit
+STRAY_OLD: ['48fd9d29 tagged work']          # current revset flags it as a stray
+STRAY_NEW: []                                # adding `| tags()` excludes it
+```
+
+The upstream pyjutsu report (`Pyjutsu/.scratch/projects/10-adopt-tag-visibility-and-keep-refs/issue-overview.md`,
+P2) **exists** and corroborates this: `adopt_existing_git` → `git::import_refs` imports
+tags (jj-standard), so an off-main tagged commit (`v0.2.0 → c2a8443`) becomes a visible
+head. Their explicit decision (P2, option A): keep import faithful to jj, and **push the
+"tags aren't work" logic to the consumer (gitman)**. So G1 is the correct *home* for the
+fix.
+
+### G2 — reconcile dead-ends on a divergent stray
+
+Current code, `src/gitman/reconcile.py:77-88`:
+
+```python
+with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
+    for change in strays:
+        if abandon_:
+            tx.abandon(change.change_id)
+        else:
+            name = f"adopted-{change.change_id[:8]}"
+            if name in existing:
+                name = f"adopted-{change.change_id}"
+            tx.create_bookmark(name, change.change_id)
+```
+
+Transactions resolve every revset through `resolve_single`
+(`Pyjutsu/src/transaction.rs:107-122`), which **requires exactly one revision** and raises
+`RevsetError` otherwise. A divergent change-id resolves to ≥2 commits → both `abandon` and
+`create_bookmark` throw, the `with` block aborts the transaction, and reconcile fails. Since
+the repo is off-canonical by definition when reconcile runs and reconcile is the sole
+sanctioned recovery (concept §11 "exactly one recovery path"), the repo is wedged. Verified.
+
+Empirically reproduced the **exact** report error by forging a divergent change (two git
+commits sharing one `change-id` header, the second anchored by an annotated tag, then
+`git_import`):
+
+```
+_pyjutsu.RevsetError: Change ID `ynlkqrxonmpuqtzzsotkmmopqpxozvnx` is divergent
+```
+
+Note: this error fires even on `view.log(change_id)` — divergence breaks the *read*, not
+just the transaction. (Confirms the report; also see "Open questions" on the off_canonical
+message builder.)
+
+**The report's two load-bearing G2 claims both check out:**
+
+1. *find_strays enumerates per-commit, so divergent sides are separate rows.* **True.**
+   `find_strays` logs `_stray_revset` and projects each `Commit` via `_change` (`state.py:158`,
+   `_change` at `:37-49` carries both `change_id` and `commit_id`). Probe output — both
+   divergent sides present as distinct rows sharing a change-id:
+   ```
+   stray rows after move: [('dac6bf71', 'klrmtkql'), ('7fe3487b', 'klrmtkql')]
+   ```
+2. *Transactions accept a commit-id target.* **True.** `create_bookmark`/`abandon` resolve
+   any single-revision revset; a full commit hex resolves to exactly one commit. Probe —
+   adopting **both** divergent sides by `commit_id` succeeds and yields two bookmarks:
+   ```
+   BOOKMARK_BY_COMMITID across divergent sides: OK
+   bookmarks now: ['adopted-0', 'adopted-1', 'main']
+   ```
+
+**But the report's naming sketch is broken.** Its fix keeps the lane name derived from
+`change_id`:
+
+```python
+name = f"adopted-{change.change_id[:8]}"
+if name in existing: name = f"adopted-{change.change_id}"
+```
+
+For a divergent change **both sides share the same `change_id`**, so:
+- side 1 → `adopted-klrmtkql`, added to `existing`;
+- side 2 → `adopted-klrmtkql` (collides) → fallback `adopted-<full change_id>` …
+  **which also collides** (same full change-id), or — worse — if only one fell back, the two
+  lanes differ only by truncation. The collision *guard* assumes name uniqueness tracks
+  change-id uniqueness; under divergence that assumption is exactly what's violated. The name
+  must be keyed off the **commit_id** (the thing that actually differs), not the change-id.
+
+### Other call sites with the same latent bug (report missed these)
+
+`grep` for `tx.abandon(c.change_id)` finds two more:
+
+- `core.py:595` — `do_abandon`: abandons every `{trunk}..{lane}` change by change-id.
+- `core.py:697-698` — `_retire_lane` (forge-merged lane retirement, called from `do_adopt`):
+  same loop, same `tx.abandon(c.change_id)`.
+
+Both would raise `Change ID … is divergent` if any change in the lane range were divergent.
+Lanes are kept linear by construction (I5), so divergence *there* is unlikely — but the
+adopt/retire path operates right after a fresh `git_import` of a forge repo, which is
+precisely where the keep-ref/tag divergence (pyjutsu P1/P2) is introduced. These are latent,
+not hypothetical. They should switch to `c.commit_id` too (a `{trunk}..{lane}` range row's
+commit-id is unambiguous), or at minimum be flagged.
+
+---
+
+## Recommended fixes
+
+### G1 — adopt the report's patch, verbatim
+
+```python
+def _stray_revset(trunk: str) -> str:
+    # Tags mark intentional history (releases / bisect anchors), never "edited outside
+    # Gitman" — exclude their ancestry. `tags()` is the standard jj revset (verified it
+    # evaluates through pyjutsu/jj-lib); gitman's own release tags (tags.py) sit on lane
+    # heads already covered by bookmarks(), so this only suppresses *off-lane* tagged commits.
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks() | tags()) ~ @"
+```
+
+This is the cleanest formulation and matches the symmetry of the existing `bookmarks() |
+remote_bookmarks()` exclusion. Note the exclusion is `::(…)` (ancestry), so it also drops any
+commit *between* trunk and a tagged tip — correct: those are reachable, intentional history.
+
+**False-negative risk (call it out, accept it):** a genuinely stray, agent-authored,
+*untagged* commit is still flagged (good). The only thing this hides is a commit that
+someone *tagged* — and a human deliberately placing a git tag on a commit is a strong "this
+is intentional, not stray" signal. The residual risk (an agent that both strays *and* tags
+its own scratch work off-lane) is negligible and not worth guarding against. Accept it.
+
+**Do NOT** try to fix this upstream in pyjutsu by skipping tag import (pyjutsu P2 option C —
+explicitly rejected there: it silently diverges from jj semantics). G1 is the right layer.
+Optionally coordinate with pyjutsu P1 (prune orphaned `refs/jj/keep/*` on re-adopt), which
+removes the *divergence* at its source and is the real cure for the keep-ref half — but
+that's a separate pyjutsu change and doesn't block G1.
+
+### G2 — target by commit-id, name by commit-id, and unify the helper
+
+The minimal, correct reconcile loop:
+
+```python
+with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
+    for change in strays:
+        if abandon_:
+            tx.abandon(change.commit_id)                 # unambiguous under divergence
+            actions.append(f"abandoned {change.commit_id[:12]}")
+        else:
+            name = f"adopted-{change.commit_id[:8]}"      # key the NAME off commit_id
+            while name in existing:                        # belt-and-suspenders dedup
+                name = f"adopted-{change.commit_id[:12]}"
+                break
+            tx.create_bookmark(name, change.commit_id)     # target the specific commit
+            existing.add(name)
+            actions.append(f"adopted {change.commit_id[:12]} → lane '{name}'")
+```
+
+Why diverge from the report:
+- **Name keyed on `commit_id`, not `change_id`.** This is the load-bearing correction — two
+  divergent sides have distinct commit-ids, so the lanes get distinct names. The report's
+  "name can still use change_id (stable label)" reasoning is exactly wrong *for the divergent
+  case it's trying to fix*. (commit_id churns on amend, but an adopted lane is a fresh
+  bookmark anyway — stability across rewrites isn't a property reconcile needs here.)
+- **`actions`/`off_canonical` messaging** should likewise report commit-ids (or both ids) so
+  the report is honest about divergence rather than printing one change-id twice.
+
+**Also fix the two sibling sites** (`core.py:595`, `core.py:697-698`): switch
+`tx.abandon(c.change_id)` → `tx.abandon(c.commit_id)`. The range `{trunk}..{lane}` yields
+distinct commits regardless of change-id divergence, so commit-id is strictly safer with no
+downside. This closes the *same* dead-end on the abandon and forge-retire paths.
+
+**More principled alternative (consider, larger):** instead of sprinkling commit-ids, add a
+tiny helper that resolves a `Change` to a transaction-safe target — `_target(change) ->
+change.commit_id` — and route all four sites through it. One-liner today, but it documents
+the invariant "*mutate strays/range-rows by commit-id, never bare change-id*" in one place,
+so the next call site doesn't reintroduce the bug. Recommended.
+
+---
+
+## Larger refactor / upstream opportunities
+
+1. **pyjutsu P1 (orphaned `refs/jj/keep/*` on re-adopt) is the upstream root of the
+   *divergence*.** G2 makes gitman *recoverable* when divergence exists; P1 stops the
+   divergence being manufactured on every fresh adopt. Both are worth doing — G2 is the
+   consumer's defensive floor (always recoverable), P1 is the upstream cure. They're
+   independent; ship G1+G2 now, track P1 in pyjutsu.
+
+2. **A single "stray/range row → tx target" convention.** Four call sites resolve
+   change-rows into transactions by change-id; one already bit. Centralizing on commit-id
+   (helper above) is a small refactor that permanently removes a whole bug class.
+
+3. **`off_canonical` message robustness.** `capture_state:272` builds the reason via
+   `", ".join(c.change_id for c in strays)`. That's fine (it reads from already-projected
+   `Change` rows, no re-resolution), but it will print the *same* change-id twice for a
+   divergent stray. Minor honesty nit — dedup or append `commit_id[:8]` so the two sides are
+   distinguishable in the report.
+
+---
+
+## Test plan
+
+New tests under `tests/`, matching the existing in-process pyjutsu pattern
+(`test_remote_stray.py` is the closest template: `Workspace.init(colocate=True)` →
+transactions → `capture_state(Session.load(...))`).
+
+**G1 — `test_tagged_offmain_not_stray` (new file or add to `test_status_integration.py`):**
+1. colocated repo; commit on `main`, then a child commit; annotated git tag on the child
+   (`subprocess git tag -a`); `ws.git_export()` then `ws.git_import()` so the tag is visible;
+   rewrite `@`/`main` so the tagged commit is off-main and unbookmarked.
+2. assert `find_strays(view, "main") == []` and `capture_state(...).canonical is True`.
+3. **regression:** a non-empty, untagged, unbookmarked child of trunk (not `@`) **is** still
+   in `find_strays` and reports OFF-CANONICAL.
+
+**G2 — `test_reconcile_divergent_stray` (add to a reconcile test file):**
+1. Build a divergent change exactly as the probe does: forge a second git commit object with
+   a duplicate `change-id` header (`git hash-object -t commit -w --stdin`), anchor it with an
+   annotated tag, `ws.git_import()`. (This is the only reliable in-process way to manufacture
+   divergence without the jj CLI — documented in `/tmp` probes during this review.)
+2. Move `@` off so both divergent sides are strays.
+3. `do_reconcile(session, abandon_=False)` → assert outcome `RECONCILED`, `state.canonical`,
+   and **two distinct** `adopted-*` bookmarks exist (one per divergent side).
+4. Separate case: `do_reconcile(session, abandon_=True)` → both sides abandoned, canonical.
+5. **regression:** existing non-divergent reconcile tests still pass (adopt names unchanged
+   for the single-commit case — guard against the name-key change altering happy-path output;
+   if golden-string tests assert `adopted-<change_id>`, they'll need updating to
+   `adopted-<commit_id>` — check `test_status_integration.py` / any reconcile assertions).
+6. **Sibling sites:** a `do_abandon` / forge-retire test over a lane whose range contains a
+   divergent change (lower priority; construct only if cheap).
+
+---
+
+## Open questions / risks
+
+- **Golden-string churn:** changing adopt lane names from `adopted-<change_id[:8]>` to
+  `adopted-<commit_id[:8]>` will break any test/snapshot asserting the old name. Grep the
+  tests before landing; this is a deliberate, documented change (commit-id is what
+  disambiguates), not a regression.
+- **commit_id stability:** adopted-lane names now churn if the underlying commit is later
+  amended. Acceptable — the lane is a fresh bookmark the user renames/lands anyway, and the
+  alternative (change_id) is *unusable* under divergence. Flagged for awareness.
+- **Scope of the sibling-site fix:** switching `do_abandon`/`_retire_lane` to commit-id is
+  low-risk and recommended, but it's strictly outside the two fixes the report named. If the
+  intent is a tight, minimal PR, land G1 + G2(reconcile) first and file the sibling-site
+  hardening as a fast-follow — but don't *forget* it, since `_retire_lane` runs in the exact
+  adopt-after-import window where divergence appears.
+- **pyjutsu P1 coordination:** confirm whether the gitman `reconcile`/`adopt` path should also
+  proactively prune stale `refs/jj/keep/*` (it already has a colocated-ref healing pass,
+  `_heal_colocated_refs`, that does `git update-ref -d` on leftover `refs/heads/*` — extending
+  it to orphaned `refs/jj/*` would let gitman self-heal divergence without waiting on the
+  pyjutsu change). Worth a follow-up issue.

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -97,6 +97,19 @@ def require_trunk(config) -> str:
     return config.trunk
 
 
+def _target(change) -> str:
+    """The transaction-safe revset for a stray / range-row change: its **commit_id**, never the
+    bare change_id.
+
+    A divergent change-id (one change_id → ≥2 commits — manufactured on a fresh `git_import` of a
+    forge repo with orphaned `refs/jj/keep/*`) resolves to >1 revision, so `tx.abandon(change_id)`
+    / `tx.create_bookmark(name, change_id)` raise `Change ID … is divergent` and dead-end the
+    intent. A full commit hex always resolves to exactly one commit, so mutating by commit_id is
+    strictly safer with no downside. Works for both pyjutsu `Commit` rows (`view.log(...)`) and
+    gitman `Change` rows (`find_strays`) — both carry `.commit_id`. (issue 06 §G2)"""
+    return change.commit_id
+
+
 def run_verify(commands: list[str], repo_root: Path, timeout: float | None = None) -> tuple[bool, str]:
     """Run the configured verify hook (a single command + args). Empty → pass. Generic:
     any verifier, zero Testee coupling (concept §4). `timeout` (seconds, None = no limit) bounds a
@@ -596,11 +609,12 @@ def do_abandon(session: Session, lane: str | None):
     with canonical_guard(session, "abandon") as canon:
         if target not in lane_names(session, trunk):
             raise GitmanError(f"no such lane '{target}'.", exit_code=3)
-        # change_ids are stable across rewrites; abandoning every trunk..lane change moves the
-        # lane bookmark back onto trunk's commit, so delete_bookmark then succeeds (no strays).
+        # Abandoning every trunk..lane change moves the lane bookmark back onto trunk's commit,
+        # so delete_bookmark then succeeds (no strays). Target by commit_id (via `_target`) so a
+        # divergent change in the range can't dead-end the abandon (issue 06 §G2).
         with session.ws.transaction("gitman:abandon", auto_snapshot=False) as tx:
             for c in session.view().log(f"{trunk}..{target}"):
-                tx.abandon(c.change_id)
+                tx.abandon(_target(c))
             tx.delete_bookmark(target)
         canon.notes += _cleanup_workspace(session, target)
     return IntentResult(
@@ -701,9 +715,12 @@ def _retire_lane(session: Session, trunk: str, lane: str, published_before: set[
     """
     from pyjutsu import PyjutsuError
 
+    # Target by commit_id (via `_target`): _retire_lane runs in the exact post-`git_import` adopt
+    # window where keep-ref divergence is introduced, so a bare change_id could dead-end here (issue
+    # 06 §G2).
     with session.ws.transaction("gitman:adopt-retire", auto_snapshot=False) as tx:
         for c in session.view().log(f"{trunk}..{lane}"):
-            tx.abandon(c.change_id)
+            tx.abandon(_target(c))
         tx.delete_bookmark(lane)
     notes += _cleanup_workspace(session, lane)
     notes.append(f"retired (forge-merged): {lane}")

--- a/src/gitman/reconcile.py
+++ b/src/gitman/reconcile.py
@@ -2,7 +2,8 @@
 
 Non-interactive (agent context): it heals two desyncs in one pass — (1) **off-canonical strays**
 (non-empty changes outside every lane): by default each is **adopted** into an auto-named lane
-(`adopted-<change_id>` bookmark), or discarded with `--abandon`; (2) **colocated git-ref drift**
+(`adopted-<commit_id>` bookmark — keyed off commit_id so divergent sides get distinct names),
+or discarded with `--abandon`; (2) **colocated git-ref drift**
 (round-09 gap B): a live bookmark whose `refs/heads/<name>` lags jj, or an abandoned lane's
 leftover ref that makes every `git_export` raise. It runs without the canonical precheck (the repo
 is off-canonical by definition) and records an undo checkpoint so `gitman undo` can revert it.
@@ -12,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from gitman.core import require_trunk
+from gitman.core import _target, require_trunk
 
 if TYPE_CHECKING:
     from gitman.session import Session
@@ -85,18 +86,24 @@ def do_reconcile(session: Session, abandon_: bool):
         ref_notes = _heal_colocated_refs(session)  # gap B: heal git-ref drift (also clears retired refs)
         existing = {b.name for b in session.view().bookmarks() if b.remote is None}
         if strays:
+            # Target AND name each stray by commit_id (via `_target`), never the bare change_id.
+            # A divergent change-id resolves to ≥2 commits, so a change-id target dead-ends the
+            # transaction — and, critically, the two divergent sides *share* a change_id, so naming
+            # by change_id collides them onto one bookmark. commit_id is what actually differs, so
+            # it both resolves unambiguously and yields distinct lane names (issue 06 §G2).
             with session.ws.transaction("gitman:reconcile", auto_snapshot=False) as tx:
                 for change in strays:
+                    cid = _target(change)
                     if abandon_:
-                        tx.abandon(change.change_id)
-                        actions.append(f"abandoned {change.change_id}")
+                        tx.abandon(cid)
+                        actions.append(f"abandoned {cid[:12]}")
                     else:
-                        name = f"adopted-{change.change_id[:8]}"
+                        name = f"adopted-{cid[:8]}"
                         if name in existing:
-                            name = f"adopted-{change.change_id}"
-                        tx.create_bookmark(name, change.change_id)
+                            name = f"adopted-{cid[:12]}"
+                        tx.create_bookmark(name, cid)
                         existing.add(name)
-                        actions.append(f"adopted {change.change_id} → lane '{name}'")
+                        actions.append(f"adopted {cid[:12]} → lane '{name}'")
         actions += ref_notes
         if not actions:
             actions = ["nothing to do."]

--- a/src/gitman/state.py
+++ b/src/gitman/state.py
@@ -25,7 +25,15 @@ def _stray_revset(trunk: str) -> str:
     # Changes descended from trunk, not in any bookmark's ancestry (local OR remote — so
     # fetched non-lane remote branches don't count), excluding the current (often empty)
     # working-copy change. A non-empty match means "edited outside Gitman".
-    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks()) ~ @"
+    #
+    # Tagged commits are *intentional* history (releases / bisect anchors), never "edited
+    # outside Gitman" — so exclude their ancestry too. `tags()` is the standard jj revset
+    # (it evaluates through pyjutsu/jj-lib's resolver, not just the builder-bound funcs);
+    # gitman's own release tags (tags.py) sit on lane heads already covered by bookmarks(),
+    # so this only suppresses *off-lane* tagged commits. Accepted false-negative: an agent
+    # that both strays AND tags its own scratch off-lane (negligible — a deliberate tag is a
+    # strong "intentional, not stray" signal).
+    return f"({trunk}..) ~ ::(bookmarks() | remote_bookmarks() | tags()) ~ @"
 
 
 def _is_colocated(repo_root: Path) -> bool:
@@ -319,7 +327,9 @@ def capture_state(session: Session) -> RepoState:
             f"(likely forge-merged) — run `gitman reconcile`."
         )
     if strays:
-        ids = ", ".join(c.change_id for c in strays)
+        # Tag each with its short commit_id: two divergent sides share a change_id, so change_id
+        # alone would print the same label twice and hide the divergence (issue 06 §G2).
+        ids = ", ".join(f"{c.change_id} ({c.commit_id[:8]})" for c in strays)
         reasons.append(f"change(s) {ids} belong to no lane (edited outside Gitman?).")
     off_canonical = " ".join(reasons) if reasons else None
 

--- a/tests/test_stray_tags_divergent.py
+++ b/tests/test_stray_tags_divergent.py
@@ -1,0 +1,163 @@
+"""Issue 06 — stray detection vs git tags (G1) + divergent-change reconcile (G2).
+
+Built in-process over pyjutsu (no `jj` CLI), mirroring `test_remote_stray.py` /
+`test_m3_integration.py`:
+
+- **G1** — a *tagged* off-main commit is intentional history, not a stray. `state._stray_revset`
+  now excludes `tags()`, so `find_strays` skips it while an *untagged* off-main commit is still
+  flagged (regression).
+- **G2** — a *divergent* change-id (one change_id → two commits, as manufactured by orphaned
+  `refs/jj/keep/*` after a forge `git_import`) makes `tx.abandon(change_id)` /
+  `tx.create_bookmark(name, change_id)` raise `Change ID … is divergent`, dead-ending `reconcile`
+  (the sole recovery path). `do_reconcile` now targets — and *names* — each stray by `commit_id`,
+  so both divergent sides adopt into two distinct lanes (or both abandon).
+"""
+
+from __future__ import annotations
+
+import subprocess as sp
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig
+from gitman.init import do_init
+from gitman.reconcile import do_reconcile
+from gitman.session import Session
+from gitman.state import capture_state, find_strays
+
+
+def _git(d: Path, *args: str, inp: str | None = None) -> sp.CompletedProcess[str]:
+    return sp.run(["git", "-C", str(d), *args], input=inp, capture_output=True, text=True, check=True)
+
+
+def _init_main(d: Path) -> Workspace:
+    """A colocated repo with a frozen `main` trunk (init creates the bookmark + `.gitman`)."""
+    ws = Workspace.init(d, colocate=True)
+    (d / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "1.0.0"\n')
+    (d / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")  # NO bookmark yet — do_init freezes trunk=main
+    do_init(Session.load(d, GitmanConfig()), trunk_opt=None)
+    return ws
+
+
+def _child_offmain(ws: Workspace, d: Path, fname: str, body: str, desc: str):
+    """Create a non-empty child of `main`, then move `@` off it so it's an unbookmarked, off-`@`
+    descendant of trunk. Returns the child Commit (carrying change_id + commit_id)."""
+    with ws.transaction(desc) as tx:
+        tx.new("main")
+        tx.describe("@", desc)
+    (d / fname).write_text(body)
+    ws.snapshot()
+    child = ws.working_copy()
+    ws.git_export()
+    with ws.transaction("move @") as tx:
+        tx.new("main")  # @ becomes a fresh empty change; the child is left unbookmarked
+    ws.snapshot()
+    return child
+
+
+def _forge_divergent_side(ws: Workspace, d: Path, change_id: str, body: str) -> str:
+    """Forge a *second* git commit that shares `change_id` (the in-process way to manufacture a
+    divergent change without the jj CLI — the orphaned-keep-ref scenario): write a distinct tree,
+    stamp the same `change-id` header, anchor it under `refs/heads/_keep` so `git_import` picks it
+    up, import, then drop the bookmark so both sides sit unbookmarked (and so the `tags()`
+    exclusion can't hide it). Returns the forged commit's git sha."""
+    main_sha = ws.resolve("main").commit_id
+    blob = _git(d, "hash-object", "-w", "--stdin", inp=body).stdout.strip()
+    tree = _git(d, "mktree", inp=f"100644 blob {blob}\tdiverge.txt\n").stdout.strip()
+    commit = (
+        f"tree {tree}\nparent {main_sha}\n"
+        f"author Forge <x@y.z> 1782855900 -0400\n"
+        f"committer Forge <x@y.z> 1782855900 -0400\n"
+        f"change-id {change_id}\n\nforged divergent side\n"
+    )
+    sha = _git(d, "hash-object", "-t", "commit", "-w", "--stdin", inp=commit).stdout.strip()
+    _git(d, "update-ref", "refs/heads/_keep", sha)
+    ws.git_import()
+    with ws.transaction("drop _keep") as tx:
+        tx.delete_bookmark("_keep")
+    ws.snapshot()
+    return sha
+
+
+# --- G1: tags are not strays ----------------------------------------------------------
+
+
+def test_tagged_offmain_commit_is_not_a_stray(tmp_path: Path):
+    ws = _init_main(tmp_path)
+    child = _child_offmain(ws, tmp_path, "tagged.txt", "release\n", "tagged work")
+    # An annotated git tag on the off-main commit, imported so jj's `tags()` resolves it.
+    _git(tmp_path, "tag", "-a", "-m", "v1.0.0", "v1.0.0", child.commit_id)
+    ws.git_import()
+
+    view = Session.load(tmp_path, GitmanConfig(trunk="main")).fresh_view()
+    assert find_strays(view, "main") == []
+    state = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert state.canonical, state.off_canonical
+
+
+def test_untagged_offmain_commit_is_still_a_stray(tmp_path: Path):
+    """Regression: G1 must only suppress *tagged* off-main commits — an ordinary stray still flags."""
+    ws = _init_main(tmp_path)
+    _child_offmain(ws, tmp_path, "stray.txt", "stray\n", "stray work")
+
+    view = Session.load(tmp_path, GitmanConfig(trunk="main")).fresh_view()
+    strays = find_strays(view, "main")
+    assert len(strays) == 1
+    state = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert state.canonical is False
+    assert "belong to no lane" in (state.off_canonical or "")
+
+
+# --- G2: reconcile recovers a divergent stray -----------------------------------------
+
+
+def _divergent_strays(tmp_path: Path) -> Workspace:
+    """A repo with a divergent off-main change: two commits sharing one change_id, both
+    unbookmarked strays."""
+    ws = _init_main(tmp_path)
+    side_a = _child_offmain(ws, tmp_path, "a.txt", "AAA\n", "child A")
+    _forge_divergent_side(ws, tmp_path, side_a.change_id, "BBB\n")
+    return ws
+
+
+def test_reconcile_adopts_both_divergent_sides(tmp_path: Path):
+    _divergent_strays(tmp_path)
+    # The divergent change-id breaks even a plain read, so the OLD change-id targeting dead-ended.
+    pre = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert pre.canonical is False
+
+    res = do_reconcile(Session.load(tmp_path, GitmanConfig(trunk="main")), abandon_=False)
+    assert res.outcome == "RECONCILED"
+    state = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert state.canonical, state.off_canonical
+    # Two distinct adopted lanes — one per divergent side. Keyed off commit_id, so the two sides
+    # (which share a change_id) do NOT collide onto a single bookmark.
+    adopted = sorted(lane.name for lane in state.lanes if lane.name.startswith("adopted-"))
+    assert len(adopted) == 2, adopted
+    assert len(set(adopted)) == 2, adopted
+
+
+def test_reconcile_abandon_clears_both_divergent_sides(tmp_path: Path):
+    _divergent_strays(tmp_path)
+
+    res = do_reconcile(Session.load(tmp_path, GitmanConfig(trunk="main")), abandon_=True)
+    assert res.outcome == "RECONCILED"
+    state = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert state.canonical, state.off_canonical
+    assert not any(lane.name.startswith("adopted-") for lane in state.lanes)
+
+
+def test_reconcile_nondivergent_stray_unchanged(tmp_path: Path):
+    """Happy path: a single, non-divergent stray still adopts into exactly one `adopted-*` lane
+    (guards the commit-id naming change against altering the common case)."""
+    ws = _init_main(tmp_path)
+    _child_offmain(ws, tmp_path, "s.txt", "stray\n", "lone stray")
+
+    res = do_reconcile(Session.load(tmp_path, GitmanConfig(trunk="main")), abandon_=False)
+    assert res.outcome == "RECONCILED"
+    state = capture_state(Session.load(tmp_path, GitmanConfig(trunk="main")))
+    assert state.canonical, state.off_canonical
+    assert len([lane for lane in state.lanes if lane.name.startswith("adopted-")]) == 1


### PR DESCRIPTION
## Issue 06 — stray detection vs git tags + divergent reconcile

Two fixes; full design analysis in `.scratch/projects/06-stray-tags-and-divergent-reconcile/ISSUE_ANALYSIS.md`.

### G1 — tagged commits are not strays
`state._stray_revset` now excludes `tags()`:
`(trunk..) ~ ::(bookmarks() | remote_bookmarks() | tags()) ~ @`. A tagged off-main commit is intentional history (release / bisect anchor), not "edited outside gitman." `tags()` evaluates through pyjutsu/jj-lib's resolver.

### G2 — reconcile recovers a divergent stray
A divergent change-id (one change_id → ≥2 commits, manufactured by orphaned `refs/jj/keep/*` after a forge `git_import`) made `tx.abandon(change_id)` / `tx.create_bookmark(name, change_id)` raise `Change ID … is divergent`, dead-ending `reconcile` — the sole recovery path.

Added `core._target(change) → commit_id` and routed **all four** stray/range-row mutation sites through it:
- `reconcile.do_reconcile` — targets **and names** each stray by `commit_id`. The two divergent sides share a `change_id`, so naming by change-id collides them onto one bookmark; `commit_id` is what actually differs.
- `core.do_abandon` and `core._retire_lane` — same latent bug; `_retire_lane` runs in the exact post-`git_import` adopt window where divergence appears.

`capture_state`'s off-canonical reason now suffixes each stray with `commit_id[:8]` so divergent sides are distinguishable.

### Tests
5 new in `tests/test_stray_tags_divergent.py`: tagged-off-main-not-stray + untagged-still-stray regression; divergent reconcile → two distinct adopted lanes; `--abandon` clears both; non-divergent happy path unchanged. Full suite green (112), ruff clean, no new ty errors.
