### PR TITLE
feat(workspace): default --workspace lanes to a hidden in-repo .worktrees/<lane>/ (issue 12)

### DIFF
--- a/.scratch/projects/12-in-repo-hidden-workspace-dir/ISSUE.md
+++ b/.scratch/projects/12-in-repo-hidden-workspace-dir/ISSUE.md
@@ -1,0 +1,137 @@
+# 12 — Put `--workspace` lanes in a hidden in-repo dir (not a parent-dir sibling)
+
+**Status: ISSUE / kickoff — no code yet.** Change gitman's default workspace location from a
+sibling directory in the parent to a hidden subdirectory **inside** the repo (git-worktree
+style), and make it self-ignoring so the nested workspace never pollutes the outer tree.
+
+> Conventions: in-repo commands run in **devenv**; all VC through **gitman** (this repo
+> dogfoods itself); **never push** without an explicit ask. Work on a dedicated lane.
+
+---
+
+## 1. Problem / motivation
+
+`gitman start <name> --workspace` currently creates the secondary jj workspace at
+`../{repo}-{lane}` — a **sibling of the repo in the parent directory**. In a fleet root like
+`~/Documents/Projects/` (≈89 sibling projects), this drops a directory such as
+`flora-studio-web/` right next to the real projects. It has a full checkout + its own
+`.devenv` venv (≈140 MB), **looks exactly like a brand-new standalone repo**, and is easy to
+mistake for one (this issue was filed after exactly that confusion in `flora`). We want the
+behavior `git worktree` users expect: workspaces tucked in a **hidden subdir at the project
+root** (e.g. `.worktrees/<lane>/`), out of sight and clearly *part of* the repo.
+
+## 2. Current behavior (where it's wired)
+
+- **`src/gitman/config.py`** — `LanesConfig.workspace_dir: str = "../{repo}-{lane}"`
+  (template; `{repo}`/`{lane}` expand). This is the only knob.
+- **`src/gitman/lanes.py`** — `resolve_workspace_path(repo_root, config, lane)` expands the
+  template; **relative paths resolve against `repo_root`** (so an in-repo path already works).
+- **`src/gitman/core.py`**
+  - `_start_workspace(...)` (~line 176): `wpath = resolve_workspace_path(...)` →
+    `session.ws.add_workspace(str(wpath), name=name)` → put its `@` on trunk + bookmark.
+  - `_cleanup_workspace(session, lane)` (~line 116): on land/abandon, **recomputes** the path
+    via `resolve_workspace_path(...)`, `forget_workspace(lane)`, then `shutil.rmtree(wpath)`.
+- **`src/gitman/invariants.py`** — `ensure_state_dir(repo_root)` (~line 67) already shows the
+  **self-ignoring-dir pattern** we want to reuse: it `mkdir`s `.gitman/` and writes `*\n` to
+  `.gitman/.gitignore` so jj/git never snapshot it **regardless of the repo's `.gitignore`**.
+
+This is *already config-driven*, so the change is small — but a naive default flip would
+(a) let the outer repo try to snapshot the nested workspace (incl. its venv), and (b) break
+cleanup of any pre-existing sibling workspaces. Both are handled below.
+
+## 3. Desired behavior
+
+- **Default** `workspace_dir = ".worktrees/{lane}"` → `gitman start foo --workspace` creates
+  `<repo>/.worktrees/foo/` (a real jj workspace whose `.jj/repo` points at the outer store).
+- The outer repo **never tracks** `.worktrees/` (no status noise, no accidental snapshot of
+  the nested checkout / its `.devenv`).
+- Land/abandon cleanup still finds and removes the workspace dir — **even for workspaces that
+  were created under the old sibling default** (don't orphan them).
+- Users can still override `workspace_dir` (incl. back to a sibling or an absolute path).
+
+## 4. Validated approach (sandbox proof — reproduce to confirm)
+
+Done in a throwaway repo; it works cleanly:
+
+```
+mkdir -p /tmp/gmtest && cd /tmp/gmtest && git init -q .
+gitman init --colocate --trunk main && gitman seed -m init
+printf '\n[lanes]\nworkspace_dir = ".worktrees/{lane}"\n' >> gitman.toml
+printf '/.worktrees/\n' > .gitignore        # (this issue replaces the manual ignore with auto-ignore)
+gitman save -m cfg
+gitman start feat --workspace
+#  → workspace at /tmp/gmtest/.worktrees/feat
+#  → .worktrees/feat/.jj/repo == "../../../.jj/repo"  (shares the outer store)
+#  → outer `gitman status` == CANONICAL, lane shows "ws feat", NO nested files as changes
+#  → git status --porcelain shows nothing under .worktrees/  (ignored)
+```
+
+Key pyjutsu facts confirmed (used by the implementation):
+- `Workspace.workspaces()` → `WorkspaceInfo` rows; **`WorkspaceInfo` fields = `name`, `path`,
+  `wc_commit_id`** — i.e. jj **records each workspace's real on-disk path**. Use it.
+- `Workspace.forget_workspace(name)` drops only the repo's record of that workspace's `@`
+  (leaves on-disk files untouched); the lane bookmark/commit survive.
+- `add_workspace(path, name=...)` bases the new `@` on the **root** commit and publishes its
+  own op (the existing `_start_workspace` already re-bases onto trunk + bookmarks).
+
+## 5. Changes to make
+
+### 5.1 Default (config.py)
+- `LanesConfig.workspace_dir = ".worktrees/{lane}"`; update the comment. Keep `{repo}`
+  supported in the template for back-compat (just no longer in the default).
+
+### 5.2 Auto-ignore the in-repo workspace root (the important bit)
+- In `_start_workspace`, **before** `add_workspace`, if the resolved `wpath` is **inside
+  `repo_root`**, ensure a self-ignoring parent: create `wpath.parent` (e.g. `.worktrees/`) and
+  write `*\n` to `<wpath.parent>/.gitignore` if absent — **mirror `ensure_state_dir`** exactly
+  (factor a shared `ensure_self_ignored_dir(path)` helper if clean). Do **not** edit the
+  repo's root `.gitignore` (avoid a tracked-file mutation on every `start`). If `wpath` is
+  **outside** `repo_root` (user override / old sibling default), write no ignore.
+- Rationale: `*` in `.worktrees/.gitignore` makes git **and** jj ignore everything under
+  `.worktrees/` (including the file itself and each workspace's `.devenv`), so the outer tree
+  stays clean with zero per-`start` tracked changes — same trick gitman already trusts for
+  `.gitman/`.
+
+### 5.3 Cleanup uses jj's recorded path, not a recompute (don't orphan old workspaces)
+- In `_cleanup_workspace`, replace `resolve_workspace_path(...)` with the **recorded** path
+  from jj: find the matching `WorkspaceInfo` in `session.ws.workspaces()` by `name == lane`
+  and use its `.path`. This way a workspace created under the *old* `../{repo}-{lane}` default
+  still gets its real dir removed after the default flips. Keep the "cwd is inside the
+  workspace → forget but keep the dir + note" branch. (Belt-and-suspenders: if no recorded
+  path, fall back to `resolve_workspace_path`.)
+
+## 6. Edge cases / considerations
+- **Existing sibling workspaces across the fleet:** flipping the default must not strand them
+  — §5.3 fixes cleanup; creation only affects *new* `--workspace` lanes.
+- **`always_workspace = true` repos:** unaffected beyond the new location.
+- **Nested-of-nested / recursion:** none — `.worktrees/` is ignored, so a workspace's own
+  checkout never contains `.worktrees/`.
+- **Override still works:** absolute paths and `{repo}`-bearing templates must still resolve.
+- **Don't write a stray `.gitignore`** when the workspace is configured outside the repo.
+
+## 7. Tests (devenv: `devenv shell -- pytest`)
+Add/extend a workspace integration test (see existing `tests/test_lifecycle_integration.py`,
+`tests/test_split_integration.py`, `tests/test_switch_integration.py`,
+`tests/test_session_root.py` for the `--workspace` patterns):
+- `start --workspace` lands the dir at `<repo>/.worktrees/<lane>`; the dir is a jj workspace;
+  outer `gitman status` is CANONICAL with a `ws <lane>` lane; `.worktrees/` is ignored (git
+  `status --porcelain` clean for it).
+- `land`/`abandon` removes the `.worktrees/<lane>` dir and forgets the workspace.
+- **Migration:** with `workspace_dir` overridden to the old `../{repo}-{lane}`, create →
+  land, and assert cleanup still removes the sibling dir (proves §5.3 uses the recorded path).
+- `ruff` + `ty` clean on touched files.
+
+## 8. VC / rollout
+- Work on a dedicated lane in **this** repo (gitman dogfoods gitman); commit as you go;
+  **don't push / open PRs without an explicit ask**.
+- Heads-up (meta): gitman is installed **editable** into fleet venvs via `repoman.lock`
+  (`source = "path:…/gitman"`), so edits go live in those venvs on the next `repoman-sync`.
+  Develop + green the suite **here** first. Behavior change is **fleet-wide** but only affects
+  *future* `--workspace` lanes; existing ones keep working (§5.3).
+
+## 9. Acceptance criteria
+- New default puts `--workspace` lanes in `<repo>/.worktrees/<lane>/`, auto-ignored, outer
+  repo stays CANONICAL with no status noise.
+- Land/abandon cleanly removes the workspace dir for both new (in-repo) and old (sibling)
+  layouts.
+- Override path still honored; full suite + ruff + ty green; nothing pushed.

--- a/.scratch/projects/12-in-repo-hidden-workspace-dir/ISSUE_ANALYSIS.md
+++ b/.scratch/projects/12-in-repo-hidden-workspace-dir/ISSUE_ANALYSIS.md
@@ -1,0 +1,340 @@
+# 12 — Design review: hidden in-repo `--workspace` dir
+
+Critical review of `ISSUE.md`. Verified against the live gitman source, the real pyjutsu API
+(`/home/andrew/Documents/Projects/Pyjutsu`), and an empirical sandbox in `/tmp` (per §4 repro).
+
+---
+
+## Verdict
+
+| Claim | Status |
+|---|---|
+| **Motivation** (sibling workspace looks like a standalone fleet repo; ~140MB; confusing) | **Confirmed — valid.** Real ergonomic problem; default flip is the right fix. |
+| `WorkspaceInfo` fields are `name`, `path`, `wc_commit_id` | **Confirmed.** (`models.py:191`, `convert.rs:218`). |
+| jj **records** each workspace's on-disk path and pyjutsu returns it **absolute** | **Confirmed — and stronger than the report claims.** pyjutsu *canonicalizes* the recorded (possibly-relative, jj-0.42) path to an absolute string (`workspace.rs:227 absolutize_workspace_path`). Empirically `feat` → `/tmp/gmtest12/.worktrees/feat`. |
+| `add_workspace(path, name=...)` signature | **Confirmed.** `Workspace.add_workspace(path, *, name=None)` (`workspace.py:84`). |
+| `forget_workspace(name)` drops only the record, leaves files | **Confirmed empirically** (row vanishes from `workspaces()`, dir stays). |
+| `*\n` in `.worktrees/.gitignore` makes git+jj ignore everything under it | **Confirmed** for the stated goal — but the *reasoning* is partly wrong (see below). |
+| Default flip only affects **future** `--workspace` lanes; old siblings keep working | **Confirmed *iff* §5.3 (cleanup-by-recorded-path) is implemented.** Without it, old siblings are orphaned on land/abandon. |
+| §5.3 cleanup migration plan | **Needs revision** — sound in spirit, but the report omits a load-bearing ordering constraint and a `str` vs `Path` detail. |
+| **Recommended location** `.worktrees/` vs `.gitman/worktrees/` | **Recommend `.worktrees/`** (the report's choice) — with reasoning below. |
+
+**Bottom line: the request is well-founded and the API assumptions are all true.** Two corrections
+to the implementation plan are required (cleanup ordering + `Path()` wrapping), one is a simplification
+(the auto-ignore is for git noise, not to prevent a jj snapshot disaster), and one existing test
+**will break** and must be updated.
+
+---
+
+## Evidence (current code)
+
+### Config — the only knob (`src/gitman/config.py:16-19`)
+```python
+class LanesConfig(BaseModel):
+    # Where `--workspace` lanes live; {repo}/{lane} expand. Default: sibling dir.
+    workspace_dir: str = "../{repo}-{lane}"
+    always_workspace: bool = False
+```
+
+### Path resolution — already supports in-repo relative paths (`src/gitman/lanes.py:39-46`)
+```python
+def resolve_workspace_path(repo_root: Path, config: GitmanConfig, lane: str) -> Path:
+    template = config.lanes.workspace_dir
+    rel = template.format(repo=repo_root.name, lane=lane)
+    path = Path(rel)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()   # <-- ".worktrees/{lane}" resolves under repo_root already
+    return path
+```
+A bare `.worktrees/{lane}` default already resolves correctly against `repo_root`. No change needed
+here for creation. `{repo}` stays supported for back-compat overrides.
+
+### Creation (`src/gitman/core.py:176-202`, `_start_workspace`)
+```python
+wpath = resolve_workspace_path(session.repo_root, session.config, name)
+with canonical_guard(session, "start") as canon:
+    ensure_unique(session, trunk, name)
+    try:
+        session.ws.add_workspace(str(wpath), name=name)  # own op; new @ on root
+        sub = Workspace.load(wpath)
+        with sub.transaction("gitman:start", auto_snapshot=False) as tx:
+            tx.new(trunk); tx.create_bookmark(name, "@")
+    except Exception:
+        shutil.rmtree(wpath, ignore_errors=True)
+        raise
+```
+
+### Cleanup (`src/gitman/core.py:116-136`, `_cleanup_workspace`) — the function §5.3 changes
+```python
+def _cleanup_workspace(session: Session, lane: str) -> list[str]:
+    from gitman.lanes import resolve_workspace_path
+    if lane not in {w.name for w in session.ws.workspaces()}:
+        return []
+    notes: list[str] = []
+    wpath = resolve_workspace_path(session.repo_root, session.config, lane)  # <-- RECOMPUTES
+    session.ws.forget_workspace(lane)
+    cwd = Path.cwd()
+    inside = cwd == wpath or wpath in cwd.parents
+    if inside:
+        notes.append(f"workspace {wpath} forgotten but kept (you are cd'd inside; ...).")
+    elif wpath.exists():
+        shutil.rmtree(wpath, ignore_errors=True)
+        notes.append(f"removed workspace {wpath}.")
+    return notes
+```
+The bug §5.3 targets: `resolve_workspace_path` recomputes from **today's config**. After the default
+flips, a workspace created under the *old* `../{repo}-{lane}` default recomputes to `.worktrees/<lane>`
+— the wrong directory — so the real sibling dir is **orphaned**. This is called from `do_land`
+(core.py:534), `do_abandon` (597), and `_retire_lane` (700) — i.e. the orphan-on-flip risk is real
+across land, abandon, and adopt.
+
+### The self-ignore pattern to mirror (`src/gitman/invariants.py:67-76`)
+```python
+def ensure_state_dir(repo_root: Path) -> Path:
+    state = repo_root / ".gitman"
+    state.mkdir(parents=True, exist_ok=True)
+    gitignore = state / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n")
+    return state
+```
+
+### pyjutsu facts (with file refs)
+- `WorkspaceInfo` = frozen pydantic model, fields `name: str`, **`path: str | None`**,
+  `wc_commit_id: CommitId` (`Pyjutsu/python/pyjutsu/models.py:191-204`). **`.path` is a `str`, not a
+  `Path`** — cleanup must wrap it: `Path(w.path)`.
+- `path` is `None` only when the store has no entry for the name — e.g. a `.jj` removed out-of-band
+  (`convert.rs:214-216`). Normal forgotten/deleted-dir workspaces still return a (lexically-joined,
+  absolute) path because `absolutize_workspace_path` falls back to the join when `canonicalize`
+  fails (`workspace.rs:227-233`). So a deleted-but-still-recorded workspace yields a usable absolute
+  path; only a corrupted store yields `None`.
+- `forget_workspace` removes the row from `workspaces()` and leaves files on disk
+  (`workspace.rs:888`, verified empirically).
+
+### Empirical sandbox results (`/tmp/gmtest12`, devenv)
+1. `gitman start feat --workspace` with `workspace_dir=".worktrees/{lane}"` → workspace at
+   `/tmp/gmtest12/.worktrees/feat`; nested `.jj/repo` = `../../../.jj/repo` (shares outer store). ✅
+2. **Outer `gitman status` is CANONICAL with `· ws feat`, +0/−0 — even with NO ignore file and a 5 MB
+   `.worktrees/feat/.devenv/state/big.bin` present.** jj-lib does **not** snapshot a nested
+   workspace's working copy into the outer `@`. The nested `.jj` is treated specially.
+3. Without the ignore, `git status --porcelain` shows `?? .worktrees/` (untracked noise). **With
+   `printf '*\n' > .worktrees/.gitignore`, that noise disappears** (git and jj both clean for it).
+4. `WorkspaceInfo.path` is an **absolute canonicalized `str`** for both `default`
+   (`/tmp/gmtest12`) and the in-repo `feat` (`/tmp/gmtest12/.worktrees/feat`).
+5. Reading `.path` then `forget_workspace("feat")`: row gone afterward, dir still on disk → **path
+   must be read BEFORE forget.**
+
+---
+
+## Where the report's reasoning is subtly off (but the plan still lands)
+
+**§5.2 rationale is half-wrong, conclusion right.** The report says the ignore is needed so "the
+outer repo [doesn't] try to snapshot the nested workspace (incl. its venv)." Empirically the outer
+jj snapshot **already ignores** a nested workspace regardless of any `.gitignore` (finding #2) —
+jj-lib does not descend into another workspace's working copy. The ignore's *actual* job is to
+silence the **colocated git** `?? .worktrees/` untracked-noise (finding #3) and to keep a bare
+`git status` / `git add -A` from ever touching it. Still worth doing — but frame it as "kill git
+noise + defense-in-depth," not "prevent a jj snapshot disaster that would otherwise happen." This
+also means the change is **lower-risk** than the report implies: even a botched ignore can't make the
+outer repo swallow the venv via jj.
+
+---
+
+## Recommended approach
+
+### A. Default location — `.worktrees/{lane}` (agree with the report)
+
+Flip `LanesConfig.workspace_dir` to `".worktrees/{lane}"`. Recommend **`.worktrees/`** over
+`.gitman/worktrees/`:
+
+- **Familiarity.** `git worktree` users and tooling expect `.worktrees/`. It reads as "checkouts,"
+  which is what they are.
+- **Separation of concerns.** `.gitman/` holds *control-plane* state (lock, undo checkpoint) that is
+  tiny and gitman-private. Workspaces are *data-plane* — full multi-hundred-MB checkouts. Co-locating
+  a 140 MB venv under `.gitman/` muddies "gitman's small state dir" and risks an `rm -rf .gitman` (a
+  reasonable "reset gitman state" reflex) nuking live working copies. Keeping them separate is safer.
+- Both are self-ignored top-level dirs; "a second hidden dir" is a negligible cost against the above.
+
+Counter-noted but not chosen: `.gitman/worktrees/` gives "one gitman-owned ignored dir." Cohesion is
+real but loses on the `rm -rf` safety and the git-worktree mental model. **Recommend `.worktrees/`.**
+
+### B. Auto-ignore — factor `ensure_self_ignored_dir(path)` (agree, with a tweak)
+
+Refactor `ensure_state_dir` to delegate to a shared helper, then reuse it for the workspace parent.
+Place the helper in `invariants.py` (where `ensure_state_dir` lives) so there's one owner:
+
+```python
+def ensure_self_ignored_dir(path: Path) -> Path:
+    """mkdir `path` and drop a `*`-ignoring `.gitignore` inside it so git/jj never snapshot its
+    contents — regardless of the repo's root .gitignore. Idempotent; never overwrites an existing
+    .gitignore."""
+    path.mkdir(parents=True, exist_ok=True)
+    gitignore = path / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n")
+    return path
+
+def ensure_state_dir(repo_root: Path) -> Path:
+    return ensure_self_ignored_dir(repo_root / ".gitman")
+```
+
+Wire it into `_start_workspace`, **before** `add_workspace`, gated on "is `wpath` inside `repo_root`":
+
+```python
+wpath = resolve_workspace_path(session.repo_root, session.config, name)
+if session.repo_root in wpath.parents:                 # in-repo workspace
+    ensure_self_ignored_dir(wpath.parent)              # e.g. <repo>/.worktrees/
+```
+
+Notes:
+- Use `session.repo_root in wpath.parents` (not a string `startswith`) — both are resolved absolute
+  paths already, so this is robust and correctly returns False for a sibling/absolute override
+  (honoring §6 "don't write a stray .gitignore when configured outside the repo").
+- Do **not** touch the repo's root `.gitignore` (agree with the report — avoids a tracked-file
+  mutation on every `start`).
+- The `*` glob covers the `.gitignore` file itself and every nested `.devenv`, so there are **zero**
+  per-`start` tracked changes (confirmed empirically).
+
+### C. Cleanup by recorded path — `_cleanup_workspace` rewrite (the load-bearing fix)
+
+The report's §5.3 is correct in intent but must respect two facts surfaced above: **(1) read `.path`
+BEFORE `forget_workspace`** (forget removes the row), and **(2) `.path` is a `str`, wrap in `Path()`**.
+
+```python
+def _cleanup_workspace(session: Session, lane: str) -> list[str]:
+    from gitman.lanes import resolve_workspace_path
+
+    # Read the RECORDED row first — forget() will drop it, and the recompute path may be wrong
+    # for workspaces created under a prior workspace_dir default.
+    rec = next((w for w in session.ws.workspaces() if w.name == lane), None)
+    if rec is None:
+        return []                                   # not a workspace lane — nothing to do
+    if rec.path is not None:
+        wpath = Path(rec.path)                       # jj's recorded, absolutized on-disk root
+    else:
+        wpath = resolve_workspace_path(session.repo_root, session.config, lane)  # belt-and-suspenders
+
+    notes: list[str] = []
+    session.ws.forget_workspace(lane)
+    cwd = Path.cwd()
+    inside = cwd == wpath or wpath in cwd.parents
+    if inside:
+        notes.append(
+            f"workspace {wpath} forgotten but kept (you are cd'd inside; "
+            f"`cd {session.repo_root}`, then delete it)."
+        )
+    elif wpath.exists():
+        shutil.rmtree(wpath, ignore_errors=True)
+        notes.append(f"removed workspace {wpath}.")
+    return notes
+```
+
+Why this is correct for every case:
+- **Old sibling workspaces:** jj recorded the real sibling path at creation; `rec.path` returns it
+  absolutized → the *actual* dir is removed, never orphaned. (This is the entire point of §5.3.)
+- **New in-repo workspaces:** `rec.path` = `<repo>/.worktrees/<lane>` → removed.
+- **cwd-inside branch:** unchanged semantics; still uses `wpath` (now the recorded one), so the
+  "you're cd'd inside" detection works for both layouts.
+- **Missing record (`path is None`):** falls back to `resolve_workspace_path` — the prior behavior,
+  no regression.
+- **Absolute vs relative:** pyjutsu always hands back absolute (`absolutize_workspace_path`), so no
+  anchoring ambiguity — unlike the raw jj-0.42 relative record this would have to handle if read
+  directly. The binding already solved this.
+
+This is a strict improvement and should arguably ship **independent of the default flip** — recording
+path is more correct than recomputing config regardless.
+
+---
+
+## Edge cases & migration
+
+| Case | Handling |
+|---|---|
+| **Existing fleet sibling workspaces** | Creation is untouched for them (they already exist). Land/abandon/adopt now find them via recorded path (§C). No orphaning. ✅ |
+| **`.path` absolute vs relative** | pyjutsu canonicalizes to absolute; lexical-join fallback for deleted dirs (`workspace.rs:227`). No relative ever reaches gitman. ✅ |
+| **`.path is None`** | Only on a corrupted/out-of-band-removed `.jj`; falls back to recompute. ✅ |
+| **Nested `.devenv` (huge)** | jj never snapshots nested workspace (finding #2); `*` ignore also hides it from git (finding #3). ✅ |
+| **cwd inside the workspace at land** | Detected via `wpath in cwd.parents`; forget-but-keep + note. Works for both layouts. ✅ |
+| **`always_workspace=true` repos** | Unaffected beyond the new location. ✅ |
+| **Override to absolute / `{repo}` sibling** | `resolve_workspace_path` still expands them; `session.repo_root in wpath.parents` is False → no ignore written (§6 honored). ✅ |
+| **Nested-of-nested recursion** | None: a workspace's own checkout has no `.worktrees/`. ✅ |
+| **Editable fleet install** | Change goes live in ~89 venvs on next `repoman-sync`; behavior change touches only *future* `--workspace` lanes. Green here first. |
+
+**Migration risk is low.** The one true back-compat hazard (orphaning old siblings) is exactly what
+§C closes. There is no on-disk migration of existing workspaces — they keep their location and keep
+working.
+
+### Should the flip be opt-in?
+**No — flip the default.** The motivation is the default itself being wrong for a fleet. An opt-in
+knob already exists (it's all config-driven); making users set it defeats the purpose. With §C in
+place there is no stranding, so a plain default flip is safe. Keep the override for anyone who wants
+the old sibling behavior.
+
+---
+
+## Test plan
+
+Mirror existing `--workspace` patterns (`tests/test_lifecycle_integration.py:155-175`,
+`test_session_root.py`, `test_split_integration.py`, `test_switch_integration.py`). All run in devenv:
+`devenv shell -- bash -c 'gitman:lint && gitman:test'`.
+
+1. **MUST-FIX existing test:** `tests/test_lifecycle_integration.py:232`
+   `wpath = tmp_path / "repo-wlane"` hardcodes the **old sibling** path and uses default `CFG`
+   (`GitmanConfig(trunk="main")`). After the flip this path won't exist → test breaks. Update to
+   `wpath = repo / ".worktrees" / "wlane"`. (This is the only place in the suite that assumes the
+   sibling location.)
+
+2. **New: in-repo default placement.** `do_start(sess, "wlane", workspace=True)` with default config
+   → assert the workspace dir is `repo / ".worktrees" / "wlane"` and exists; `{w.name for w in
+   ws.workspaces()} == {"default", "wlane"}`; `capture_state` is `canonical` with the lane showing
+   `workspace == "wlane"`.
+
+3. **New: auto-ignore.** Assert `(repo / ".worktrees" / ".gitignore").read_text() == "*\n"`. Drop a
+   file under `.worktrees/feat/` and assert `git -C repo status --porcelain` has no `.worktrees`
+   entry (subprocess; or assert outer `capture_state` stays `canonical` / `+0 −0`). Assert the root
+   `.gitignore` was **not** modified.
+
+4. **New: cleanup removes in-repo dir.** `start --workspace` → `do_land`/`do_abandon` → assert
+   `.worktrees/wlane` is gone and the workspace is forgotten (`wlane not in {w.name for w in
+   ws.workspaces()}`).
+
+5. **New: migration (the §C proof).** Build a `Session` with config overridden to the **old**
+   `workspace_dir="../{repo}-{lane}"`; `start --workspace`; confirm the sibling dir exists; then
+   **flip the session's config back to the new default** and `do_land` — assert cleanup still removes
+   the *sibling* dir (proves cleanup uses the recorded path, not the recomputed one). Build via
+   `GitmanConfig(trunk="main", lanes=LanesConfig(workspace_dir="../{repo}-{lane}"))`.
+
+6. **New: override-outside-repo writes no ignore.** With an absolute/sibling `workspace_dir`, assert
+   no `.gitignore` is created at the override's parent and `session.repo_root not in wpath.parents`.
+
+7. **`ensure_self_ignored_dir` unit test** (pure): tmp dir → mkdir + `*\n`; idempotent; never
+   overwrites a pre-existing `.gitignore`.
+
+8. `ruff` + `ty` clean on `config.py`, `core.py`, `invariants.py`, touched tests.
+
+---
+
+## Docs to update (grep-verified)
+- `src/gitman/config.py:17-18` — comment + default.
+- `docs/USING_GITMAN.md:132` — `[lanes].workspace_dir` default → `.worktrees/{lane}`.
+- `docs/GITMAN_CONCEPT.md:492` — same table row.
+- Optionally note the `.worktrees/` self-ignored dir alongside the `.gitman/` mention
+  (`USING_GITMAN.md:84`).
+
+---
+
+## Open questions / risks
+
+1. **`reconcile` / off-canonical recovery** — `reconcile.py` has no workspace handling today (grep
+   clean). A workspace whose dir was deleted by hand but still recorded is out of scope here; §C's
+   `path is None` / fallback handles the store-corruption case but not "dir gone, record present"
+   beyond `wpath.exists()` being False (cleanup then no-ops cleanly — acceptable).
+2. **MEMORY note — conflicted-survivor-lane bookmark wedging adopt/reconcile** is orthogonal to this
+   change; this work doesn't touch it but `_retire_lane` (core.py:700) does call `_cleanup_workspace`,
+   so the recorded-path fix benefits adopt-time retirement of workspaced survivor lanes too.
+3. **gix global-excludes gap** — `snapshot()` wires `.git/info/exclude` but not the user-global
+   `core.excludesFile` (`workspace.rs:494` comment). Irrelevant here (we write a per-dir `.gitignore`,
+   which the snapshotter *does* honor via per-directory chaining — `workspace.rs:540-544`), but worth
+   knowing the per-dir `.gitignore` is the reliable lever, not global excludes.
+4. **Pre-existing `.worktrees/` in a consumer repo** (e.g. someone using `git worktree`) — collision
+   is unlikely in this fleet (jj-managed), and the override exists as an escape hatch. Low risk.

--- a/docs/GITMAN_CONCEPT.md
+++ b/docs/GITMAN_CONCEPT.md
@@ -489,7 +489,7 @@ Pydantic-validated.
 | Key | Meaning |
 |---|---|
 | `trunk` | Trunk bookmark/branch. **Written once by `init`, then frozen** (I1). |
-| `[lanes] workspace_dir` | Where `--workspace` lanes live (default `../<repo>-<lane>`). |
+| `[lanes] workspace_dir` | Where `--workspace` lanes live (default `.worktrees/<lane>` — a hidden, self-ignored in-repo dir; `../<repo>-<lane>` for the old sibling layout). |
 | `[lanes] always_workspace` | If true, `start` always isolates (default false). |
 | `[publish] verify` | Command run before publish/release (`[]` → no gate). |
 | `[publish] on_fail` | `block` (default) or `warn`. |

--- a/docs/USING_GITMAN.md
+++ b/docs/USING_GITMAN.md
@@ -81,7 +81,10 @@ This works on a brand-new dir **and** on an existing git repo (with or without h
 - Scaffolds **`.claude/skills/gitman/SKILL.md`** — the agent's how-to for this repo.
 
 Commit `gitman.toml` and the skill. Gitman's own state lives under `.gitman/` (a
-self-ignoring dir); add `.gitman/` to `.gitignore` if you prefer it explicit.
+self-ignoring dir); add `.gitman/` to `.gitignore` if you prefer it explicit. A `--workspace`
+lane's checkout lives under a second self-ignoring dir, `.worktrees/<lane>/` (in-repo by
+default — see `[lanes].workspace_dir`); both carry their own `*` `.gitignore`, so neither shows
+up as untracked noise and there's nothing to add to your root `.gitignore`.
 
 ### Make the first commit (brand-new repos)
 
@@ -129,7 +132,7 @@ See [`../examples/gitman.toml`](../examples/gitman.toml) for an annotated sample
 | Key | Meaning |
 |---|---|
 | `trunk` | Trunk bookmark/branch. Written once by `init`, then **frozen**. |
-| `[lanes].workspace_dir` | Where `--workspace` lanes live (default `../{repo}-{lane}`). |
+| `[lanes].workspace_dir` | Where `--workspace` lanes live (default `.worktrees/{lane}` — a hidden, self-ignored in-repo dir; set `../{repo}-{lane}` for the old sibling layout). |
 | `[lanes].always_workspace` | If true, `start` always isolates (default false). |
 | `[publish].verify` | Command run before publish (`[]` → no gate). Any verifier. |
 | `[publish].on_fail` | `block` (default) or `warn`. |

--- a/src/gitman/config.py
+++ b/src/gitman/config.py
@@ -14,8 +14,11 @@ from pydantic import BaseModel, Field
 
 
 class LanesConfig(BaseModel):
-    # Where `--workspace` lanes live; {repo}/{lane} expand. Default: sibling dir.
-    workspace_dir: str = "../{repo}-{lane}"
+    # Where `--workspace` lanes live; {repo}/{lane} expand. Default: a hidden, self-ignored
+    # in-repo dir (`.worktrees/<lane>`) — keeps each ~140 MB checkout *inside* the repo (not a
+    # sibling that looks like a standalone fleet clone) and out of the small `.gitman/` control
+    # dir. {repo} stays supported for an explicit sibling override (`../{repo}-{lane}`).
+    workspace_dir: str = ".worktrees/{lane}"
     always_workspace: bool = False
 
 

--- a/src/gitman/core.py
+++ b/src/gitman/core.py
@@ -137,13 +137,21 @@ def pick_remote(ws: Workspace) -> str:
 def _cleanup_workspace(session: Session, lane: str) -> list[str]:
     """Forget a retired lane's workspace and remove its dir — unless the caller is cd'd
     inside it (then forget but keep the dir, and say so). Never blocks. Publishes its own jj
-    op → only call inside a `canonical_guard` body. See plan / concept §20."""
+    op → only call inside a `canonical_guard` body. See plan / concept §20.
+
+    Removes the workspace at jj's *recorded* on-disk path (`WorkspaceInfo.path`), NOT a path
+    recomputed from today's `workspace_dir` config — so a workspace created under a prior default
+    (e.g. the old `../{repo}-{lane}` sibling) is cleaned at its real location instead of being
+    orphaned. `.path` must be read BEFORE `forget_workspace` (forget drops the row) and is a `str`
+    (wrap in `Path`). Only a corrupted/out-of-band-removed store yields `path is None` → fall back
+    to the config recompute (prior behavior)."""
     from gitman.lanes import resolve_workspace_path
 
-    if lane not in {w.name for w in session.ws.workspaces()}:
-        return []
+    rec = next((w for w in session.ws.workspaces() if w.name == lane), None)
+    if rec is None:
+        return []  # not a workspace lane — nothing to do
+    wpath = Path(rec.path) if rec.path is not None else resolve_workspace_path(session.repo_root, session.config, lane)
     notes: list[str] = []
-    wpath = resolve_workspace_path(session.repo_root, session.config, lane)
     session.ws.forget_workspace(lane)
     cwd = Path.cwd()
     inside = cwd == wpath or wpath in cwd.parents
@@ -203,10 +211,16 @@ def _start_workspace(session: Session, trunk: str, name: str, messages: list[str
     guard's `except` restores `op_before`, forgetting the workspace record."""
     from pyjutsu import Workspace
 
-    from gitman.invariants import canonical_guard
+    from gitman.invariants import canonical_guard, ensure_self_ignored_dir
     from gitman.lanes import ensure_unique, resolve_workspace_path
 
     wpath = resolve_workspace_path(session.repo_root, session.config, name)
+    # For an in-repo workspace (the default `.worktrees/<lane>`), self-ignore its parent so
+    # colocated git never reports the checkout as `?? .worktrees/` noise (jj-lib already never
+    # snapshots a nested workspace). Gated to in-repo only: an outside-repo override writes no
+    # stray .gitignore (§6). Both paths are resolved-absolute, so `in wpath.parents` is robust.
+    if session.repo_root in wpath.parents:
+        ensure_self_ignored_dir(wpath.parent)
     with canonical_guard(session, "start") as canon:
         ensure_unique(session, trunk, name)
         try:

--- a/src/gitman/invariants.py
+++ b/src/gitman/invariants.py
@@ -64,16 +64,24 @@ def clear_undo_checkpoint(repo_root: Path) -> None:
     (repo_root / LAST_UNDO_PATH).unlink(missing_ok=True)
 
 
+def ensure_self_ignored_dir(path: Path) -> Path:
+    """`mkdir` `path` and drop a `*`-ignoring `.gitignore` inside it so git/jj never snapshot its
+    contents into the working copy — regardless of the repo's root `.gitignore`. Idempotent; never
+    overwrites an existing `.gitignore`. The `*` glob also covers the `.gitignore` file itself, so
+    there are zero tracked changes. Used for both `.gitman/` (control state) and an in-repo
+    `.worktrees/` (workspace checkouts) — see `core._start_workspace`."""
+    path.mkdir(parents=True, exist_ok=True)
+    gitignore = path / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n")
+    return path
+
+
 def ensure_state_dir(repo_root: Path) -> Path:
     """Create `.gitman/` and make it self-ignoring so jj/git never snapshot Gitman's own
     state (lock, undo checkpoint) into the working copy — regardless of the repo's
     .gitignore. Must run before any state file is written."""
-    state = repo_root / ".gitman"
-    state.mkdir(parents=True, exist_ok=True)
-    gitignore = state / ".gitignore"
-    if not gitignore.exists():
-        gitignore.write_text("*\n")
-    return state
+    return ensure_self_ignored_dir(repo_root / ".gitman")
 
 
 # --- the shared-root lock (UNCHANGED body; ALWAYS called with session.repo_root) ------

--- a/tests/test_lifecycle_integration.py
+++ b/tests/test_lifecycle_integration.py
@@ -155,7 +155,7 @@ def test_start_workspace_creates_isolated_lane(tmp_path: Path):
     _init(tmp_path)
     repo = tmp_path / "repo"
     repo.mkdir()
-    # Use a nested repo so the workspace dir (sibling of repo) is predictable.
+    # Use a nested repo so the in-repo workspace dir (.worktrees/<lane>) is predictable.
     ws = Workspace.init(repo, colocate=True)
     (repo / "f.txt").write_text("base\n")
     with ws.transaction("initial") as tx:
@@ -229,7 +229,7 @@ def test_stale_working_copy_refused(tmp_path: Path):
         tx.create_bookmark("main", "@")
 
     do_start(_sess(repo), "wlane", workspace=True)
-    wpath = tmp_path / "repo-wlane"  # workspace_dir default "../{repo}-{lane}" → sibling of repo
+    wpath = repo / ".worktrees" / "wlane"  # workspace_dir default ".worktrees/{lane}" → in-repo
     sub = Workspace.load(wpath)
 
     op_now = ws.head_operation()

--- a/tests/test_workspace_inrepo.py
+++ b/tests/test_workspace_inrepo.py
@@ -1,0 +1,175 @@
+"""Issue 12 — `--workspace` lanes live in a hidden, self-ignored in-repo `.worktrees/<lane>/`.
+
+Built in-process over pyjutsu (no `jj` CLI), mirroring `test_lifecycle_integration.py`. Covers:
+
+- the default location flip (`.worktrees/<lane>` under the repo, not a `../{repo}-{lane}` sibling);
+- the auto-ignore (`.worktrees/.gitignore` = `*`, so colocated git reports no `?? .worktrees/`
+  noise; the repo's root `.gitignore` is never touched);
+- cleanup by jj's *recorded* `WorkspaceInfo.path` — proven by the migration case where a workspace
+  created under the OLD sibling default is still removed (not orphaned) after the default flips;
+- an outside-repo override writing no stray `.gitignore`;
+- the `ensure_self_ignored_dir` helper itself.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pyjutsu import Workspace
+
+from gitman.config import GitmanConfig, LanesConfig
+from gitman.core import do_abandon, do_land, do_save, do_start
+from gitman.invariants import ensure_self_ignored_dir
+from gitman.session import Session
+from gitman.state import capture_state
+
+
+def _repo(d: Path) -> Workspace:
+    """A colocated repo on `main` with one committed file."""
+    ws = Workspace.init(d, colocate=True)
+    (d / "f.txt").write_text("base\n")
+    with ws.transaction("initial") as tx:
+        tx.describe("@", "initial")
+        tx.create_bookmark("main", "@")
+    return ws
+
+
+def _sess(d: Path, cfg: GitmanConfig | None = None) -> Session:
+    return Session.load(d, cfg or GitmanConfig(trunk="main"))
+
+
+# --- default placement + auto-ignore --------------------------------------------------
+
+
+def test_workspace_lands_in_repo_dot_worktrees(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+
+    do_start(_sess(repo), "wlane", workspace=True)
+
+    wpath = repo / ".worktrees" / "wlane"
+    assert wpath.is_dir()
+    ws = Workspace.load(repo)
+    assert {w.name for w in ws.workspaces()} == {"default", "wlane"}
+    state = capture_state(_sess(repo))
+    assert state.canonical, state.off_canonical
+    assert [lane.name for lane in state.lanes] == ["wlane"]
+    assert state.lanes[0].workspace == "wlane"
+
+
+def test_worktrees_dir_is_self_ignored(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+    root_gitignore_before = (repo / ".gitignore").read_text() if (repo / ".gitignore").exists() else None
+
+    do_start(_sess(repo), "wlane", workspace=True)
+
+    # The parent `.worktrees/` carries a `*`-ignoring .gitignore …
+    assert (repo / ".worktrees" / ".gitignore").read_text() == "*\n"
+    # … so even a fat file under the checkout is invisible to colocated git (no `?? .worktrees/`).
+    (repo / ".worktrees" / "wlane" / "big.bin").write_text("x" * 1024)
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout
+    assert ".worktrees" not in porcelain
+    # The repo's ROOT .gitignore is never mutated.
+    root_after = (repo / ".gitignore").read_text() if (repo / ".gitignore").exists() else None
+    assert root_after == root_gitignore_before
+
+
+# --- cleanup removes the in-repo dir --------------------------------------------------
+
+
+def test_land_removes_in_repo_workspace(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+    do_start(_sess(repo), "wlane", workspace=True)
+    (repo / ".worktrees" / "wlane" / "f.txt").write_text("base\nfeat\n")
+    sub = Workspace.load(repo / ".worktrees" / "wlane")
+    sub.snapshot()
+    do_save(Session.load(repo / ".worktrees" / "wlane", GitmanConfig(trunk="main")), "feat work")
+
+    do_land(_sess(repo), ["wlane"])
+
+    assert not (repo / ".worktrees" / "wlane").exists()
+    assert "wlane" not in {w.name for w in Workspace.load(repo).workspaces()}
+
+
+def test_abandon_removes_in_repo_workspace(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+    do_start(_sess(repo), "wlane", workspace=True)
+    assert (repo / ".worktrees" / "wlane").is_dir()
+
+    do_abandon(_sess(repo), "wlane")
+
+    assert not (repo / ".worktrees" / "wlane").exists()
+    assert "wlane" not in {w.name for w in Workspace.load(repo).workspaces()}
+
+
+# --- the §C migration proof: cleanup uses jj's recorded path, not today's config ------
+
+
+def test_cleanup_uses_recorded_path_for_old_sibling_workspace(tmp_path: Path):
+    """A workspace created under the OLD `../{repo}-{lane}` sibling default must still be removed
+    after the default flips to `.worktrees/<lane>` — cleanup reads jj's recorded `WorkspaceInfo.path`
+    (the real sibling), not a path recomputed from the new config (which would orphan it)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+    old_cfg = GitmanConfig(trunk="main", lanes=LanesConfig(workspace_dir="../{repo}-{lane}"))
+
+    do_start(_sess(repo, old_cfg), "wlane", workspace=True)
+    sibling = tmp_path / "repo-wlane"  # the OLD sibling location
+    assert sibling.is_dir()
+    assert not (repo / ".worktrees" / "wlane").exists()
+
+    # Now the world moves to the NEW default and the lane is abandoned.
+    do_abandon(_sess(repo), "wlane")  # default config → workspace_dir=".worktrees/{lane}"
+
+    assert not sibling.exists(), "old sibling workspace orphaned — cleanup recomputed from new config"
+    assert "wlane" not in {w.name for w in Workspace.load(repo).workspaces()}
+
+
+# --- outside-repo override writes no stray .gitignore ---------------------------------
+
+
+def test_override_outside_repo_writes_no_ignore(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _repo(repo)
+    sibling_cfg = GitmanConfig(trunk="main", lanes=LanesConfig(workspace_dir="../{repo}-{lane}"))
+
+    do_start(_sess(repo, sibling_cfg), "wlane", workspace=True)
+
+    sibling = tmp_path / "repo-wlane"
+    assert sibling.is_dir()
+    # No `.gitignore` was written at the override's parent (the fleet root) …
+    assert not (tmp_path / ".gitignore").exists()
+    # … and no in-repo `.worktrees/` was created either.
+    assert not (repo / ".worktrees").exists()
+
+    from gitman.lanes import resolve_workspace_path
+
+    wpath = resolve_workspace_path(repo, sibling_cfg, "wlane")
+    assert repo not in wpath.parents
+
+
+# --- the helper itself ----------------------------------------------------------------
+
+
+def test_ensure_self_ignored_dir(tmp_path: Path):
+    target = tmp_path / "data" / "nested"
+    ensure_self_ignored_dir(target)
+    assert target.is_dir()
+    assert (target / ".gitignore").read_text() == "*\n"
+
+    # Idempotent + never overwrites a pre-existing .gitignore.
+    (target / ".gitignore").write_text("custom\n")
+    ensure_self_ignored_dir(target)
+    assert (target / ".gitignore").read_text() == "custom\n"


### PR DESCRIPTION
## Issue 12 — `--workspace` lanes in a hidden in-repo `.worktrees/{lane}/`

Full design analysis in `.scratch/projects/12-in-repo-hidden-workspace-dir/ISSUE_ANALYSIS.md`.

The old default dropped each secondary workspace at `../{repo}-{lane}` — a sibling in the fleet parent that looks like a standalone ~140 MB clone. This flips the default to an in-repo, self-ignoring `.worktrees/{lane}/`.

### Changes
- **config** — `LanesConfig.workspace_dir` default → `.worktrees/{lane}` (`{repo}` still supported for an explicit sibling override). `resolve_workspace_path` already resolves a relative path under `repo_root`, so creation needs no other change.
- **invariants** — factored `ensure_self_ignored_dir(path)` out of `ensure_state_dir`; `core._start_workspace` calls it on `wpath.parent`, gated to in-repo (`session.repo_root in wpath.parents`) so an outside-repo override writes no stray `.gitignore`. Its job is silencing colocated-git `?? .worktrees/` noise — jj-lib already never snapshots a nested workspace.
- **core (load-bearing)** — `_cleanup_workspace` now removes the workspace at jj's *recorded* `WorkspaceInfo.path` (read **before** `forget_workspace`; wrapped `Path(...)`), not a path recomputed from today's config — so a workspace created under the old sibling default is cleaned at its real location, never orphaned.

### Docs
Updated `config.py` comment, `docs/USING_GITMAN.md`, `docs/GITMAN_CONCEPT.md`.

### Tests
7 new in `tests/test_workspace_inrepo.py`: in-repo placement; auto-ignore (+ root `.gitignore` untouched); land/abandon cleanup; the **migration proof** (old sibling still cleaned via recorded path); override-outside-repo writes no ignore; `ensure_self_ignored_dir` unit. Updated `test_lifecycle_integration.py`'s stale-working-copy test off the sibling path. Full suite green, ruff clean, no new ty errors.
